### PR TITLE
Insert item templated method 

### DIFF
--- a/examples/celleditors/core/mainwindow.cpp
+++ b/examples/celleditors/core/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "item_constants.h"
 #include "modeleditorwidget.h"
 #include "samplemodel.h"
+#include "items.h"
 #include <QCoreApplication>
 #include <QSettings>
 #include <QTabWidget>
@@ -66,9 +67,9 @@ void MainWindow::init_application()
 void MainWindow::init_models()
 {
     // populating first model with content
-    m_model->insertNewItem(Constants::DemoPropertiesType);
-    m_model->insertNewItem(Constants::DemoPropertiesType);
-    m_model->insertNewItem(Constants::DemoPropertiesType);
+    m_model->insertItem<DemoPropertiesItem>();
+    m_model->insertItem<DemoPropertiesItem>();
+    m_model->insertItem<DemoPropertiesItem>();
 
     m_tabWidget->addTab(new ModelEditorWidget(m_model.get()), "Available properties");
     m_tabWidget->setCurrentIndex(m_tabWidget->count() - 1);

--- a/examples/celleditors/core/samplemodel.cpp
+++ b/examples/celleditors/core/samplemodel.cpp
@@ -14,7 +14,7 @@
 namespace  {
 std::unique_ptr<ModelView::ItemCatalogue> CreateToyItemCatalogue()
 {
-    std::unique_ptr<ModelView::ItemCatalogue> result = std::make_unique<ModelView::ItemCatalogue>();
+    auto result = std::make_unique<ModelView::ItemCatalogue>();
     result->registerItem<DemoPropertiesItem>();
     return result;
 }

--- a/examples/dragandmove/core/samplemodel.cpp
+++ b/examples/dragandmove/core/samplemodel.cpp
@@ -18,7 +18,7 @@ namespace
 {
 std::unique_ptr<ModelView::ItemCatalogue> CreateToyItemCatalogue()
 {
-    std::unique_ptr<ModelView::ItemCatalogue> result = std::make_unique<ModelView::ItemCatalogue>();
+    auto result = std::make_unique<ModelView::ItemCatalogue>();
     result->registerItem<DemoItem>();
     result->registerItem<DemoContainerItem>();
     return result;

--- a/examples/dragandmove/core/samplemodel.cpp
+++ b/examples/dragandmove/core/samplemodel.cpp
@@ -55,7 +55,7 @@ SampleModel::SampleModel() : SessionModel("SampleModel")
 
 void SampleModel::append_random_item(ModelView::SessionItem* container)
 {
-    auto item = dynamic_cast<DemoItem*>(insertNewItem(Constants::DemoItemType, container));
+    auto item = insertItem<DemoItem>(container);
     item->setProperty(DemoItem::P_COLOR_PROPERTY, random_color());
     item->setProperty(DemoItem::P_STRING_PROPERTY, QVariant::fromValue(random_name()));
     item->setProperty(DemoItem::P_INTEGER_PROPERTY, ModelView::Utils::RandInt(0, 10));
@@ -65,12 +65,12 @@ void SampleModel::append_random_item(ModelView::SessionItem* container)
 
 void SampleModel::init_model_content()
 {
-    auto container = insertNewItem(Constants::DemoContainerItemType);
+    auto container = insertItem<DemoContainerItem>();
     append_random_item(container);
     append_random_item(container);
     append_random_item(container);
 
-    container = insertNewItem(Constants::DemoContainerItemType);
+    container = insertItem<DemoContainerItem>();
     append_random_item(container);
     append_random_item(container);
 }

--- a/examples/layereditor/core/model/MaterialModel.cpp
+++ b/examples/layereditor/core/model/MaterialModel.cpp
@@ -77,16 +77,13 @@ ExternalProperty MaterialModel::material_property(const std::string& id)
 
 void MaterialModel::init_model()
 {
-    auto container = insertNewItem(::Constants::MaterialContainerType);
-    auto material =
-        dynamic_cast<SLDMaterialItem*>(insertNewItem(::Constants::SLDMaterialType, container));
+    auto container = insertItem<MaterialContainerItem>();
+    auto material = insertItem<SLDMaterialItem>(container);
     material->set_properties("Air", QColor(Qt::blue), 1e-06, 1e-07);
 
-    material =
-        dynamic_cast<SLDMaterialItem*>(insertNewItem(::Constants::SLDMaterialType, container));
+    material = insertItem<SLDMaterialItem>(container);
     material->set_properties("Au", QColor(Qt::yellow), 2.4e-06, 5.6e-07);
 
-    material =
-        dynamic_cast<SLDMaterialItem*>(insertNewItem(::Constants::SLDMaterialType, container));
+    material = insertItem<SLDMaterialItem>(container);
     material->set_properties("Si2O3", QColor(Qt::darkCyan), 3.4e-06, 3.6e-07);
 }

--- a/examples/layereditor/core/model/SampleModel.cpp
+++ b/examples/layereditor/core/model/SampleModel.cpp
@@ -35,10 +35,10 @@ SampleModel::SampleModel() : SessionModel("SampleModel")
 
 void SampleModel::init_model()
 {
-    auto multilayer = insertNewItem(::Constants::MultiLayerType);
-    auto layer = insertNewItem(::Constants::LayerType, multilayer);
-    auto assembly = insertNewItem(::Constants::MultiLayerType, multilayer);
-    layer = insertNewItem(::Constants::LayerType, assembly);
-    layer = insertNewItem(::Constants::LayerType, assembly);
-    layer = insertNewItem(::Constants::LayerType, multilayer);
+    auto multilayer = insertItem<MultiLayerItem>();
+    insertItem<LayerItem>(multilayer);
+    auto assembly = insertItem<MultiLayerItem>(multilayer);
+    insertItem<LayerItem>(assembly);
+    insertItem<LayerItem>(assembly);
+    insertItem<LayerItem>(multilayer);
 }

--- a/examples/plotgraphs/core/graphmodel.cpp
+++ b/examples/plotgraphs/core/graphmodel.cpp
@@ -15,6 +15,7 @@
 #include "modelutils.h"
 #include "mvvm_types.h"
 #include "numericutils.h"
+#include "containeritem.h"
 #include <QColor>
 #include <cmath>
 
@@ -57,12 +58,11 @@ void GraphModel::add_graph()
 
     // FIXME remove graph_count and data_count when mapper will report true items
 
-    auto data =
-        dynamic_cast<Data1DItem*>(insertNewItem(Constants::Data1DItemType, data_container(), "", data_count));
+    auto data = insertItem<Data1DItem>(data_container(), "", data_count);
     data->setFixedBinAxis(npoints, xmin, xmax);
     data->setContent(bin_values(ModelView::Utils::RandDouble(0.5, 1.0)));
 
-    auto graph = dynamic_cast<GraphItem*>(insertNewItem(Constants::GraphItemType, viewport(), "", graph_count));
+    auto graph = insertItem<GraphItem>(viewport(), "", graph_count);
     graph->setDataItem(data);
     auto rndm = []() -> int { return ModelView::Utils::RandInt(0, 255); };
     graph->setProperty(GraphItem::P_COLOR, QVariant::fromValue(QColor(rndm(), rndm(), rndm())));
@@ -112,10 +112,10 @@ ContainerItem* GraphModel::data_container()
 
 void GraphModel::init_model()
 {
-    auto container = insertNewItem(Constants::ContainerType);
+    auto container = insertItem<ContainerItem>();
     container->setDisplayName("Data container");
 
-    auto viewport = insertNewItem(Constants::GraphViewportItemType);
+    auto viewport = insertItem<GraphViewportItem>();
     viewport->setDisplayName("Graph container");
     add_graph();
 }

--- a/examples/treeviews/core/samplemodel.cpp
+++ b/examples/treeviews/core/samplemodel.cpp
@@ -41,11 +41,11 @@ SampleModel::SampleModel() : SessionModel("SampleModel")
 
 void SampleModel::init_model()
 {
-    auto multi_layer = insertNewItem(::Constants::MultiLayerType);
-    auto layer = insertNewItem(::Constants::LayerType, multi_layer);
-    insertNewItem(::Constants::ParticleType, layer);
+    auto multi_layer = insertItem<MultiLayer>();
+    auto layer = insertItem<LayerItem>(multi_layer);
+    insertItem<ParticleItem>(layer);
 
-    insertNewItem(::Constants::LayerType, multi_layer);
+    insertItem<LayerItem>(multi_layer);
 
-    insertNewItem(::Constants::InterferenceType);
+    insertItem<InterferenceFunctionItem>();
 }

--- a/mvvm/model/sessionitem.h
+++ b/mvvm/model/sessionitem.h
@@ -113,7 +113,7 @@ template <typename T> T& SessionItem::item(const std::string& tag) const
 
 //! Returns all items under given tag casted to specific type.
 
-template <typename T> std::vector<T*> SessionItem::items(const std::string& tag) const
+template <typename T=SessionItem> std::vector<T*> SessionItem::items(const std::string& tag) const
 {
     std::vector<T*> result;
     for (auto item : getItems(tag))

--- a/mvvm/model/sessionmodel.h
+++ b/mvvm/model/sessionmodel.h
@@ -47,6 +47,9 @@ public:
     SessionItem* insertNewItem(const model_type& modelType, SessionItem* parent = nullptr,
                                const std::string& tag = {}, int row = -1);
 
+    template<typename T>
+    T* insertItem(SessionItem* parent = nullptr, const std::string& tag = {}, int row = -1);
+
     SessionItem* copyItem(const SessionItem* item, SessionItem* parent, const std::string& tag = {}, int row = -1);
 
     SessionItem* rootItem() const;
@@ -92,6 +95,13 @@ private:
     std::unique_ptr<ModelMapper> m_mapper;
     std::unique_ptr<SessionItem> m_root_item;
 };
+
+template<typename T>
+T* SessionModel::insertItem(SessionItem* parent, const std::string& tag, int row)
+{
+    T x;
+    return dynamic_cast<T*>(insertNewItem(x.modelType(), parent, tag, row));
+}
 
 } // namespace ModelView
 

--- a/mvvm/serialization/jsonitemdata.cpp
+++ b/mvvm/serialization/jsonitemdata.cpp
@@ -52,7 +52,7 @@ QJsonArray JsonItemData::get_json(const SessionItemData& data)
 
 std::unique_ptr<SessionItemData> JsonItemData::get_data(const QJsonArray& object)
 {
-    std::unique_ptr<SessionItemData> result = std::make_unique<SessionItemData>();
+    auto result = std::make_unique<SessionItemData>();
 
     for (const auto& x : object) {
         if (!is_item_data(x.toObject()))

--- a/tests/model/TestCopyItemCommand.cpp
+++ b/tests/model/TestCopyItemCommand.cpp
@@ -20,11 +20,12 @@ TEST_F(TestCopyItemCommand, copyChild)
     SessionModel model;
 
     // parent with children and data
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", 0);
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
-    auto child0 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+
+    auto child0 = model.insertItem<SessionItem>(parent, "tag1", -1);
     child0->setData(42.0);
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
     child1->setData(43.0);
 
     // making copy of child

--- a/tests/model/TestData1DItem.cpp
+++ b/tests/model/TestData1DItem.cpp
@@ -73,7 +73,7 @@ TEST_F(TestData1DItem, setContent)
 TEST_F(TestData1DItem, checkSignalsOnAxisChange)
 {
     SessionModel model;
-    auto item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto item = model.insertItem<Data1DItem>();
 
     MockWidgetForItem widget(item);
 

--- a/tests/model/TestData1DItem.cpp
+++ b/tests/model/TestData1DItem.cpp
@@ -91,7 +91,7 @@ TEST_F(TestData1DItem, checkSignalsOnAxisChange)
 TEST_F(TestData1DItem, checkSignalsOnContentChange)
 {
     SessionModel model;
-    auto item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto item = model.insertItem<Data1DItem>();
     item->setFixedBinAxis(3, 0.0, 3.0);
 
     MockWidgetForItem widget(item);

--- a/tests/model/TestGraphItem.cpp
+++ b/tests/model/TestGraphItem.cpp
@@ -33,8 +33,8 @@ TEST_F(TestGraphItem, initialState)
 TEST_F(TestGraphItem, setDataItem)
 {
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto data_item = model.insertItem<Data1DItem>();
+    auto graph_item = model.insertItem<GraphItem>();
 
     graph_item->setDataItem(data_item);
 
@@ -46,8 +46,8 @@ TEST_F(TestGraphItem, setDataItem)
 TEST_F(TestGraphItem, binCenters)
 {
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto data_item = model.insertItem<Data1DItem>();
+    auto graph_item = model.insertItem<GraphItem>();
 
     std::vector<double> expected_content = {1.0, 2.0, 3.0};
     std::vector<double> expected_centers = {0.5, 1.5, 2.5};
@@ -65,8 +65,8 @@ TEST_F(TestGraphItem, binCenters)
 TEST_F(TestGraphItem, setNullData)
 {
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto data_item = model.insertItem<Data1DItem>();
+    auto graph_item = model.insertItem<GraphItem>();
 
     // preparing data item
     std::vector<double> expected_content = {1.0, 2.0, 3.0};
@@ -89,8 +89,8 @@ TEST_F(TestGraphItem, setNullData)
 TEST_F(TestGraphItem, onSetDataItem)
 {
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto data_item = model.insertItem<Data1DItem>();
+    auto graph_item = model.insertItem<GraphItem>();
 
     MockWidgetForItem widget(graph_item);
 

--- a/tests/model/TestGraphViewportItem.cpp
+++ b/tests/model/TestGraphViewportItem.cpp
@@ -80,7 +80,7 @@ TEST_F(TestGraphViewportItem, onAddItem)
     EXPECT_CALL(widget, onRowAboutToBeRemoved(_, _, _)).Times(0);
 
     // triggering action
-    model.insertNewItem(Constants::GraphItemType, viewport_item);
+    model.insertItem<GraphItem>(viewport_item);
 }
 
 //! Check signaling on set data item.

--- a/tests/model/TestGraphViewportItem.cpp
+++ b/tests/model/TestGraphViewportItem.cpp
@@ -35,11 +35,9 @@ TEST_F(TestGraphViewportItem, addItem)
 {
     SessionModel model;
 
-    auto viewport_item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
-    auto graph_item =
-        dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType, viewport_item));
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto viewport_item = model.insertItem<GraphViewportItem>();
+    auto graph_item = model.insertItem<GraphItem>(viewport_item);
+    auto data_item = model.insertItem<Data1DItem>();
 
     const std::vector<double> expected_content = {1.0, 2.0, 3.0};
     const std::vector<double> expected_centers = {0.5, 1.5, 2.5};
@@ -70,8 +68,7 @@ TEST_F(TestGraphViewportItem, addItem)
 TEST_F(TestGraphViewportItem, onAddItem)
 {
     SessionModel model;
-    auto viewport_item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
+    auto viewport_item = model.insertItem<GraphViewportItem>();
 
     MockWidgetForItem widget(viewport_item);
 
@@ -91,19 +88,17 @@ TEST_F(TestGraphViewportItem, onAddItem)
 TEST_F(TestGraphViewportItem, onSetDataItem)
 {
     SessionModel model;
-    auto viewport_item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
+    auto viewport_item = model.insertItem<GraphViewportItem>();
 
     // setting upda tata item
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
     const std::vector<double> expected_content = {1.0, 2.0, 3.0};
     const std::vector<double> expected_centers = {0.5, 1.5, 2.5};
     data_item->setFixedBinAxis(3, 0.0, 3.0);
     data_item->setContent(expected_content);
 
     // inserting graph item
-    auto graph_item =
-        dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType, viewport_item));
+    auto graph_item = model.insertItem<GraphItem>(viewport_item);
 
     MockWidgetForItem widget(viewport_item);
 

--- a/tests/model/TestItemController.cpp
+++ b/tests/model/TestItemController.cpp
@@ -50,7 +50,7 @@ TEST_F(TestItemController, initialState)
 TEST_F(TestItemController, itemDeletedBeforeController)
 {
     SessionModel model;
-    auto item = dynamic_cast<PropertyItem*>(model.insertNewItem(Constants::PropertyType));
+    auto item = model.insertItem<PropertyItem>();
 
     auto controller = std::make_unique<TestController>();
     controller->setItem(item);
@@ -68,7 +68,7 @@ TEST_F(TestItemController, itemDeletedBeforeController)
 TEST_F(TestItemController, unsubscribeScenario)
 {
     SessionModel model;
-    auto item = dynamic_cast<PropertyItem*>(model.insertNewItem(Constants::PropertyType));
+    auto item = model.insertItem<PropertyItem>();
 
     auto controller = std::make_unique<TestController>();
     controller->setItem(item);
@@ -93,7 +93,7 @@ TEST_F(TestItemController, unsubscribeScenario)
 TEST_F(TestItemController, controllerDeletedBeforeItem)
 {
     SessionModel model;
-    auto item = dynamic_cast<PropertyItem*>(model.insertNewItem(Constants::PropertyType));
+    auto item = model.insertItem<PropertyItem>();
 
     auto controller = std::make_unique<TestController>();
     controller->setItem(item);

--- a/tests/model/TestItemMapper.cpp
+++ b/tests/model/TestItemMapper.cpp
@@ -26,7 +26,7 @@ TEST(TestItemMapper, initialState)
 
     // item in model context does have a mapper
     SessionModel model;
-    auto item2 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item2 = model.insertItem<SessionItem>(model.rootItem(), "", 0);
     EXPECT_NO_THROW(item2->mapper());
 }
 
@@ -35,7 +35,7 @@ TEST(TestItemMapper, initialState)
 TEST(TestItemMapper, onItemDestroy)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     MockWidgetForItem widget(item);
 
@@ -56,7 +56,7 @@ TEST(TestItemMapper, onItemDestroy)
 TEST(TestItemMapper, onDataChange)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     MockWidgetForItem widget(item);
 
@@ -77,7 +77,7 @@ TEST(TestItemMapper, onDataChange)
 TEST(TestItemMapper, onDataChangeDuplicate)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     MockWidgetForItem widget(item);
 
@@ -98,7 +98,7 @@ TEST(TestItemMapper, onDataChangeDuplicate)
 TEST(TestItemMapper, setActivity)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     MockWidgetForItem widget(item);
 
@@ -120,7 +120,7 @@ TEST(TestItemMapper, setActivity)
 TEST(TestItemMapper, unsubscribe)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     MockWidgetForItem widget1(item);
     MockWidgetForItem widget2(item);
@@ -139,7 +139,7 @@ TEST(TestItemMapper, unsubscribe)
 TEST(TestItemMapper, onPropertyChange)
 {
     SessionModel model;
-    auto item = dynamic_cast<CompoundItem*>(model.insertNewItem(Constants::CompoundType));
+    auto item = model.insertItem<CompoundItem>();
     EXPECT_TRUE(item != nullptr);
 
     auto property = item->addProperty<PropertyItem>("height", 42.0);
@@ -164,9 +164,9 @@ TEST(TestItemMapper, onPropertyChange)
 TEST(TestItemMapper, onChildPropertyChange)
 {
     SessionModel model;
-    auto compound1 = dynamic_cast<CompoundItem*>(model.insertNewItem(Constants::CompoundType));
+    auto compound1 = model.insertItem<CompoundItem>();
     compound1->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/true);
-    auto compound2 = dynamic_cast<CompoundItem*>(model.insertNewItem(Constants::CompoundType, compound1));
+    auto compound2 = model.insertItem<CompoundItem>(compound1);
 
     auto property = compound2->addProperty<PropertyItem>("height", 42.0);
 
@@ -190,7 +190,7 @@ TEST(TestItemMapper, onChildPropertyChange)
 TEST(TestItemMapper, onRowInsert)
 {
     SessionModel model;
-    auto compound1 = dynamic_cast<CompoundItem*>(model.insertNewItem(Constants::CompoundType));
+    auto compound1 = model.insertItem<CompoundItem>();
     compound1->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/true);
 
     MockWidgetForItem widget(compound1);
@@ -205,7 +205,7 @@ TEST(TestItemMapper, onRowInsert)
     EXPECT_CALL(widget, onRowAboutToBeRemoved(_, _, _)).Times(0);
 
     // perform action
-    model.insertNewItem(Constants::CompoundType, compound1, expected_tag, expected_row);
+    model.insertItem<CompoundItem>(compound1, expected_tag, expected_row);
 }
 
 //! Inserting item to item.
@@ -216,9 +216,9 @@ TEST(TestItemMapper, onRowAboutToRemove)
     std::string expected_tag = "tag1";
 
     SessionModel model;
-    auto compound1 = dynamic_cast<CompoundItem*>(model.insertNewItem(Constants::CompoundType));
+    auto compound1 = model.insertItem<CompoundItem>();
     compound1->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/true);
-    model.insertNewItem(Constants::CompoundType, compound1, expected_tag, expected_row);
+    model.insertItem<CompoundItem>(compound1, expected_tag, expected_row);
 
     MockWidgetForItem widget(compound1);
 

--- a/tests/model/TestItemUtils.cpp
+++ b/tests/model/TestItemUtils.cpp
@@ -3,6 +3,7 @@
 #include "itemutils.h"
 #include "sessionitem.h"
 #include "sessionmodel.h"
+#include "propertyitem.h"
 #include "taginfo.h"
 #include <memory>
 
@@ -79,16 +80,15 @@ TEST_F(TestItemUtils, iterateIfItem)
 
 TEST_F(TestItemUtils, iterateModel)
 {
-    const model_type modelType = Constants::BaseType;
     SessionModel model;
 
     // building model
-    auto parent1 = model.insertNewItem(modelType);
-    auto parent2 = model.insertNewItem(modelType);
+    auto parent1 = model.insertItem<SessionItem>();
+    auto parent2 = model.insertItem<SessionItem>();
     parent1->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
     parent2->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    auto child1 = model.insertNewItem(modelType, parent1);
-    auto child2 = model.insertNewItem(modelType, parent1);
+    auto child1 = model.insertItem<SessionItem>(parent1);
+    auto child2 = model.insertItem<SessionItem>(parent1);
 
     std::vector<const SessionItem*> visited_items;
     auto fun = [&](const SessionItem* item) { visited_items.push_back(item); };
@@ -106,14 +106,12 @@ TEST_F(TestItemUtils, itemCopyNumber)
 {
     SessionModel model;
 
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
-    const std::string model_a(Constants::BaseType);
-    const std::string model_b(Constants::PropertyType);
-    auto child1 = model.insertNewItem(model_a, parent);
-    auto child2 = model.insertNewItem(model_a, parent);
-    auto child3 = model.insertNewItem(model_b, parent);
+    auto child1 = model.insertItem<SessionItem>(parent);
+    auto child2 = model.insertItem<SessionItem>(parent);
+    auto child3 = model.insertItem<PropertyItem>(parent);
 
     EXPECT_EQ(Utils::CopyNumber(child1), 0);
     EXPECT_EQ(Utils::CopyNumber(child2), 1);
@@ -126,13 +124,13 @@ TEST_F(TestItemUtils, TopLevelAndPropertyItems)
 {
     SessionModel model;
 
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
     parent->registerTag(TagInfo::universalTag("default_tag"), /*set_as_default*/ true);
     parent->registerTag(TagInfo::propertyTag("property_tag", Constants::PropertyType));
 
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "default_tag", -1);
-    auto child2 = model.insertNewItem(Constants::PropertyType, parent, "property_tag", -1);
-    auto child3 = model.insertNewItem(Constants::BaseType, parent, "default_tag", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "default_tag", -1);
+    auto child2 = model.insertItem<PropertyItem>(parent, "property_tag", -1);
+    auto child3 = model.insertItem<SessionItem>(parent, "default_tag", -1);
 
     EXPECT_EQ(Utils::TopLevelItems(*parent), std::vector<SessionItem*>({child1, child3}));
     EXPECT_EQ(Utils::SinglePropertyItems(*parent), std::vector<SessionItem*>({child2}));

--- a/tests/model/TestJsonModel.cpp
+++ b/tests/model/TestJsonModel.cpp
@@ -5,6 +5,7 @@
 #include "taginfo.h"
 #include "test_utils.h"
 #include "itempool.h"
+#include "propertyitem.h"
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonObject>
@@ -76,7 +77,7 @@ TEST_F(TestJsonModel, emptyModelToJsonAndBack)
 
     // attempt to reconstruct non-empty model
     SessionModel target2("TestModel");
-    target2.insertNewItem(Constants::BaseType);
+    target2.insertItem<SessionItem>();
     EXPECT_THROW(converter.json_to_model(object, target2), std::runtime_error);
 
     // succesfull reconstruction
@@ -92,7 +93,7 @@ TEST_F(TestJsonModel, singleItemToJsonAndBack)
     JsonModel converter;
     SessionModel model("TestModel");
 
-    auto item = model.insertNewItem(Constants::BaseType, nullptr, "", -1);
+    auto item = model.insertItem<SessionItem>(nullptr, "", -1);
 
     QJsonObject object;
     converter.model_to_json(model, object);
@@ -114,12 +115,12 @@ TEST_F(TestJsonModel, parentAndChildToJsonAndBack)
     SessionModel model("TestModel");
 
     // filling original model with content
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
     parent->setDisplayName("parent_name");
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
     parent->setData(QVariant::fromValue(42));
-    auto child = model.insertNewItem(Constants::PropertyType, parent);
+    auto child = model.insertItem<PropertyItem>(parent);
     child->setDisplayName("child_name");
 
     // writing model to json
@@ -163,7 +164,7 @@ TEST_F(TestJsonModel, identifiers)
 
     // creating model and converting it to json
     SessionModel source("SourceModel", pool1);
-    auto parent1 = source.insertNewItem(Constants::BaseType);
+    auto parent1 = source.insertItem<SessionItem>();
     QJsonObject json_source;
     converter.model_to_json(source, json_source);
 
@@ -198,12 +199,12 @@ TEST_F(TestJsonModel, parentAndChildToFileAndBack)
     SessionModel model("TestModel");
 
     // filling original model with content
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
     parent->setDisplayName("parent_name");
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
     parent->setData(QVariant::fromValue(42));
-    auto child = model.insertNewItem(Constants::PropertyType, parent);
+    auto child = model.insertItem<PropertyItem>(parent);
     child->setDisplayName("child_name");
 
     // writing model to json

--- a/tests/model/TestLinkedItem.cpp
+++ b/tests/model/TestLinkedItem.cpp
@@ -2,6 +2,7 @@
 #include "linkeditem.h"
 #include "sessionmodel.h"
 #include "itempool.h"
+#include "propertyitem.h"
 #include "MockWidgets.h"
 
 using namespace ModelView;
@@ -30,8 +31,8 @@ TEST_F(TestLinkedItem, initialState)
 TEST_F(TestLinkedItem, sameModelContext)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::PropertyType);
-    auto linked = dynamic_cast<LinkedItem*>(model.insertNewItem(Constants::LinkedType));
+    auto item = model.insertItem<PropertyItem>();
+    auto linked = model.insertItem<LinkedItem>();
 
     // no link by default
     EXPECT_EQ(linked->linkedItem(), nullptr);
@@ -53,8 +54,8 @@ TEST_F(TestLinkedItem, differentModelContext)
     SessionModel model1("TestModel1", pool);
     SessionModel model2("TestModel2", pool);
 
-    auto item = model1.insertNewItem(Constants::PropertyType);
-    auto linked = dynamic_cast<LinkedItem*>(model2.insertNewItem(Constants::LinkedType));
+    auto item = model1.insertItem<PropertyItem>();
+    auto linked = model2.insertItem<LinkedItem>();
 
     // no link by default
     EXPECT_EQ(linked->linkedItem(), nullptr);
@@ -71,8 +72,8 @@ TEST_F(TestLinkedItem, differentModelContext)
 TEST_F(TestLinkedItem, onSetLink)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::PropertyType);
-    auto linked = dynamic_cast<LinkedItem*>(model.insertNewItem(Constants::LinkedType));
+    auto item = model.insertItem<PropertyItem>();
+    auto linked = model.insertItem<LinkedItem>();
 
     // no link by default
     EXPECT_EQ(linked->linkedItem(), nullptr);
@@ -95,8 +96,8 @@ TEST_F(TestLinkedItem, setNullAsLink)
     auto pool = std::make_shared<ItemPool>();
 
     SessionModel model("TestModel", pool);
-    auto linked = dynamic_cast<LinkedItem*>(model.insertNewItem(Constants::LinkedType));
-    auto item = model.insertNewItem(Constants::PropertyType);
+    auto linked = model.insertItem<LinkedItem>();
+    auto item = model.insertItem<PropertyItem>();
 
     // no link by default
     EXPECT_EQ(linked->linkedItem(), nullptr);

--- a/tests/model/TestModelMapper.cpp
+++ b/tests/model/TestModelMapper.cpp
@@ -25,7 +25,7 @@ TEST(TestModelMapper, onDataChange)
     MockWidgetForModel widget(&model);
 
     EXPECT_CALL(widget, onRowInserted(_, _, _));
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     // expecting signal to be called once
     const int role = ItemDataRole::DATA;
@@ -73,7 +73,7 @@ TEST(TestModelMapper, onRowInserted)
     EXPECT_CALL(widget, onModelReset(_)).Times(0);
 
     // perform action
-    model.insertNewItem(Constants::BaseType, model.rootItem(), expected_tag, 0);
+    model.insertItem<SessionItem>(model.rootItem(), expected_tag, 0);
 }
 
 //! Inserting item and checking corresponding signals.
@@ -86,7 +86,7 @@ TEST(TestModelMapper, onRowRemoved)
     const int expected_index(0);
     const std::string expected_tag("");
     EXPECT_CALL(widget, onRowInserted(model.rootItem(), expected_tag, expected_index)).Times(1);
-    model.insertNewItem(Constants::BaseType, model.rootItem(), expected_tag, expected_index);
+    model.insertItem<SessionItem>(model.rootItem(), expected_tag, expected_index);
 
     EXPECT_CALL(widget, onDataChange(_, _)).Times(0);
     EXPECT_CALL(widget, onRowInserted(_, _, _)).Times(0);

--- a/tests/model/TestModelMapper.cpp
+++ b/tests/model/TestModelMapper.cpp
@@ -102,8 +102,8 @@ TEST(TestModelMapper, onRowRemoved)
 
 TEST(TestModelMapper, onModelDestroyed)
 {
-    std::unique_ptr<SessionModel> model = std::make_unique<SessionModel>();
-    std::unique_ptr<MockWidgetForModel> widget = std::make_unique<MockWidgetForModel>(model.get());
+    auto model = std::make_unique<SessionModel>();
+    auto widget = std::make_unique<MockWidgetForModel>(model.get());
 
     EXPECT_CALL(*widget, onDataChange(_, _)).Times(0);
     EXPECT_CALL(*widget, onRowInserted(_, _, _)).Times(0);
@@ -120,8 +120,8 @@ TEST(TestModelMapper, onModelDestroyed)
 
 TEST(TestModelMapper, onModelReset)
 {
-    std::unique_ptr<SessionModel> model = std::make_unique<SessionModel>();
-    std::unique_ptr<MockWidgetForModel> widget = std::make_unique<MockWidgetForModel>(model.get());
+    auto model = std::make_unique<SessionModel>();
+    auto widget = std::make_unique<MockWidgetForModel>(model.get());
 
     EXPECT_CALL(*widget, onDataChange(_, _)).Times(0);
     EXPECT_CALL(*widget, onRowInserted(_, _, _)).Times(0);

--- a/tests/model/TestModelUtils.cpp
+++ b/tests/model/TestModelUtils.cpp
@@ -21,8 +21,8 @@ TEST_F(TestModelUtils, topItem)
     EXPECT_EQ(Utils::TopItem<SessionItem>(&model), nullptr);
     EXPECT_EQ(Utils::TopItem<ToyItems::MultiLayerItem>(&model), nullptr);
 
-    auto multilayer1 = model.insertNewItem(ToyItems::Constants::MultiLayerType);
-    model.insertNewItem(ToyItems::Constants::MultiLayerType);
+    auto multilayer1 = model.insertItem<ToyItems::MultiLayerItem>();
+    model.insertItem<ToyItems::MultiLayerItem>();
 
     EXPECT_EQ(Utils::TopItem<>(&model), multilayer1);
     EXPECT_EQ(Utils::TopItem<SessionItem>(&model), multilayer1);
@@ -36,11 +36,9 @@ TEST_F(TestModelUtils, topItems)
     EXPECT_EQ(Utils::TopItems<SessionItem>(&model).size(), 0);
     EXPECT_EQ(Utils::TopItems<ToyItems::MultiLayerItem>(&model).size(), 0);
 
-    auto multilayer1 = dynamic_cast<ToyItems::MultiLayerItem*>(
-        model.insertNewItem(ToyItems::Constants::MultiLayerType));
-    auto particle = model.insertNewItem(ToyItems::Constants::ParticleType);
-    auto multilayer2 = dynamic_cast<ToyItems::MultiLayerItem*>(
-        model.insertNewItem(ToyItems::Constants::MultiLayerType));
+    auto multilayer1 = model.insertItem<ToyItems::MultiLayerItem>();
+    auto particle = model.insertItem<ToyItems::ParticleItem>();
+    auto multilayer2 = model.insertItem<ToyItems::MultiLayerItem>();
 
     std::vector<SessionItem*> expected1 = {multilayer1, particle, multilayer2};
     EXPECT_EQ(Utils::TopItems<SessionItem>(&model), expected1);

--- a/tests/model/TestModelUtils.cpp
+++ b/tests/model/TestModelUtils.cpp
@@ -53,21 +53,16 @@ TEST_F(TestModelUtils, findItems)
     EXPECT_EQ(Utils::FindItems<SessionItem>(&model).size(), 1); // because of rootItem
     EXPECT_EQ(Utils::FindItems<ToyItems::MultiLayerItem>(&model).size(), 0);
 
-    auto multilayer1 = dynamic_cast<ToyItems::MultiLayerItem*>(
-        model.insertNewItem(ToyItems::Constants::MultiLayerType));
-    model.insertNewItem(ToyItems::Constants::ParticleType);
-    auto multilayer2 = dynamic_cast<ToyItems::MultiLayerItem*>(
-        model.insertNewItem(ToyItems::Constants::MultiLayerType));
+    auto multilayer1 = model.insertItem<ToyItems::MultiLayerItem>();
+    model.insertItem<ToyItems::ParticleItem>();
+    auto multilayer2 = model.insertItem<ToyItems::MultiLayerItem>();
 
     std::vector<ToyItems::MultiLayerItem*> expected2 = {multilayer1, multilayer2};
     EXPECT_EQ(Utils::FindItems<ToyItems::MultiLayerItem>(&model), expected2);
 
     // adding layers to multilayer
-    auto layer1 = dynamic_cast<ToyItems::LayerItem*>(
-        model.insertNewItem(ToyItems::Constants::LayerType, multilayer1));
-
-    auto layer2 = dynamic_cast<ToyItems::LayerItem*>(
-        model.insertNewItem(ToyItems::Constants::LayerType, multilayer2));
+    auto layer1 = model.insertItem<ToyItems::LayerItem>(multilayer1);
+    auto layer2 = model.insertItem<ToyItems::LayerItem>(multilayer2);
 
     std::vector<ToyItems::LayerItem*> expected3 = {layer1, layer2};
     EXPECT_EQ(Utils::FindItems<ToyItems::LayerItem>(&model), expected3);
@@ -77,7 +72,7 @@ TEST_F(TestModelUtils, DeleteItemFromModel)
 {
     ToyItems::SampleModel model;
 
-    auto item = model.insertNewItem(Constants::BaseType);
+    auto item = model.insertItem<SessionItem>();
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);
     Utils::DeleteItemFromModel(item);
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);

--- a/tests/model/TestMoveItemCommand.cpp
+++ b/tests/model/TestMoveItemCommand.cpp
@@ -18,10 +18,10 @@ TestMoveItemCommand::~TestMoveItemCommand() = default;
 TEST_F(TestMoveItemCommand, rootContextNext)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1); // 0
-    auto item1 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1); // 1
-    auto item2 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1); // 2
-    auto item3 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1); // 3
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1); // 0
+    auto item1 = model.insertItem<SessionItem>(model.rootItem(), "", -1); // 1
+    auto item2 = model.insertItem<SessionItem>(model.rootItem(), "", -1); // 2
+    auto item3 = model.insertItem<SessionItem>(model.rootItem(), "", -1); // 3
 
     // expecting 4 items in the order of insertion
     std::vector<SessionItem*> expected = {item0, item1, item2, item3};
@@ -54,10 +54,10 @@ TEST_F(TestMoveItemCommand, rootContextNext)
 TEST_F(TestMoveItemCommand, rootContextSamePos)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item1 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item2 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item3 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item1 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item2 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item3 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
 
     // expecting 4 items in the order of insertion
     std::vector<SessionItem*> expected = {item0, item1, item2, item3};
@@ -84,10 +84,10 @@ TEST_F(TestMoveItemCommand, rootContextSamePos)
 TEST_F(TestMoveItemCommand, rootContextPrev)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item1 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item2 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item3 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item1 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item2 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item3 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
 
     // expecting 4 items in the order of insertion
     std::vector<SessionItem*> expected = {item0, item1, item2, item3};
@@ -114,10 +114,10 @@ TEST_F(TestMoveItemCommand, rootContextPrev)
 TEST_F(TestMoveItemCommand, rootContextLast)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item1 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item2 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item3 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item1 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item2 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item3 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
 
     // expecting 4 items in the order of insertion
     std::vector<SessionItem*> expected = {item0, item1, item2, item3};
@@ -145,10 +145,10 @@ TEST_F(TestMoveItemCommand, rootContextLast)
 TEST_F(TestMoveItemCommand, rootContextLast2)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item1 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item2 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto item3 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item1 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item2 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto item3 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
 
     // expecting 4 items in the order of insertion
     std::vector<SessionItem*> expected = {item0, item1, item2, item3};
@@ -176,12 +176,12 @@ TEST_F(TestMoveItemCommand, rootContextLast2)
 TEST_F(TestMoveItemCommand, fromRootToParent)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", -1);
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
 
-    auto child0 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child0 = model.insertItem<SessionItem>(parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
 
     // expected items for root item
     std::vector<SessionItem*> expected = {item0, parent};
@@ -222,12 +222,12 @@ TEST_F(TestMoveItemCommand, fromRootToParent)
 TEST_F(TestMoveItemCommand, fromParentToRoot)
 {
     SessionModel model;
-    auto item0 = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto item0 = model.insertItem<SessionItem>(model.rootItem(), "", -1);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", -1);
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
 
-    auto child0 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child0 = model.insertItem<SessionItem>(parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
 
     // expected items for root item
     std::vector<SessionItem*> expected = {item0, parent};
@@ -268,14 +268,14 @@ TEST_F(TestMoveItemCommand, fromParentToRoot)
 TEST_F(TestMoveItemCommand, betweenParentTags)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", -1);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", -1);
     parent->registerTag(TagInfo::universalTag("tag1"));
     parent->registerTag(TagInfo::universalTag("tag2"));
 
-    auto child0 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
-    auto child2 = model.insertNewItem(Constants::BaseType, parent, "tag2", -1);
-    auto child3 = model.insertNewItem(Constants::BaseType, parent, "tag2", -1);
+    auto child0 = model.insertItem<SessionItem>(parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
+    auto child2 = model.insertItem<SessionItem>(parent, "tag2", -1);
+    auto child3 = model.insertItem<SessionItem>(parent, "tag2", -1);
 
     // expected items for root item
     std::vector<SessionItem*> expected = {parent};

--- a/tests/model/TestPath.cpp
+++ b/tests/model/TestPath.cpp
@@ -48,7 +48,6 @@ TEST_F(TestPath, fromString)
 
 TEST_F(TestPath, pathFromItem)
 {
-    const model_type modelType = Constants::BaseType;
     SessionModel model;
 
     // unexisting path
@@ -58,11 +57,11 @@ TEST_F(TestPath, pathFromItem)
     EXPECT_TRUE(model.pathFromItem(xx.get()).str().empty());
 
     // three children beneeth root item
-    SessionItem* item0 = model.insertNewItem(modelType);
+    SessionItem* item0 = model.insertItem<SessionItem>();
     item0->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    SessionItem* item1 = model.insertNewItem(modelType);
+    SessionItem* item1 = model.insertItem<SessionItem>();
     item1->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    SessionItem* item2 = model.insertNewItem(modelType);
+    SessionItem* item2 = model.insertItem<SessionItem>();
     item2->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
     EXPECT_EQ(model.pathFromItem(item0).str(), "0");
@@ -70,18 +69,18 @@ TEST_F(TestPath, pathFromItem)
     EXPECT_EQ(model.pathFromItem(item2).str(), "2");
 
     // adding granchildren to item0
-    SessionItem* child00 = model.insertNewItem(modelType, item0);
-    SessionItem* child01 = model.insertNewItem(modelType, item0);
+    SessionItem* child00 = model.insertItem<SessionItem>(item0);
+    SessionItem* child01 = model.insertItem<SessionItem>(item0);
 
     EXPECT_EQ(model.pathFromItem(child00).str(), "0,0");
     EXPECT_EQ(model.pathFromItem(child01).str(), "0,1");
 
     // adding grandchildren to item2
-    SessionItem* child20 = model.insertNewItem(modelType, item2);
+    SessionItem* child20 = model.insertItem<SessionItem>(item2);
     child20->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
-    SessionItem* child200 = model.insertNewItem(modelType, child20);
-    SessionItem* child201 = model.insertNewItem(modelType, child20);
+    SessionItem* child200 = model.insertItem<SessionItem>(child20);
+    SessionItem* child201 = model.insertItem<SessionItem>(child20);
 
     EXPECT_EQ(model.pathFromItem(child200).str(), "2,0,0");
     EXPECT_EQ(model.pathFromItem(child201).str(), "2,0,1");
@@ -89,7 +88,6 @@ TEST_F(TestPath, pathFromItem)
 
 TEST_F(TestPath, itemFromPath)
 {
-    const model_type modelType = Constants::BaseType;
     SessionModel model;
 
     // access to non-existing item
@@ -97,21 +95,21 @@ TEST_F(TestPath, itemFromPath)
     non_existing.append(8);
     EXPECT_EQ(model.itemFromPath(non_existing), nullptr);
 
-    SessionItem* item0 = model.insertNewItem(modelType);
+    SessionItem* item0 = model.insertItem<SessionItem>();
     item0->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    SessionItem* item1 = model.insertNewItem(modelType);
+    SessionItem* item1 = model.insertItem<SessionItem>();
     item1->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    SessionItem* item2 = model.insertNewItem(modelType);
+    SessionItem* item2 = model.insertItem<SessionItem>();
     item2->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
     EXPECT_EQ(model.itemFromPath(Path::fromVector({0})), item0);
     EXPECT_EQ(model.itemFromPath(Path::fromVector({1})), item1);
     EXPECT_EQ(model.itemFromPath(Path::fromVector({2})), item2);
 
-    SessionItem* child20 = model.insertNewItem(modelType, item2);
+    SessionItem* child20 = model.insertItem<SessionItem>(item2);
     child20->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    SessionItem* child200 = model.insertNewItem(modelType, child20);
-    SessionItem* child201 = model.insertNewItem(modelType, child20);
+    SessionItem* child200 = model.insertItem<SessionItem>(child20);
+    SessionItem* child201 = model.insertItem<SessionItem>(child20);
 
     EXPECT_EQ(model.itemFromPath(Path::fromVector({2, 0})), child20);
     EXPECT_EQ(model.itemFromPath(Path::fromVector({2, 0, 0})), child200);

--- a/tests/model/TestRemoveItemCommand.cpp
+++ b/tests/model/TestRemoveItemCommand.cpp
@@ -18,7 +18,7 @@ TestRemoveItemCommand::~TestRemoveItemCommand() = default;
 TEST_F(TestRemoveItemCommand, removeAtCommand)
 {
     SessionModel model;
-    auto item = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto item = model.insertItem<SessionItem>(model.rootItem(), "", 0);
 
     auto item_identifier = item->identifier();
 
@@ -39,12 +39,12 @@ TEST_F(TestRemoveItemCommand, removeAtCommand)
 TEST_F(TestRemoveItemCommand, removeAtCommandChild)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", 0);
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
 
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
     child1->setData(42.0);
-    model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    model.insertItem<SessionItem>(parent, "tag1", -1);
 
     auto child1_identifier = child1->identifier();
 
@@ -69,10 +69,10 @@ TEST_F(TestRemoveItemCommand, removeAtCommandChild)
 TEST_F(TestRemoveItemCommand, removeAtCommandParentWithChild)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", 0);
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
 
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
     child1->setData(42.0);
 
     auto parent_identifier = parent->identifier();
@@ -104,17 +104,17 @@ TEST_F(TestRemoveItemCommand, removeAtCommandParentWithChild)
 TEST_F(TestRemoveItemCommand, removeAtCommandMultitag)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType, model.rootItem(), "", 0);
+    auto parent = model.insertItem<SessionItem>(model.rootItem(), "", 0);
     parent->registerTag(TagInfo::universalTag("tag1"));
     parent->registerTag(TagInfo::universalTag("tag2"));
 
-    auto child1 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child1 = model.insertItem<SessionItem>(parent, "tag1", -1);
     child1->setData(41.0);
 
-    auto child2 = model.insertNewItem(Constants::BaseType, parent, "tag1", -1);
+    auto child2 = model.insertItem<SessionItem>(parent, "tag1", -1);
     child2->setData(42.0);
 
-    auto child3 = model.insertNewItem(Constants::BaseType, parent, "tag2", -1);
+    auto child3 = model.insertItem<SessionItem>(parent, "tag2", -1);
     child3->setData(43.0);
 
     auto parent_identifier = parent->identifier();

--- a/tests/model/TestSessionItemContainer.cpp
+++ b/tests/model/TestSessionItemContainer.cpp
@@ -136,7 +136,7 @@ TEST_F(TestSessionItemContainer, indexOfItem)
 
     // not existing items
     EXPECT_EQ(tag.indexOfItem(nullptr), -1);
-    std::unique_ptr<SessionItem> child3 = std::make_unique<SessionItem>(model_type);
+    auto child3 = std::make_unique<SessionItem>(model_type);
     EXPECT_EQ(tag.indexOfItem(child3.get()), -1);
 }
 

--- a/tests/model/TestSetValueCommand.cpp
+++ b/tests/model/TestSetValueCommand.cpp
@@ -21,7 +21,7 @@ TEST_F(TestSetValueCommand, setValueCommand)
     const int role = ItemDataRole::DATA;
 
     // inserting single item
-    auto item = model.insertNewItem(Constants::BaseType);
+    auto item = model.insertItem<SessionItem>();
     EXPECT_FALSE(model.data(item, role).isValid());
 
     QVariant expected(42.0);
@@ -46,7 +46,7 @@ TEST_F(TestSetValueCommand, setSameValueCommand)
     const int role = ItemDataRole::DATA;
 
     // inserting single item
-    auto item = model.insertNewItem(Constants::BaseType);
+    auto item = model.insertItem<SessionItem>();
     QVariant expected(42.0);
     item->setData(expected, role);
 

--- a/tests/model/TestVectorItem.cpp
+++ b/tests/model/TestVectorItem.cpp
@@ -35,7 +35,7 @@ TEST_F(TestVectorItem, initialState)
 TEST_F(TestVectorItem, initialStateFromModel)
 {
     SessionModel model;
-    auto item = dynamic_cast<VectorItem*>(model.insertNewItem(Constants::VectorType));
+    auto item = model.insertItem<VectorItem>();
 
     EXPECT_EQ(item->property(VectorItem::P_X).toDouble(), 0.0);
     EXPECT_EQ(item->property(VectorItem::P_Y).toDouble(), 0.0);

--- a/tests/toyitems/toy_models.cpp
+++ b/tests/toyitems/toy_models.cpp
@@ -14,7 +14,7 @@
 namespace  {
 std::unique_ptr<ModelView::ItemCatalogue> CreateToyItemCatalogue()
 {
-    std::unique_ptr<ModelView::ItemCatalogue> result = std::make_unique<ModelView::ItemCatalogue>();
+    auto result = std::make_unique<ModelView::ItemCatalogue>();
     result->registerItem<ToyItems::MultiLayerItem>();
     result->registerItem<ToyItems::LayerItem>();
     result->registerItem<ToyItems::ParticleItem>();

--- a/tests/viewmodel/TestAxisPlotControllers.cpp
+++ b/tests/viewmodel/TestAxisPlotControllers.cpp
@@ -54,7 +54,7 @@ TEST_F(TestAxisPlotControllers, setViewportAxisItem)
 
     // creating the model with single ViewportAxisItem
     SessionModel model;
-    auto axisItem = dynamic_cast<ViewportAxisItem*>(model.insertNewItem(Constants::ViewportAxisType));
+    auto axisItem = model.insertItem<ViewportAxisItem>();
     axisItem->setProperty(ViewportAxisItem::P_MIN, expected_min);
     axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
 
@@ -86,7 +86,7 @@ TEST_F(TestAxisPlotControllers, changeQCPAxis)
 
     // creating the model with single ViewportAxisItem
     SessionModel model;
-    auto axisItem = dynamic_cast<ViewportAxisItem*>(model.insertNewItem(Constants::ViewportAxisType));
+    auto axisItem = model.insertItem<ViewportAxisItem>();
     axisItem->setProperty(ViewportAxisItem::P_MIN, 42.0);
     axisItem->setProperty(ViewportAxisItem::P_MAX, 42.1);
 
@@ -122,7 +122,7 @@ TEST_F(TestAxisPlotControllers, changeViewportAxisItem)
 
     // creating the model with single ViewportAxisItem
     SessionModel model;
-    auto axisItem = dynamic_cast<ViewportAxisItem*>(model.insertNewItem(Constants::ViewportAxisType));
+    auto axisItem = model.insertItem<ViewportAxisItem>();
     axisItem->setProperty(ViewportAxisItem::P_MIN, 42.0);
     axisItem->setProperty(ViewportAxisItem::P_MAX, 42.1);
 
@@ -155,7 +155,7 @@ TEST_F(TestAxisPlotControllers, changeViewportAxisItemYCase)
 
     // creating the model with single ViewportAxisItem
     SessionModel model;
-    auto axisItem = dynamic_cast<ViewportAxisItem*>(model.insertNewItem(Constants::ViewportAxisType));
+    auto axisItem = model.insertItem<ViewportAxisItem>();
     axisItem->setProperty(ViewportAxisItem::P_MIN, 42.0);
     axisItem->setProperty(ViewportAxisItem::P_MAX, 42.1);
 

--- a/tests/viewmodel/TestData1DPlotController.cpp
+++ b/tests/viewmodel/TestData1DPlotController.cpp
@@ -39,7 +39,7 @@ TEST_F(TestData1DPlotController, dataPoints)
 
     // creating data item with single point
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
     data_item->setFixedBinAxis(1, 1.0, 2.0);
 
     // creating controller and point it to Data1DItem
@@ -67,9 +67,9 @@ TEST_F(TestData1DPlotController, twoDataItems)
 
     // creating data item with single point
     SessionModel model;
-    auto data_item1 = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item1 = model.insertItem<Data1DItem>();
     data_item1->setFixedBinAxis(1, 1.0, 2.0);
-    auto data_item2 = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item2 = model.insertItem<Data1DItem>();
     data_item2->setFixedBinAxis(2, 0.0, 2.0);
 
     // creating controller and point it to Data1DItem

--- a/tests/viewmodel/TestDefaultEditorFactory.cpp
+++ b/tests/viewmodel/TestDefaultEditorFactory.cpp
@@ -13,6 +13,7 @@
 #include "sessionitem.h"
 #include "externalproperty.h"
 #include "reallimits.h"
+#include "propertyitem.h"
 #include "integereditor.h"
 
 using namespace ModelView;
@@ -28,7 +29,7 @@ public:
     {
         // populating model with data
         SessionModel model;
-        auto propertyItem = model.insertNewItem(Constants::PropertyType);
+        auto propertyItem = model.insertItem<PropertyItem>();
         propertyItem->setData(variant);
 
         // create view model and use index of data cell to create an editor

--- a/tests/viewmodel/TestDefaultViewModel.cpp
+++ b/tests/viewmodel/TestDefaultViewModel.cpp
@@ -379,7 +379,7 @@ TEST_F(TestDefaultViewModel, onModelReset)
 
 TEST_F(TestDefaultViewModel, onModelDestroyed)
 {
-    std::unique_ptr<SessionModel> model = std::make_unique<SessionModel>();
+    auto model = std::make_unique<SessionModel>();
     model->insertItem<SessionItem>();
 
     DefaultViewModel viewModel(model.get());

--- a/tests/viewmodel/TestDefaultViewModel.cpp
+++ b/tests/viewmodel/TestDefaultViewModel.cpp
@@ -32,7 +32,7 @@ TEST_F(TestDefaultViewModel, initialState)
 TEST_F(TestDefaultViewModel, fromPropertyItem)
 {
     SessionModel model;
-    auto propertyItem = model.insertNewItem(Constants::PropertyType);
+    auto propertyItem = model.insertItem<PropertyItem>();
     propertyItem->setData(42.0);
 
     DefaultViewModel viewModel(&model);
@@ -58,7 +58,7 @@ TEST_F(TestDefaultViewModel, fromPropertyItem)
 TEST_F(TestDefaultViewModel, sessionItemFromIndex)
 {
     SessionModel model;
-    auto propertyItem = model.insertNewItem(Constants::PropertyType);
+    auto propertyItem = model.insertItem<PropertyItem>();
     propertyItem->setData(42.0);
 
     DefaultViewModel viewModel(&model);
@@ -79,7 +79,7 @@ TEST_F(TestDefaultViewModel, sessionItemFromIndex)
 TEST_F(TestDefaultViewModel, indexFromSessionItem)
 {
     SessionModel model;
-    auto propertyItem = model.insertNewItem(Constants::PropertyType);
+    auto propertyItem = model.insertItem<PropertyItem>();
     propertyItem->setData(42.0);
 
     DefaultViewModel viewModel(&model);
@@ -99,7 +99,7 @@ TEST_F(TestDefaultViewModel, indexFromSessionItem)
 TEST_F(TestDefaultViewModel, findPropertyItemView)
 {
     SessionModel model;
-    auto propertyItem = model.insertNewItem(Constants::PropertyType);
+    auto propertyItem = model.insertItem<PropertyItem>();
     propertyItem->setData(42.0);
 
     DefaultViewModel viewModel(&model);
@@ -113,7 +113,7 @@ TEST_F(TestDefaultViewModel, findPropertyItemView)
 TEST_F(TestDefaultViewModel, propertyItemDataChanged)
 {
     SessionModel model;
-    auto propertyItem = model.insertNewItem(Constants::PropertyType);
+    auto propertyItem = model.insertItem<PropertyItem>();
     propertyItem->setData(42.0);
 
     // constructing viewModel from sample model
@@ -140,14 +140,12 @@ TEST_F(TestDefaultViewModel, propertyItemDataChanged)
 TEST_F(TestDefaultViewModel, insertSingleTopItem)
 {
     SessionModel model;
-    const model_type modelType(Constants::BaseType);
-
     DefaultViewModel viewModel(&model);
 
     QSignalSpy spyInsert(&viewModel, &DefaultViewModel::rowsInserted);
 
     // inserting single item
-    model.insertNewItem(modelType);
+    model.insertItem<SessionItem>();
 
     // root item should have one child
     EXPECT_EQ(viewModel.rowCount(), 1);
@@ -171,10 +169,9 @@ TEST_F(TestDefaultViewModel, insertSingleTopItem)
 TEST_F(TestDefaultViewModel, removeSingleTopItem)
 {
     SessionModel model;
-    const model_type modelType(Constants::BaseType);
 
     // inserting single item
-    model.insertNewItem(modelType);
+    model.insertItem<SessionItem>();
 
     // constructing viewModel from sample model
     DefaultViewModel viewModel(&model);
@@ -204,11 +201,10 @@ TEST_F(TestDefaultViewModel, removeSingleTopItem)
 TEST_F(TestDefaultViewModel, removeOneOfTopItems)
 {
     SessionModel model;
-    const model_type modelType(Constants::BaseType);
 
     // inserting single item
-    model.insertNewItem(modelType);
-    model.insertNewItem(modelType);
+    model.insertItem<SessionItem>();
+    model.insertItem<SessionItem>();
 
     // constructing viewModel from sample model
     DefaultViewModel viewModel(&model);
@@ -251,16 +247,16 @@ TEST_F(TestDefaultViewModel, propertyItemAppearance)
     SessionModel model;
 
     // default item
-    auto item1 = model.insertNewItem(Constants::PropertyType);
+    auto item1 = model.insertItem<PropertyItem>();
     item1->setData(42.0);
 
     // disabled item
-    auto item2 = model.insertNewItem(Constants::PropertyType);
+    auto item2 = model.insertItem<PropertyItem>();
     item2->setData(42.0);
     item2->setEnabled(false);
 
     // read only item
-    auto item3 = model.insertNewItem(Constants::PropertyType);
+    auto item3 = model.insertItem<PropertyItem>();
     item3->setData(42.0);
     item3->setEditable(false);
 
@@ -300,7 +296,7 @@ TEST_F(TestDefaultViewModel, propertyItemAppearanceChanged)
     SessionModel model;
 
     // default item
-    auto item = model.insertNewItem(Constants::PropertyType);
+    auto item = model.insertItem<PropertyItem>();
     item->setData(42.0);
 
     // setting up ViewModel and spying it's dataChanged signals
@@ -351,10 +347,9 @@ TEST_F(TestDefaultViewModel, propertyItemAppearanceChanged)
 TEST_F(TestDefaultViewModel, setRootItem)
 {
     SessionModel model;
-    const model_type modelType(Constants::BaseType);
-
     DefaultViewModel viewModel(&model);
-    auto item = model.insertNewItem(modelType);
+
+    auto item = model.insertItem<PropertyItem>();
 
     viewModel.setSessionModel(&model);
     viewModel.setRootSessionItem(item);
@@ -368,11 +363,10 @@ TEST_F(TestDefaultViewModel, setRootItem)
 
 TEST_F(TestDefaultViewModel, onModelReset)
 {
-    std::unique_ptr<SessionModel> model = std::make_unique<SessionModel>();
-    const model_type modelType(Constants::BaseType);
-    model->insertNewItem(modelType);
-    model->insertNewItem(modelType);
-    model->insertNewItem(modelType);
+    auto model = std::make_unique<SessionModel>();
+    model->insertItem<SessionItem>();
+    model->insertItem<SessionItem>();
+    model->insertItem<SessionItem>();
 
     DefaultViewModel viewModel(model.get());
     model->clear();
@@ -386,8 +380,7 @@ TEST_F(TestDefaultViewModel, onModelReset)
 TEST_F(TestDefaultViewModel, onModelDestroyed)
 {
     std::unique_ptr<SessionModel> model = std::make_unique<SessionModel>();
-    const model_type modelType(Constants::BaseType);
-    model->insertNewItem(modelType);
+    model->insertItem<SessionItem>();
 
     DefaultViewModel viewModel(model.get());
     EXPECT_EQ(viewModel.rowCount(), 1);

--- a/tests/viewmodel/TestGraphPlotController.cpp
+++ b/tests/viewmodel/TestGraphPlotController.cpp
@@ -37,14 +37,14 @@ TEST_F(TestGraphPlotController, setItem)
 
     // setup model and single data item in it
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
     data_item->setFixedBinAxis(2, 0.0, 2.0);
     std::vector<double> expected_centers = {0.5, 1.5};
     std::vector<double> expected_values = {42.0, 43.0};
     data_item->setContent(expected_values);
 
     // setup graph item
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto graph_item = model.insertItem<GraphItem>();
     graph_item->setProperty(GraphItem::P_COLOR, QColor(Qt::red));
     graph_item->setDataItem(data_item);
 
@@ -67,7 +67,7 @@ TEST_F(TestGraphPlotController, setDataAfter)
     GraphPlotController controller(custom_plot.get());
 
     SessionModel model;
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto graph_item = model.insertItem<GraphItem>();
 
     controller.setItem(graph_item);
 
@@ -78,7 +78,7 @@ TEST_F(TestGraphPlotController, setDataAfter)
     EXPECT_EQ(TestUtils::binValues(graph), std::vector<double>());
 
     // setup data after and single data item in it
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
     data_item->setFixedBinAxis(2, 0.0, 2.0);
     std::vector<double> expected_centers = {0.5, 1.5};
     std::vector<double> expected_values = {42.0, 43.0};
@@ -101,14 +101,14 @@ TEST_F(TestGraphPlotController, unlinkFromDataItem)
 
     // setup model and single data item in it
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
     data_item->setFixedBinAxis(2, 0.0, 2.0);
     std::vector<double> expected_centers = {0.5, 1.5};
     std::vector<double> expected_values = {42.0, 43.0};
     data_item->setContent(expected_values);
 
     // setup graph item
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto graph_item = model.insertItem<GraphItem>();
     graph_item->setProperty(GraphItem::P_COLOR, QColor(Qt::red));
     graph_item->setDataItem(data_item);
 
@@ -140,10 +140,10 @@ TEST_F(TestGraphPlotController, controllerDelete)
 
     // setup model and single data item in it
     SessionModel model;
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
 
     // setup graph item
-    auto graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    auto graph_item = model.insertItem<GraphItem>();
     graph_item->setDataItem(data_item);
 
     // initializing controller
@@ -155,7 +155,7 @@ TEST_F(TestGraphPlotController, controllerDelete)
     EXPECT_EQ(custom_plot->graphCount(), 0);
 
     //  inserting item again
-    graph_item = dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType));
+    graph_item = model.insertItem<GraphItem>();
     graph_item->setDataItem(data_item);
 }
 

--- a/tests/viewmodel/TestGraphViewportController.cpp
+++ b/tests/viewmodel/TestGraphViewportController.cpp
@@ -36,8 +36,7 @@ TEST_F(TestGraphViewportPlotController, setItem)
 
     // setting up controller with viewport item
     SessionModel model;
-    auto item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
+    auto item = model.insertItem<GraphViewportItem>();
     controller.setItem(item);
 
     // no graphs in empty GraphViewportItem
@@ -59,17 +58,15 @@ TEST_F(TestGraphViewportPlotController, addGraphAndSetItem)
 
     // setting up controller with viewport item
     SessionModel model;
-    auto viewport_item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
+    auto viewport_item = model.insertItem<GraphViewportItem>();
 
-    auto data_item = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data_item = model.insertItem<Data1DItem>();
     const std::vector<double> expected_content = {1.0, 2.0, 3.0};
     const std::vector<double> expected_centers = {0.5, 1.5, 2.5};
     data_item->setFixedBinAxis(3, 0.0, 3.0);
     data_item->setContent(expected_content);
 
-    auto graph_item =
-        dynamic_cast<GraphItem*>(model.insertNewItem(Constants::GraphItemType, viewport_item));
+    auto graph_item = model.insertItem<GraphItem>(viewport_item);
     graph_item->setDataItem(data_item);
     controller.setItem(viewport_item);
 
@@ -92,28 +89,26 @@ TEST_F(TestGraphViewportPlotController, addAndRemoveGraphs)
 
     // setting up controller with viewport item
     SessionModel model;
-    auto viewport_item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
+    auto viewport_item = model.insertItem<GraphViewportItem>();
     controller.setItem(viewport_item);
 
     // No graphs yet.
     EXPECT_EQ(custom_plot->graphCount(), 0);
 
     // Populating with data items
-    auto data1 = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data1 = model.insertItem<Data1DItem>();
     const std::vector<double> expected_content1 = {1.0, 2.0, 3.0};
     const std::vector<double> expected_centers = {0.5, 1.5, 2.5};
     data1->setFixedBinAxis(3, 0.0, 3.0);
     data1->setContent(expected_content1);
 
-    auto data2 = dynamic_cast<Data1DItem*>(model.insertNewItem(Constants::Data1DItemType));
+    auto data2 = model.insertItem<Data1DItem>();
     const std::vector<double> expected_content2 = {4.0, 5.0, 6.0};
     data2->setFixedBinAxis(3, 0.0, 3.0);
     data2->setContent(expected_content2);
 
     // adding graph item to viewport
-    auto graph_item1 = dynamic_cast<GraphItem*>(
-        model.insertNewItem(Constants::GraphItemType, viewport_item, "", 0));
+    auto graph_item1 = model.insertItem<GraphItem>(viewport_item, "", 0);
 
     // check that QCustomPlot knows about graph
     EXPECT_EQ(custom_plot->graphCount(), 1);
@@ -124,8 +119,7 @@ TEST_F(TestGraphViewportPlotController, addAndRemoveGraphs)
     EXPECT_EQ(custom_plot->graphCount(), 1);
 
     // adding secong graph
-    auto graph_item2 = dynamic_cast<GraphItem*>(
-        model.insertNewItem(Constants::GraphItemType, viewport_item, "", 1));
+    auto graph_item2 = model.insertItem<GraphItem>(viewport_item, "", 1);
     graph_item2->setDataItem(data2);
 
     // check that QCustomPlot knows about two graph
@@ -156,8 +150,7 @@ TEST_F(TestGraphViewportPlotController, addMoreGraphs)
 
     // setting up controller with viewport item
     SessionModel model;
-    auto viewport_item =
-        dynamic_cast<GraphViewportItem*>(model.insertNewItem(Constants::GraphViewportItemType));
+    auto viewport_item = model.insertItem<GraphViewportItem>();
     controller.setItem(viewport_item);
 
     // No graphs yet.
@@ -165,12 +158,12 @@ TEST_F(TestGraphViewportPlotController, addMoreGraphs)
 
     // adding graph item to viewport
     // FIXME remove row specification after ItemMapper reporting correct row
-    model.insertNewItem(Constants::GraphItemType, viewport_item, "", 0);
+    model.insertItem<GraphItem>(viewport_item, "", 0);
     EXPECT_EQ(custom_plot->graphCount(), 1);
 
-    model.insertNewItem(Constants::GraphItemType, viewport_item, "", 1);
+    model.insertItem<GraphItem>(viewport_item, "", 1);
     EXPECT_EQ(custom_plot->graphCount(), 2);
 
-    model.insertNewItem(Constants::GraphItemType, viewport_item, "", 0);
+    model.insertItem<GraphItem>(viewport_item, "", 0);
     EXPECT_EQ(custom_plot->graphCount(), 3);
 }

--- a/tests/viewmodel/TestPropertiesRowStrategy.cpp
+++ b/tests/viewmodel/TestPropertiesRowStrategy.cpp
@@ -96,7 +96,7 @@ TEST_F(TestPropertiesRowStrategy, baseItemInModelContext)
     EXPECT_EQ(items.size(), 0);
     TestUtils::clean_items(items);
 
-    model.insertNewItem(Constants::BaseType);
+    model.insertItem<SessionItem>();
     items = strategy.constructRow(model.rootItem());
     EXPECT_EQ(items.size(), 0);
 
@@ -108,13 +108,13 @@ TEST_F(TestPropertiesRowStrategy, baseItemInModelContext)
 TEST_F(TestPropertiesRowStrategy, propertyItemTree)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
 
     parent->registerTag(TagInfo::universalTag("universal_tag"));
     parent->registerTag(TagInfo::propertyTag("property_tag", Constants::PropertyType));
 
-    model.insertNewItem(Constants::BaseType, parent, "universal_tag");
-    model.insertNewItem(Constants::PropertyType, parent, "property_tag");
+    model.insertItem<SessionItem>(parent, "universal_tag");
+    model.insertItem<PropertyItem>(parent, "property_tag");
 
     PropertiesRowStrategy strategy({});
     auto items = strategy.constructRow(model.rootItem());
@@ -134,7 +134,7 @@ TEST_F(TestPropertiesRowStrategy, propertyItemTree)
 TEST_F(TestPropertiesRowStrategy, vectorItemInModelContext)
 {
     SessionModel model;
-    model.insertNewItem(Constants::VectorType);
+    model.insertItem<VectorItem>();
 
     PropertiesRowStrategy strategy({});
     auto items = strategy.constructRow(model.rootItem());

--- a/tests/viewmodel/TestPropertyTableViewModel.cpp
+++ b/tests/viewmodel/TestPropertyTableViewModel.cpp
@@ -2,7 +2,9 @@
 #include "propertytableviewmodel.h"
 #include "sessionmodel.h"
 #include "sessionitem.h"
+#include "propertyitem.h"
 #include "taginfo.h"
+#include "vectoritem.h"
 
 using namespace ModelView;
 
@@ -25,7 +27,7 @@ TEST_F(TestPropertyTableViewModel, initialState)
 TEST_F(TestPropertyTableViewModel, baseItem)
 {
     SessionModel model;
-    model.insertNewItem(Constants::BaseType);
+    model.insertItem<SessionItem>();
 
     PropertyTableViewModel viewModel;
     viewModel.setSessionModel(&model);
@@ -37,14 +39,14 @@ TEST_F(TestPropertyTableViewModel, baseItem)
 TEST_F(TestPropertyTableViewModel, propertyItem)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
 
     parent->registerTag(TagInfo::universalTag("universal_tag"));
     parent->registerTag(TagInfo::propertyTag("property_tag", Constants::PropertyType));
 
-    model.insertNewItem(Constants::BaseType, parent, "universal_tag");
-    model.insertNewItem(Constants::PropertyType, parent, "property_tag");
-    model.insertNewItem(Constants::BaseType, parent, "universal_tag");
+    model.insertItem<SessionItem>(parent, "universal_tag");
+    model.insertItem<PropertyItem>(parent, "property_tag");
+    model.insertItem<SessionItem>(parent, "universal_tag");
 
     PropertyTableViewModel viewModel;
     viewModel.setSessionModel(&model);
@@ -63,7 +65,7 @@ TEST_F(TestPropertyTableViewModel, propertyItem)
 TEST_F(TestPropertyTableViewModel, vectorItem)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::VectorType);
+    auto parent = model.insertItem<VectorItem>();
 
     PropertyTableViewModel viewModel;
     viewModel.setSessionModel(&model);

--- a/tests/viewmodel/TestPropertyViewModel.cpp
+++ b/tests/viewmodel/TestPropertyViewModel.cpp
@@ -2,6 +2,8 @@
 #include "sessionitem.h"
 #include "sessionmodel.h"
 #include "taginfo.h"
+#include "propertyitem.h"
+#include "vectoritem.h"
 #include "google_test.h"
 
 using namespace ModelView;
@@ -27,7 +29,7 @@ TEST_F(TestPropertyViewModel, initialState)
 TEST_F(TestPropertyViewModel, baseItem)
 {
     SessionModel model;
-    model.insertNewItem(Constants::BaseType);
+    model.insertItem<SessionItem>();
 
     PropertyViewModel viewModel;
     viewModel.setSessionModel(&model);
@@ -41,14 +43,14 @@ TEST_F(TestPropertyViewModel, baseItem)
 TEST_F(TestPropertyViewModel, propertyItem)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
 
     parent->registerTag(TagInfo::universalTag("universal_tag"));
     parent->registerTag(TagInfo::propertyTag("property_tag", Constants::PropertyType));
 
-    model.insertNewItem(Constants::BaseType, parent, "universal_tag");
-    model.insertNewItem(Constants::PropertyType, parent, "property_tag");
-    model.insertNewItem(Constants::BaseType, parent, "universal_tag");
+    model.insertItem<SessionItem>(parent, "universal_tag");
+    model.insertItem<PropertyItem>(parent, "property_tag");
+    model.insertItem<SessionItem>(parent, "universal_tag");
 
     PropertyViewModel viewModel;
     viewModel.setSessionModel(&model);
@@ -64,7 +66,7 @@ TEST_F(TestPropertyViewModel, propertyItem)
 TEST_F(TestPropertyViewModel, vectorItem)
 {
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::VectorType);
+    auto parent = model.insertItem<VectorItem>();
 
     PropertyViewModel viewModel;
     viewModel.setSessionModel(&model);

--- a/tests/viewmodel/TestToyInterferenceFunctionItem.cpp
+++ b/tests/viewmodel/TestToyInterferenceFunctionItem.cpp
@@ -18,8 +18,7 @@ TestToyInterferenceFunctionItem::~TestToyInterferenceFunctionItem() = default;
 TEST_F(TestToyInterferenceFunctionItem, rotationAngleEnabled)
 {
     ToyItems::SampleModel model;
-    auto interference = dynamic_cast<ToyItems::InterferenceFunctionItem*>(
-        model.insertNewItem(ToyItems::Constants::InterferenceType));
+    auto interference = model.insertItem<ToyItems::InterferenceFunctionItem>();
 
     // by default integration flag is ON, rotation angle is disabled
     EXPECT_TRUE(interference->property(ToyItems::InterferenceFunctionItem::P_INTEGRATION).toBool());

--- a/tests/viewmodel/TestToyLayerItem.cpp
+++ b/tests/viewmodel/TestToyLayerItem.cpp
@@ -25,7 +25,7 @@ TestToyLayerItem::~TestToyLayerItem() = default;
 TEST_F(TestToyLayerItem, inModel)
 {
     ToyItems::SampleModel model;
-    auto layer = model.insertNewItem(ToyItems::Constants::LayerType);
+    auto layer = model.insertItem<ToyItems::LayerItem>();
 
     EXPECT_FALSE(layer->data().isValid());
     EXPECT_EQ(layer->displayName(), ToyItems::Constants::LayerType);
@@ -34,7 +34,7 @@ TEST_F(TestToyLayerItem, inModel)
 TEST_F(TestToyLayerItem, inViewModel)
 {
     ToyItems::SampleModel model;
-    auto layerItem = model.insertNewItem(ToyItems::Constants::LayerType);
+    auto layerItem = model.insertItem<ToyItems::LayerItem>();
 
     // constructing viewModel from sample model
     DefaultViewModel viewModel(&model);
@@ -76,7 +76,7 @@ TEST_F(TestToyLayerItem, inViewModel)
 TEST_F(TestToyLayerItem, layerItemDataChanged)
 {
     ToyItems::SampleModel model;
-    auto layerItem = dynamic_cast<CompoundItem*>(model.insertNewItem(ToyItems::Constants::LayerType));
+    auto layerItem = model.insertItem<ToyItems::LayerItem>();
 
     // constructing viewModel from sample model
     DefaultViewModel viewModel(&model);
@@ -103,12 +103,12 @@ TEST_F(TestToyLayerItem, layerItemDataChanged)
 TEST_F(TestToyLayerItem, displayNameInMultiLayer)
 {
     ToyItems::SampleModel model;
-    auto multiLayer = model.insertNewItem(ToyItems::Constants::MultiLayerType);
+    auto multiLayer = model.insertItem<ToyItems::MultiLayerItem>();
 
-    auto layer0 = model.insertNewItem(ToyItems::Constants::LayerType, multiLayer);
+    auto layer0 = model.insertItem<ToyItems::LayerItem>(multiLayer);
     EXPECT_EQ(layer0->displayName(), "Layer");
 
-    auto layer1 = model.insertNewItem(ToyItems::Constants::LayerType, multiLayer);
+    auto layer1 = model.insertItem<ToyItems::LayerItem>(multiLayer);
     EXPECT_EQ(layer0->displayName(), "Layer0");
     EXPECT_EQ(layer1->displayName(), "Layer1");
 }
@@ -118,7 +118,7 @@ TEST_F(TestToyLayerItem, displayNameInMultiLayer)
 TEST_F(TestToyLayerItem, setRootItemContext)
 {
     ToyItems::SampleModel model;
-    auto layer = model.insertNewItem(ToyItems::Constants::LayerType);
+    auto layer = model.insertItem<ToyItems::LayerItem>();
     DefaultViewModel viewModel(&model);
     viewModel.setRootSessionItem(layer);
 
@@ -135,7 +135,7 @@ TEST_F(TestToyLayerItem, setRootItemContext)
 TEST_F(TestToyLayerItem, inTopItemsViewModelContext)
 {
     ToyItems::SampleModel model;
-    auto layer = model.insertNewItem(ToyItems::Constants::LayerType);
+    auto layer = model.insertItem<ToyItems::LayerItem>();
 
     TopItemsViewModel viewModel(&model);
     viewModel.setRootSessionItem(layer);
@@ -143,7 +143,7 @@ TEST_F(TestToyLayerItem, inTopItemsViewModelContext)
     EXPECT_EQ(viewModel.rowCount(QModelIndex()), 0);
     EXPECT_EQ(viewModel.columnCount(QModelIndex()), 2);
 
-    model.insertNewItem(ToyItems::Constants::ParticleType, layer);
+    model.insertItem<ToyItems::ParticleItem>(layer);
     EXPECT_EQ(viewModel.rowCount(QModelIndex()), 1);
     EXPECT_EQ(viewModel.columnCount(QModelIndex()), 2);
 }

--- a/tests/viewmodel/TestToyMultiLayerItem.cpp
+++ b/tests/viewmodel/TestToyMultiLayerItem.cpp
@@ -22,7 +22,7 @@ TestToyMultilayerItem::~TestToyMultilayerItem() = default;
 TEST_F(TestToyMultilayerItem, multiLayer)
 {
     ToyItems::SampleModel model;
-    auto multiLayer = model.insertNewItem(ToyItems::Constants::MultiLayerType);
+    auto multiLayer = model.insertItem<ToyItems::MultiLayerItem>();
 
     EXPECT_FALSE(multiLayer->data().isValid());
     EXPECT_EQ(multiLayer->displayName(), ToyItems::Constants::MultiLayerType);
@@ -34,7 +34,7 @@ TEST_F(TestToyMultilayerItem, multiLayer)
 TEST_F(TestToyMultilayerItem, multiLayerView)
 {
     ToyItems::SampleModel model;
-    auto multiLayerItem = model.insertNewItem(ToyItems::Constants::MultiLayerType);
+    auto multiLayerItem = model.insertItem<ToyItems::MultiLayerItem>();
 
     DefaultViewModel viewModel(&model);
     EXPECT_EQ(viewModel.rowCount(), 1);
@@ -54,7 +54,7 @@ TEST_F(TestToyMultilayerItem, multiLayerView)
 TEST_F(TestToyMultilayerItem, findMultiLayerView)
 {
     ToyItems::SampleModel model;
-    auto multiLayerItem = model.insertNewItem(ToyItems::Constants::MultiLayerType);
+    auto multiLayerItem = model.insertItem<ToyItems::MultiLayerItem>();
 
     DefaultViewModel viewModel(&model);
 
@@ -69,7 +69,7 @@ TEST_F(TestToyMultilayerItem, viewItemsForMultiLayer)
 {
     ToyItems::SampleModel model;
 
-    auto multiLayer = model.insertNewItem(ToyItems::Constants::MultiLayerType);
+    auto multiLayer = model.insertItem<ToyItems::MultiLayerItem>();
 
     ViewLabelItem labelItem(multiLayer);
     EXPECT_EQ(labelItem.data(Qt::DisplayRole).toString().toStdString(),

--- a/tests/viewmodel/TestToyShapeGroupItem.cpp
+++ b/tests/viewmodel/TestToyShapeGroupItem.cpp
@@ -65,7 +65,7 @@ TEST_F(TestToyShapeGroupItem, setCurrentType)
 TEST_F(TestToyShapeGroupItem, inModelContext)
 {
     ToyItems::SampleModel model;
-    auto item = dynamic_cast<GroupItem*>(model.insertNewItem(ToyItems::Constants::ShapeGroupType));
+    auto item = model.insertItem<ToyItems::ShapeGroupItem>();
     ASSERT_TRUE(item != nullptr);
 
     EXPECT_EQ(item->currentIndex(), 1);
@@ -88,7 +88,7 @@ TEST_F(TestToyShapeGroupItem, inModelContext)
 TEST_F(TestToyShapeGroupItem, setDataInModelContext)
 {
     ToyItems::SampleModel model;
-    auto item = dynamic_cast<GroupItem*>(model.insertNewItem(ToyItems::Constants::ShapeGroupType));
+    auto item = model.insertItem<ToyItems::ShapeGroupItem>();
     ASSERT_TRUE(item != nullptr);
 
     // initial status
@@ -111,7 +111,7 @@ TEST_F(TestToyShapeGroupItem, viewItemsFromShapeGroup)
 {
     ToyItems::SampleModel model;
 
-    auto groupItem = model.insertNewItem(ToyItems::Constants::ShapeGroupType);
+    auto groupItem = model.insertItem<ToyItems::ShapeGroupItem>();
 
     ViewLabelItem labelItem(groupItem);
     EXPECT_EQ(labelItem.data(Qt::DisplayRole).toString().toStdString(),
@@ -126,7 +126,7 @@ TEST_F(TestToyShapeGroupItem, viewItemsFromShapeGroup)
 TEST_F(TestToyShapeGroupItem, inDefaultViewModelContext)
 {
     ToyItems::SampleModel model;
-    auto groupItem = model.insertNewItem(ToyItems::Constants::ShapeGroupType);
+    auto groupItem = model.insertItem<ToyItems::ShapeGroupItem>();
 
     // constructing viewModel from sample model
     DefaultViewModel viewModel(&model);
@@ -177,11 +177,10 @@ TEST_F(TestToyShapeGroupItem, inDefaultViewModelContext)
 TEST_F(TestToyShapeGroupItem, inPropertyViewModelContext)
 {
     ToyItems::SampleModel model;
-    auto parent = model.insertNewItem(Constants::BaseType);
+    auto parent = model.insertItem<SessionItem>();
     parent->registerTag(TagInfo::propertyTag("property_tag", ToyItems::Constants::ShapeGroupType));
 
-    auto groupItem = dynamic_cast<GroupItem*>(
-        model.insertNewItem(ToyItems::Constants::ShapeGroupType, parent, "property_tag"));
+    auto groupItem = model.insertItem<ToyItems::ShapeGroupItem>(parent, "property_tag");
     ASSERT_TRUE(groupItem != nullptr);
 
     // constructing viewModel from sample model

--- a/tests/viewmodel/TestVectorItemView.cpp
+++ b/tests/viewmodel/TestVectorItemView.cpp
@@ -24,7 +24,7 @@ TestVectorItemView::~TestVectorItemView() = default;
 TEST_F(TestVectorItemView, fromVector)
 {
     SessionModel model;
-    auto vectorItem = model.insertNewItem(Constants::VectorType);
+    auto vectorItem = model.insertItem<VectorItem>();
 
     // constructing viewModel from sample model
     DefaultViewModel viewModel(&model);

--- a/tests/viewmodel/TestViewDataItem.cpp
+++ b/tests/viewmodel/TestViewDataItem.cpp
@@ -29,7 +29,7 @@ TEST_F(TestViewDataItem, initialState)
 TEST_F(TestViewDataItem, dataForDouble)
 {
     // create SessionItem with data on board
-    std::unique_ptr<SessionItem> item = std::make_unique<SessionItem>();
+    auto item = std::make_unique<SessionItem>();
     QVariant expected(42.0);
     EXPECT_TRUE(item->setData(expected));
 
@@ -45,7 +45,7 @@ TEST_F(TestViewDataItem, dataForDouble)
 TEST_F(TestViewDataItem, setDataForDouble)
 {
     // create SessionItem with data on board
-    std::unique_ptr<SessionItem> item = std::make_unique<SessionItem>();
+    auto item = std::make_unique<SessionItem>();
     QVariant expected(42.0);
     EXPECT_TRUE(item->setData(expected));
 
@@ -70,7 +70,7 @@ TEST_F(TestViewDataItem, setDataForDouble)
 TEST_F(TestViewDataItem, dataForColor)
 {
     // create SessionItem with data on board
-    std::unique_ptr<SessionItem> item = std::make_unique<SessionItem>();
+    auto item = std::make_unique<SessionItem>();
     QVariant expected = QVariant::fromValue(QColor(Qt::green));
     EXPECT_TRUE(item->setData(expected));
 
@@ -86,7 +86,7 @@ TEST_F(TestViewDataItem, dataForColor)
 TEST_F(TestViewDataItem, setDataForColor)
 {
     // create SessionItem with data on board
-    std::unique_ptr<SessionItem> item = std::make_unique<SessionItem>();
+    auto item = std::make_unique<SessionItem>();
     QVariant expected = QVariant::fromValue(QColor(Qt::green));
     EXPECT_TRUE(item->setData(expected));
 

--- a/tests/viewmodel/TestViewLabelItem.cpp
+++ b/tests/viewmodel/TestViewLabelItem.cpp
@@ -29,7 +29,7 @@ TEST_F(TestViewLabelItem, initialViewLabelItem)
 TEST_F(TestViewLabelItem, ViewLabelItem_data)
 {
     // create SessionItem with data on board
-    std::unique_ptr<SessionItem> item = std::make_unique<SessionItem>();
+    auto item = std::make_unique<SessionItem>();
     QVariant expected = QVariant::fromValue(std::string("Layer"));
     EXPECT_TRUE(item->setData(expected, ItemDataRole::DISPLAY));
 
@@ -45,7 +45,7 @@ TEST_F(TestViewLabelItem, ViewLabelItem_data)
 TEST_F(TestViewLabelItem, ViewLabelItem_setData)
 {
     // create SessionItem with data on board
-    std::unique_ptr<SessionItem> item = std::make_unique<SessionItem>();
+    auto item = std::make_unique<SessionItem>();
     QVariant expected = QVariant::fromValue(std::string("Layer"));
     EXPECT_TRUE(item->setData(expected, ItemDataRole::DISPLAY));
 

--- a/tests/viewmodel/TestViewModelUtils.cpp
+++ b/tests/viewmodel/TestViewModelUtils.cpp
@@ -4,6 +4,7 @@
 #include "sessionitem.h"
 #include "sessionmodel.h"
 #include "viewmodelutils.h"
+#include "vectoritem.h"
 #include <QColor>
 #include <QModelIndexList>
 #include <QStandardItemModel>
@@ -129,7 +130,7 @@ TEST_F(TestViewModelUtils, parentItemsFromIndex)
 {
     // creating VectorItem and viewModel to see it as a table
     SessionModel model;
-    auto parent = model.insertNewItem(Constants::VectorType);
+    auto parent = model.insertItem<VectorItem>();
     PropertyTableViewModel viewModel;
     viewModel.setSessionModel(&model);
 


### PR DESCRIPTION
The method SessionModel::insertItem is intended to replace SessionModel::insertNewItem to provide
concrete type right out of the box and to hide numerous Constants::MultiLayerItemType and similar constants from the user.
 
Still to do:
+ Write more elegant SessionModel::insertItem implementation
+ Consider SessionModel::insertNewItem complete removal
+ Implement templated InserItemCommand as a replacement of InsertNewItemCommand