### PR TITLE
Scene proxy widget

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,5 +11,6 @@ add_subdirectory(plotgraphs)
 add_subdirectory(sampleview)
 add_subdirectory(treeviews)
 add_subdirectory(quickrefl)
+add_subdirectory(graphicsproxy)
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,4 @@
 + sampleview
 + treeviews
 + collidingmice
++ graphicsproxy

--- a/examples/graphicsproxy/CMakeLists.txt
+++ b/examples/graphicsproxy/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(core)
+add_subdirectory(main)

--- a/examples/graphicsproxy/README.md
+++ b/examples/graphicsproxy/README.md
@@ -1,0 +1,5 @@
+# Qt mvvm example: graphicsproxy.
+
+Example shows how to embed QCustomPlot in QGraphicsScene to plot complex graphics
+on top of heat map.
+

--- a/examples/graphicsproxy/core/CMakeLists.txt
+++ b/examples/graphicsproxy/core/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(library_name graphicsproxycore)
+
+file(GLOB source_files ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+file(GLOB include_files ${CMAKE_CURRENT_LIST_DIR}/*.h)
+
+add_library(${library_name} STATIC ${source_files} ${include_files})
+
+target_link_libraries(${library_name} PUBLIC mvvm_viewmodel Qt5::Core Qt5::Gui Qt5::Widgets)
+target_include_directories(${library_name} PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/examples/graphicsproxy/core/axesrectangleview.cpp
+++ b/examples/graphicsproxy/core/axesrectangleview.cpp
@@ -22,7 +22,7 @@ QRectF AxesRectangleView::boundingRect() const
     return rect;
 }
 
-//! Recalculates bounding rectangle using viewport as reported by the adapter.
+//! Recalculates bounding rectangle using axes viewport as reported by the adapter.
 
 void AxesRectangleView::advance(int phase)
 {

--- a/examples/graphicsproxy/core/axesrectangleview.cpp
+++ b/examples/graphicsproxy/core/axesrectangleview.cpp
@@ -1,0 +1,28 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "axesrectangleview.h"
+#include <mvvm/plotting/sceneadapterinterface.h>
+
+AxesRectangleView::AxesRectangleView(const ModelView::SceneAdapterInterface* scene_adapter)
+    : scene_adapter(scene_adapter)
+{
+    // the key flag to hide children going outside of *this* bounding rectangle
+    setFlag(QGraphicsItem::ItemClipsChildrenToShape, true);
+}
+
+QRectF AxesRectangleView::boundingRect() const
+{
+    return scene_adapter->viewportRectangle();
+}
+
+void AxesRectangleView::paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*)
+{
+    // nothing to paint
+}

--- a/examples/graphicsproxy/core/axesrectangleview.cpp
+++ b/examples/graphicsproxy/core/axesrectangleview.cpp
@@ -19,7 +19,17 @@ AxesRectangleView::AxesRectangleView(const ModelView::SceneAdapterInterface* sce
 
 QRectF AxesRectangleView::boundingRect() const
 {
-    return scene_adapter->viewportRectangle();
+    return rect;
+}
+
+//! Recalculates bounding rectangle using viewport as reported by the adapter.
+
+void AxesRectangleView::advance(int phase)
+{
+    if (!phase)
+        return;
+    prepareGeometryChange();
+    rect = scene_adapter->viewportRectangle();
 }
 
 void AxesRectangleView::paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*)

--- a/examples/graphicsproxy/core/axesrectangleview.h
+++ b/examples/graphicsproxy/core/axesrectangleview.h
@@ -31,7 +31,7 @@ public:
     QRectF boundingRect() const override;
 
 protected:
-    void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*);
+    void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*) override;
 
 private:
     const ModelView::SceneAdapterInterface* scene_adapter{nullptr};

--- a/examples/graphicsproxy/core/axesrectangleview.h
+++ b/examples/graphicsproxy/core/axesrectangleview.h
@@ -30,11 +30,14 @@ public:
 
     QRectF boundingRect() const override;
 
+    void advance(int phase) override;
+
 protected:
     void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*) override;
 
 private:
     const ModelView::SceneAdapterInterface* scene_adapter{nullptr};
+    QRectF rect;
 };
 
 #endif // GRAPHICSPROXY_AXESRECTANGLEVIEW_H

--- a/examples/graphicsproxy/core/axesrectangleview.h
+++ b/examples/graphicsproxy/core/axesrectangleview.h
@@ -1,0 +1,40 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_AXESRECTANGLEVIEW_H
+#define GRAPHICSPROXY_AXESRECTANGLEVIEW_H
+
+#include <QGraphicsObject>
+
+namespace ModelView
+{
+class SceneAdapterInterface;
+}
+
+//! Transparent rectangle to cover axes area of QCustomPlot on QGraphicsScene. The size of
+//! rectangle always matches axes viewport at any zoom level. Hides all children items which
+//! go out of axes range of QCustomPlot.
+
+class AxesRectangleView : public QGraphicsObject
+{
+    Q_OBJECT
+
+public:
+    AxesRectangleView(const ModelView::SceneAdapterInterface* scene_adapter);
+
+    QRectF boundingRect() const override;
+
+protected:
+    void paint(QPainter*, const QStyleOptionGraphicsItem*, QWidget*);
+
+private:
+    const ModelView::SceneAdapterInterface* scene_adapter{nullptr};
+};
+
+#endif // GRAPHICSPROXY_AXESRECTANGLEVIEW_H

--- a/examples/graphicsproxy/core/colormapproxywidget.cpp
+++ b/examples/graphicsproxy/core/colormapproxywidget.cpp
@@ -7,13 +7,10 @@
 //
 // ************************************************************************** //
 
-#include "graphicsscene.h"
 #include "colormapproxywidget.h"
+#include <mvvm/plotting/colormapcanvas.h>
 
-GraphicsScene::GraphicsScene(QObject* parent) : QGraphicsScene(parent) {}
-
-void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
+ColorMapProxyWidget::ColorMapProxyWidget(ModelView::ColorMapCanvas* colormap)
 {
-    auto proxy = new ColorMapProxyWidget(colormap);
-    addItem(proxy);
+    setWidget(colormap);
 }

--- a/examples/graphicsproxy/core/colormapproxywidget.h
+++ b/examples/graphicsproxy/core/colormapproxywidget.h
@@ -7,24 +7,23 @@
 //
 // ************************************************************************** //
 
-#ifndef GRAPHICSPROXY_GRAPHICSSCENE_H
-#define GRAPHICSPROXY_GRAPHICSSCENE_H
+#ifndef GRAPHICSPROXY_COLORMAPPROXYWIDGET_H
+#define GRAPHICSPROXY_COLORMAPPROXYWIDGET_H
 
-#include <QGraphicsScene>
+#include <QGraphicsProxyWidget>
 
-namespace ModelView  {
+namespace ModelView
+{
 class ColorMapCanvas;
 }
 
-//! Custom graphics scene to show QCustomPlot with additional elements on top.
+//! Custom proxy widget to embed color map in graphics scene.
 
-class GraphicsScene : public QGraphicsScene
+class ColorMapProxyWidget : public QGraphicsProxyWidget
 {
     Q_OBJECT
 public:
-    GraphicsScene(QObject* parent);
-
-    void setColorMap(ModelView::ColorMapCanvas* colormap);
+    ColorMapProxyWidget(ModelView::ColorMapCanvas* colormap);
 };
 
-#endif //  GRAPHICSPROXY_GRAPHICSSCENE_H
+#endif //  GRAPHICSPROXY_COLORMAPPROXYWIDGET_H

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -10,9 +10,9 @@
 #include "graphicsscene.h"
 #include "colormapproxywidget.h"
 #include "regionofinterestview.h"
+#include "axesrectangleview.h"
 #include <mvvm/plotting/sceneadapterinterface.h>
 #include <mvvm/plotting/colormapcanvas.h>
-#include <QDebug>
 
 namespace
 {
@@ -38,7 +38,10 @@ void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
 
 void GraphicsScene::setRegionOfInterest(RegionOfInterestItem* roi)
 {
-    addItem(new RegionOfInterestView(roi, scene_adapter.get()));
+    auto axes_view = new AxesRectangleView(scene_adapter.get());
+    auto roi_view = new RegionOfInterestView(roi, scene_adapter.get());
+    roi_view->setParentItem(axes_view);
+    addItem(axes_view);
 }
 
 //! Adjust size of scene and color map proxy.
@@ -49,5 +52,6 @@ void GraphicsScene::update_size(const QSize& newSize)
         colormap_proxy->resize(newSize);
         setSceneRect(scene_origin_x, scene_origin_y, newSize.width(), newSize.height());
         colormap_proxy->setPos(0.0, 0.0);
+        advance();
     }
 }

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -9,11 +9,34 @@
 
 #include "graphicsscene.h"
 #include "colormapproxywidget.h"
+#include <QDebug>
 
-GraphicsScene::GraphicsScene(QObject* parent) : QGraphicsScene(parent) {}
+namespace
+{
+const double scene_origin_x{0.0};
+const double scene_origin_y{0.0};
+const QRectF default_scene_rect{QPointF{scene_origin_x, scene_origin_y}, QSizeF{800, 600}};
+} // namespace
+
+GraphicsScene::GraphicsScene(QObject* parent) : QGraphicsScene(parent)
+{
+    setSceneRect(default_scene_rect);
+}
 
 void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
 {
-    auto proxy = new ColorMapProxyWidget(colormap);
-    addItem(proxy);
+    clear();
+    colormap_proxy = new ColorMapProxyWidget(colormap);
+    addItem(colormap_proxy);
+}
+
+//! Adjust size of scene and color map proxy.
+
+void GraphicsScene::update_size(const QSize& newSize)
+{
+    if (colormap_proxy) {
+        colormap_proxy->resize(newSize);
+        setSceneRect(scene_origin_x, scene_origin_y, newSize.width(), newSize.height());
+        colormap_proxy->setPos(0.0, 0.0);
+    }
 }

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -30,6 +30,11 @@ void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
     addItem(colormap_proxy);
 }
 
+void GraphicsScene::setRegionOfInterest(RegionOfInterestItem* roi)
+{
+
+}
+
 //! Adjust size of scene and color map proxy.
 
 void GraphicsScene::update_size(const QSize& newSize)

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -38,7 +38,7 @@ void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
 
 void GraphicsScene::setRegionOfInterest(RegionOfInterestItem* roi)
 {
-    addItem(new RegionOfInterestView(roi));
+    addItem(new RegionOfInterestView(roi, scene_adapter.get()));
 }
 
 //! Adjust size of scene and color map proxy.

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -10,6 +10,8 @@
 #include "graphicsscene.h"
 #include "colormapproxywidget.h"
 #include "regionofinterestview.h"
+#include <mvvm/plotting/sceneadapterinterface.h>
+#include <mvvm/plotting/colormapcanvas.h>
 #include <QDebug>
 
 namespace
@@ -24,9 +26,12 @@ GraphicsScene::GraphicsScene(QObject* parent) : QGraphicsScene(parent)
     setSceneRect(default_scene_rect);
 }
 
+GraphicsScene::~GraphicsScene() = default;
+
 void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
 {
     clear();
+    scene_adapter = colormap->createSceneAdapter();
     colormap_proxy = new ColorMapProxyWidget(colormap);
     addItem(colormap_proxy);
 }

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -9,6 +9,7 @@
 
 #include "graphicsscene.h"
 #include "colormapproxywidget.h"
+#include "regionofinterestview.h"
 #include <QDebug>
 
 namespace
@@ -32,7 +33,7 @@ void GraphicsScene::setColorMap(ModelView::ColorMapCanvas* colormap)
 
 void GraphicsScene::setRegionOfInterest(RegionOfInterestItem* roi)
 {
-
+    addItem(new RegionOfInterestView(roi));
 }
 
 //! Adjust size of scene and color map proxy.

--- a/examples/graphicsproxy/core/graphicsscene.cpp
+++ b/examples/graphicsproxy/core/graphicsscene.cpp
@@ -1,0 +1,12 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "graphicsscene.h"
+
+GraphicsScene::GraphicsScene(QObject* parent) : QGraphicsScene(parent) {}

--- a/examples/graphicsproxy/core/graphicsscene.h
+++ b/examples/graphicsproxy/core/graphicsscene.h
@@ -18,6 +18,7 @@ class ColorMapCanvas;
 }
 
 class ColorMapProxyWidget;
+class RegionOfInterestItem;
 
 //! Custom graphics scene to show QCustomPlot with additional elements on top.
 
@@ -28,6 +29,7 @@ public:
     GraphicsScene(QObject* parent);
 
     void setColorMap(ModelView::ColorMapCanvas* colormap);
+    void setRegionOfInterest(RegionOfInterestItem* roi);
 
     void update_size(const QSize& newSize);
 

--- a/examples/graphicsproxy/core/graphicsscene.h
+++ b/examples/graphicsproxy/core/graphicsscene.h
@@ -11,6 +11,7 @@
 #define GRAPHICSPROXY_GRAPHICSSCENE_H
 
 #include <QGraphicsScene>
+#include <memory>
 
 namespace ModelView
 {

--- a/examples/graphicsproxy/core/graphicsscene.h
+++ b/examples/graphicsproxy/core/graphicsscene.h
@@ -30,12 +30,14 @@ public:
     GraphicsScene(QObject* parent);
     ~GraphicsScene() override;
 
-    void setColorMap(ModelView::ColorMapCanvas* colormap);
-    void setRegionOfInterest(RegionOfInterestItem* roi);
+    void setContext(ModelView::ColorMapCanvas* colormap, RegionOfInterestItem* roi);
 
     void update_size(const QSize& newSize);
 
 private:
+    void create_colormap_proxy(ModelView::ColorMapCanvas* colormap);
+    void create_roi_view(RegionOfInterestItem* roi_item);
+
     ColorMapProxyWidget* colormap_proxy{nullptr};
     std::unique_ptr<ModelView::SceneAdapterInterface> scene_adapter;
 };

--- a/examples/graphicsproxy/core/graphicsscene.h
+++ b/examples/graphicsproxy/core/graphicsscene.h
@@ -15,6 +15,7 @@
 namespace ModelView
 {
 class ColorMapCanvas;
+class SceneAdapterInterface;
 }
 
 class ColorMapProxyWidget;
@@ -27,6 +28,7 @@ class GraphicsScene : public QGraphicsScene
     Q_OBJECT
 public:
     GraphicsScene(QObject* parent);
+    ~GraphicsScene() override;
 
     void setColorMap(ModelView::ColorMapCanvas* colormap);
     void setRegionOfInterest(RegionOfInterestItem* roi);
@@ -35,6 +37,7 @@ public:
 
 private:
     ColorMapProxyWidget* colormap_proxy{nullptr};
+    std::unique_ptr<ModelView::SceneAdapterInterface> scene_adapter;
 };
 
 #endif //  GRAPHICSPROXY_GRAPHICSSCENE_H

--- a/examples/graphicsproxy/core/graphicsscene.h
+++ b/examples/graphicsproxy/core/graphicsscene.h
@@ -1,0 +1,24 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_GRAPHICSSCENE_H
+#define GRAPHICSPROXY_GRAPHICSSCENE_H
+
+#include <QGraphicsScene>
+
+//! Custom graphics scene to show QCustomPlot with additional elements on top.
+
+class GraphicsScene : public QGraphicsScene
+{
+    Q_OBJECT
+public:
+    GraphicsScene(QObject* parent);
+};
+
+#endif //  GRAPHICSPROXY_GRAPHICSSCENE_H

--- a/examples/graphicsproxy/core/graphicsscene.h
+++ b/examples/graphicsproxy/core/graphicsscene.h
@@ -12,9 +12,12 @@
 
 #include <QGraphicsScene>
 
-namespace ModelView  {
+namespace ModelView
+{
 class ColorMapCanvas;
 }
+
+class ColorMapProxyWidget;
 
 //! Custom graphics scene to show QCustomPlot with additional elements on top.
 
@@ -25,6 +28,11 @@ public:
     GraphicsScene(QObject* parent);
 
     void setColorMap(ModelView::ColorMapCanvas* colormap);
+
+    void update_size(const QSize& newSize);
+
+private:
+    ColorMapProxyWidget* colormap_proxy{nullptr};
 };
 
 #endif //  GRAPHICSPROXY_GRAPHICSSCENE_H

--- a/examples/graphicsproxy/core/graphicsview.cpp
+++ b/examples/graphicsproxy/core/graphicsview.cpp
@@ -9,5 +9,18 @@
 
 #include "graphicsview.h"
 #include "graphicsscene.h"
+#include <QResizeEvent>
 
-GraphicsView::GraphicsView(GraphicsScene* scene, QWidget* parent) : QGraphicsView(scene, parent) {}
+GraphicsView::GraphicsView(GraphicsScene* scene, QWidget* parent) : QGraphicsView(scene, parent),
+    scene(scene)
+{
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+}
+
+//! Notifies scene about size change.
+
+void GraphicsView::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    scene->update_size(event->size());
+}

--- a/examples/graphicsproxy/core/graphicsview.cpp
+++ b/examples/graphicsproxy/core/graphicsview.cpp
@@ -1,0 +1,13 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "graphicsview.h"
+#include "graphicsscene.h"
+
+GraphicsView::GraphicsView(GraphicsScene* scene, QWidget* parent) : QGraphicsView(scene, parent) {}

--- a/examples/graphicsproxy/core/graphicsview.h
+++ b/examples/graphicsproxy/core/graphicsview.h
@@ -1,0 +1,26 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_GRAPHICSVIEW_H
+#define GRAPHICSPROXY_GRAPHICSVIEW_H
+
+#include <QGraphicsView>
+
+class GraphicsScene;
+
+//! Custom graphics view to show QCustomPlot with additional elements on top.
+
+class GraphicsView : public QGraphicsView
+{
+    Q_OBJECT
+public:
+    GraphicsView(GraphicsScene* scene, QWidget* parent);
+};
+
+#endif //  GRAPHICSPROXY_GRAPHICSVIEW_H

--- a/examples/graphicsproxy/core/graphicsview.h
+++ b/examples/graphicsproxy/core/graphicsview.h
@@ -21,6 +21,12 @@ class GraphicsView : public QGraphicsView
     Q_OBJECT
 public:
     GraphicsView(GraphicsScene* scene, QWidget* parent);
+
+protected:
+    void resizeEvent(QResizeEvent *event);
+
+private:
+    GraphicsScene* scene{nullptr};
 };
 
 #endif //  GRAPHICSPROXY_GRAPHICSVIEW_H

--- a/examples/graphicsproxy/core/mainwindow.cpp
+++ b/examples/graphicsproxy/core/mainwindow.cpp
@@ -1,0 +1,61 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "mainwindow.h"
+#include "scenemodel.h"
+#include "scenewidget.h"
+#include <QCoreApplication>
+#include <QSettings>
+#include <QTabWidget>
+
+namespace
+{
+const QString main_window_group = "MainWindow";
+const QString size_key = "size";
+const QString pos_key = "pos";
+} // namespace
+
+MainWindow::MainWindow() : m_model(std::make_unique<SceneModel>())
+{
+    setCentralWidget(new SceneWidget(m_model.get()));
+
+    init_application();
+}
+
+MainWindow::~MainWindow() = default;
+
+void MainWindow::closeEvent(QCloseEvent* event)
+{
+    write_settings();
+    QMainWindow::closeEvent(event);
+}
+
+void MainWindow::init_application()
+{
+    QCoreApplication::setApplicationName("graphicsproxy");
+    QCoreApplication::setApplicationVersion("0.1");
+    QCoreApplication::setOrganizationName("qt-mvvm");
+
+    QSettings settings;
+    if (settings.childGroups().contains(main_window_group)) {
+        settings.beginGroup(main_window_group);
+        resize(settings.value(size_key, QSize(400, 400)).toSize());
+        move(settings.value(pos_key, QPoint(200, 200)).toPoint());
+        settings.endGroup();
+    }
+}
+
+void MainWindow::write_settings()
+{
+    QSettings settings;
+    settings.beginGroup(main_window_group);
+    settings.setValue(size_key, size());
+    settings.setValue(pos_key, pos());
+    settings.endGroup();
+}

--- a/examples/graphicsproxy/core/mainwindow.h
+++ b/examples/graphicsproxy/core/mainwindow.h
@@ -1,0 +1,37 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_MAINWINDOW_H
+#define GRAPHICSPROXY_MAINWINDOW_H
+
+#include <QMainWindow>
+#include <memory>
+
+class SceneModel;
+class QTabWidget;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    MainWindow();
+    ~MainWindow();
+
+protected:
+    void closeEvent(QCloseEvent* event);
+
+private:
+    void init_application();
+    void write_settings();
+    void init_model();
+
+    std::unique_ptr<SceneModel> m_model;
+};
+
+#endif //  GRAPHICSPROXY_MAINWINDOW_H

--- a/examples/graphicsproxy/core/regionofinterestview.cpp
+++ b/examples/graphicsproxy/core/regionofinterestview.cpp
@@ -1,0 +1,21 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "regionofinterestview.h"
+
+RegionOfInterestView::RegionOfInterestView(RegionOfInterestItem* item)
+    : item(item)
+{
+
+}
+
+QRectF RegionOfInterestView::boundingRect() const
+{
+    return bounding_rect;
+}

--- a/examples/graphicsproxy/core/regionofinterestview.cpp
+++ b/examples/graphicsproxy/core/regionofinterestview.cpp
@@ -10,7 +10,6 @@
 #include "regionofinterestview.h"
 #include "sceneitems.h"
 #include <QPainter>
-#include <QDebug>
 #include <mvvm/plotting/sceneadapterinterface.h>
 
 namespace
@@ -36,6 +35,13 @@ RegionOfInterestView::RegionOfInterestView(RegionOfInterestItem* item,
 QRectF RegionOfInterestView::boundingRect() const
 {
     return rect.marginsAdded(QMarginsF(bbox_margins, bbox_margins, bbox_margins, bbox_margins));
+}
+
+void RegionOfInterestView::advance(int phase)
+{
+    if (!phase)
+        return;
+    update_geometry();
 }
 
 void RegionOfInterestView::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)

--- a/examples/graphicsproxy/core/regionofinterestview.cpp
+++ b/examples/graphicsproxy/core/regionofinterestview.cpp
@@ -10,17 +10,21 @@
 #include "regionofinterestview.h"
 #include "sceneitems.h"
 #include <QPainter>
+#include <QDebug>
+#include <mvvm/plotting/sceneadapterinterface.h>
 
 namespace
 {
 const double bbox_margins = 5; // additional margins around rectangle to form bounding box
+} // namespace
 
-double toSceneX(double value) { return value;}
-double toSceneY(double value) { return value;}
-}
-
-RegionOfInterestView::RegionOfInterestView(RegionOfInterestItem* item) : item(item)
+RegionOfInterestView::RegionOfInterestView(RegionOfInterestItem* item,
+                                           const ModelView::SceneAdapterInterface* scene_adapter)
+    : item(item), scene_adapter(scene_adapter)
 {
+    if (!scene_adapter)
+        throw std::runtime_error("Error in RegionOfInterestView: scene adapter is not initialized");
+
     setFlag(QGraphicsItem::ItemIsSelectable);
     setFlag(QGraphicsItem::ItemIsMovable);
     setFlag(QGraphicsItem::ItemSendsGeometryChanges);
@@ -49,12 +53,9 @@ void RegionOfInterestView::paint(QPainter* painter, const QStyleOptionGraphicsIt
 void RegionOfInterestView::update_geometry()
 {
     prepareGeometryChange();
-//    rect = QRectF(0.0, 0.0, width(), height());
-//    setX(toSceneX(par(RegionOfInterestItem::P_XLOW)));
-//    setY(toSceneY(par(RegionOfInterestItem::P_YUP)));
-    rect = QRectF(0.0, 0.0, 100.0, 100.0);
-    setX(50.0);
-    setY(50.0);
+    rect = QRectF(0.0, 0.0, width(), height());
+    setX(scene_adapter->toSceneX(par(RegionOfInterestItem::P_XLOW)));
+    setY(scene_adapter->toSceneY(par(RegionOfInterestItem::P_YUP)));
 }
 
 qreal RegionOfInterestView::width() const
@@ -71,28 +72,28 @@ qreal RegionOfInterestView::height() const
 
 qreal RegionOfInterestView::left() const
 {
-    return toSceneX(par(RegionOfInterestItem::P_XLOW));
+    return scene_adapter->toSceneX(par(RegionOfInterestItem::P_XLOW));
 }
 
 //! returns the x-coordinate of the rectangle's right edge
 
 qreal RegionOfInterestView::right() const
 {
-    return toSceneX(par(RegionOfInterestItem::P_XUP));
+    return scene_adapter->toSceneX(par(RegionOfInterestItem::P_XUP));
 }
 
 //! Returns the y-coordinate of the rectangle's top edge.
 
 qreal RegionOfInterestView::top() const
 {
-    return toSceneY(par(RegionOfInterestItem::P_YUP));
+    return scene_adapter->toSceneY(par(RegionOfInterestItem::P_YUP));
 }
 
 //! Returns the y-coordinate of the rectangle's bottom edge.
 
 qreal RegionOfInterestView::bottom() const
 {
-    return toSceneY(par(RegionOfInterestItem::P_YLOW));
+    return scene_adapter->toSceneY(par(RegionOfInterestItem::P_YLOW));
 }
 
 double RegionOfInterestView::par(const std::string& name) const

--- a/examples/graphicsproxy/core/regionofinterestview.cpp
+++ b/examples/graphicsproxy/core/regionofinterestview.cpp
@@ -74,33 +74,35 @@ qreal RegionOfInterestView::height() const
     return bottom() - top();
 }
 
-//! returns the x-coordinate of the rectangle's left edge
+//! Returns the x-coordinate of the rectangle's left edge in the coordinate system of the scene.
 
 qreal RegionOfInterestView::left() const
 {
     return scene_adapter->toSceneX(par(RegionOfInterestItem::P_XLOW));
 }
 
-//! returns the x-coordinate of the rectangle's right edge
+//! Returns the x-coordinate of the rectangle's right edge in the coordinate system of the scene.
 
 qreal RegionOfInterestView::right() const
 {
     return scene_adapter->toSceneX(par(RegionOfInterestItem::P_XUP));
 }
 
-//! Returns the y-coordinate of the rectangle's top edge.
+//! Returns the y-coordinate of the rectangle's top edge in the coordinate system of the scene.
 
 qreal RegionOfInterestView::top() const
 {
     return scene_adapter->toSceneY(par(RegionOfInterestItem::P_YUP));
 }
 
-//! Returns the y-coordinate of the rectangle's bottom edge.
+//! Returns the y-coordinate of the rectangle's bottom edge in the coordinate system of the scene.
 
 qreal RegionOfInterestView::bottom() const
 {
     return scene_adapter->toSceneY(par(RegionOfInterestItem::P_YLOW));
 }
+
+//! Returns the value of ComboItem's property with given name.
 
 double RegionOfInterestView::par(const std::string& name) const
 {

--- a/examples/graphicsproxy/core/regionofinterestview.cpp
+++ b/examples/graphicsproxy/core/regionofinterestview.cpp
@@ -8,14 +8,94 @@
 // ************************************************************************** //
 
 #include "regionofinterestview.h"
+#include "sceneitems.h"
+#include <QPainter>
 
-RegionOfInterestView::RegionOfInterestView(RegionOfInterestItem* item)
-    : item(item)
+namespace
 {
+const double bbox_margins = 5; // additional margins around rectangle to form bounding box
 
+double toSceneX(double value) { return value;}
+double toSceneY(double value) { return value;}
+}
+
+RegionOfInterestView::RegionOfInterestView(RegionOfInterestItem* item) : item(item)
+{
+    setFlag(QGraphicsItem::ItemIsSelectable);
+    setFlag(QGraphicsItem::ItemIsMovable);
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges);
+    setAcceptHoverEvents(true);
+
+    update_geometry();
 }
 
 QRectF RegionOfInterestView::boundingRect() const
 {
-    return bounding_rect;
+    return rect.marginsAdded(QMarginsF(bbox_margins, bbox_margins, bbox_margins, bbox_margins));
+}
+
+void RegionOfInterestView::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)
+{
+    // drawing rectangular frame made of two colors to look good on both black and white
+    painter->setPen(QPen(QColor(34, 67, 255)));
+    painter->drawRect(rect);
+    QRectF secondRect = rect.marginsAdded(QMarginsF(1, 1, 1, 1));
+    painter->setPen(QPen(QColor(255, 255, 245)));
+    painter->drawRect(secondRect);
+}
+
+//! Updates geometry from item.
+
+void RegionOfInterestView::update_geometry()
+{
+    prepareGeometryChange();
+//    rect = QRectF(0.0, 0.0, width(), height());
+//    setX(toSceneX(par(RegionOfInterestItem::P_XLOW)));
+//    setY(toSceneY(par(RegionOfInterestItem::P_YUP)));
+    rect = QRectF(0.0, 0.0, 100.0, 100.0);
+    setX(50.0);
+    setY(50.0);
+}
+
+qreal RegionOfInterestView::width() const
+{
+    return right() - left();
+}
+
+qreal RegionOfInterestView::height() const
+{
+    return bottom() - top();
+}
+
+//! returns the x-coordinate of the rectangle's left edge
+
+qreal RegionOfInterestView::left() const
+{
+    return toSceneX(par(RegionOfInterestItem::P_XLOW));
+}
+
+//! returns the x-coordinate of the rectangle's right edge
+
+qreal RegionOfInterestView::right() const
+{
+    return toSceneX(par(RegionOfInterestItem::P_XUP));
+}
+
+//! Returns the y-coordinate of the rectangle's top edge.
+
+qreal RegionOfInterestView::top() const
+{
+    return toSceneY(par(RegionOfInterestItem::P_YUP));
+}
+
+//! Returns the y-coordinate of the rectangle's bottom edge.
+
+qreal RegionOfInterestView::bottom() const
+{
+    return toSceneY(par(RegionOfInterestItem::P_YLOW));
+}
+
+double RegionOfInterestView::par(const std::string& name) const
+{
+    return item->property(name).value<double>();
 }

--- a/examples/graphicsproxy/core/regionofinterestview.h
+++ b/examples/graphicsproxy/core/regionofinterestview.h
@@ -1,0 +1,33 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_REGIONOFINTERESTVIEW_H
+#define GRAPHICSPROXY_REGIONOFINTERESTVIEW_H
+
+#include <QGraphicsObject>
+
+class RegionOfInterestItem;
+
+//! Graphics object to represent RegionOfInterestItem on graphics scene.
+
+class RegionOfInterestView : public QGraphicsObject
+{
+    Q_OBJECT
+
+public:
+    RegionOfInterestView(RegionOfInterestItem* item);
+
+    QRectF boundingRect() const override;
+
+private:
+    RegionOfInterestItem* item{nullptr};
+    QRectF bounding_rect;
+};
+
+#endif // GRAPHICSPROXY_REGIONOFINTERESTVIEW_H

--- a/examples/graphicsproxy/core/regionofinterestview.h
+++ b/examples/graphicsproxy/core/regionofinterestview.h
@@ -15,6 +15,7 @@
 class RegionOfInterestItem;
 
 //! Graphics object to represent RegionOfInterestItem on graphics scene.
+//! Follows standard QGraphicsScene notations: (x,y) origin is top left corner.
 
 class RegionOfInterestView : public QGraphicsObject
 {
@@ -25,9 +26,22 @@ public:
 
     QRectF boundingRect() const override;
 
+protected:
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*);
+
 private:
+    void update_geometry();
+    qreal width() const;
+    qreal height() const;
+    qreal left() const;
+    qreal right() const;
+    qreal top() const;
+    qreal bottom() const;
+
+    double par(const std::string& name) const;
+
     RegionOfInterestItem* item{nullptr};
-    QRectF bounding_rect;
+    QRectF rect;
 };
 
 #endif // GRAPHICSPROXY_REGIONOFINTERESTVIEW_H

--- a/examples/graphicsproxy/core/regionofinterestview.h
+++ b/examples/graphicsproxy/core/regionofinterestview.h
@@ -32,6 +32,8 @@ public:
 
     QRectF boundingRect() const override;
 
+    void advance(int phase) override;
+
 protected:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*);
 

--- a/examples/graphicsproxy/core/regionofinterestview.h
+++ b/examples/graphicsproxy/core/regionofinterestview.h
@@ -12,6 +12,11 @@
 
 #include <QGraphicsObject>
 
+namespace ModelView
+{
+class SceneAdapterInterface;
+}
+
 class RegionOfInterestItem;
 
 //! Graphics object to represent RegionOfInterestItem on graphics scene.
@@ -22,7 +27,8 @@ class RegionOfInterestView : public QGraphicsObject
     Q_OBJECT
 
 public:
-    RegionOfInterestView(RegionOfInterestItem* item);
+    RegionOfInterestView(RegionOfInterestItem* item,
+                         const ModelView::SceneAdapterInterface* scene_adapter);
 
     QRectF boundingRect() const override;
 
@@ -42,6 +48,7 @@ private:
 
     RegionOfInterestItem* item{nullptr};
     QRectF rect;
+    const ModelView::SceneAdapterInterface* scene_adapter{nullptr};
 };
 
 #endif // GRAPHICSPROXY_REGIONOFINTERESTVIEW_H

--- a/examples/graphicsproxy/core/sceneitems.cpp
+++ b/examples/graphicsproxy/core/sceneitems.cpp
@@ -1,0 +1,23 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "sceneitems.h"
+
+namespace
+{
+const std::string RegionOfInterestItemType = "RegionOfInterest";
+}
+
+RegionOfInterestItem::RegionOfInterestItem() : ModelView::CompoundItem(RegionOfInterestItemType)
+{
+    addProperty(P_XLOW, 0.0)->setDisplayName("Xlow");
+    addProperty(P_YLOW, 0.0)->setDisplayName("Ylow");
+    addProperty(P_XUP, 0.0)->setDisplayName("Xup");
+    addProperty(P_YUP, 0.0)->setDisplayName("Yup");
+}

--- a/examples/graphicsproxy/core/sceneitems.h
+++ b/examples/graphicsproxy/core/sceneitems.h
@@ -1,0 +1,33 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_SCENEITEMS_H
+#define GRAPHICSPROXY_SCENEITEMS_H
+
+/*!
+@file sceneitems.h
+@brief Collection of items for graphics scene.
+*/
+
+#include <mvvm/model/compounditem.h>
+
+//! Item to represent region of interest on top of heat map.
+
+class RegionOfInterestItem : public ModelView::CompoundItem
+{
+public:
+    static inline const std::string P_XLOW = "P_XLOW";
+    static inline const std::string P_YLOW = "P_YLOW";
+    static inline const std::string P_XUP = "P_XUP";
+    static inline const std::string P_YUP = "P_YUP";
+
+    RegionOfInterestItem();
+};
+
+#endif // GRAPHICSPROXY_SCENEMODEL_H

--- a/examples/graphicsproxy/core/scenemodel.cpp
+++ b/examples/graphicsproxy/core/scenemodel.cpp
@@ -1,0 +1,80 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "scenemodel.h"
+#include <cmath>
+#include <mvvm/model/modelutils.h>
+#include <mvvm/standarditems/axisitems.h>
+#include <mvvm/standarditems/colormapitem.h>
+#include <mvvm/standarditems/colormapviewportitem.h>
+#include <mvvm/standarditems/containeritem.h>
+#include <mvvm/standarditems/data2ditem.h>
+
+using namespace ModelView;
+
+namespace
+{
+const int nbinsx = 200;
+const int nbinsy = 100;
+
+// fills with data point
+void fill_data(Data2DItem* data_item, double scale = 1.0)
+{
+    const auto xAxis = data_item->xAxis();
+    const auto yAxis = data_item->yAxis();
+    std::vector<double> values;
+    for (auto y : yAxis->binCenters()) {
+        for (auto x : xAxis->binCenters()) {
+            double r = scale * (3.0 * std::sqrt(x * x + y * y) + 1e-2);
+            double z = 2 * x * (std::cos(r + 2) / r - std::sin(r + 2) / r);
+            values.push_back(z);
+        }
+    }
+
+    data_item->setContent(values);
+}
+} // namespace
+
+SceneModel::SceneModel() : SessionModel("ColorMapModel")
+{
+    init_model();
+}
+
+//! Updates data.
+
+void SceneModel::update_data(double scale)
+{
+    auto data_item = data_container()->item<Data2DItem>(ContainerItem::T_ITEMS);
+    fill_data(data_item, scale);
+}
+
+void SceneModel::add_colormap()
+{
+    auto data_item = insertItem<Data2DItem>(data_container());
+    data_item->setAxes(FixedBinAxisItem::create(nbinsx, -5.0, 5.0),
+                       FixedBinAxisItem::create(nbinsy, 0.0, 5.0));
+    fill_data(data_item);
+
+    auto viewport_item = insertItem<ColorMapViewportItem>();
+    auto colormap_item = insertItem<ColorMapItem>(viewport_item);
+    colormap_item->setDataItem(data_item);
+}
+
+ContainerItem* SceneModel::data_container()
+{
+    return Utils::TopItem<ContainerItem>(this);
+}
+
+void SceneModel::init_model()
+{
+    auto container = insertItem<ContainerItem>();
+    container->setDisplayName("Data container");
+
+    add_colormap();
+}

--- a/examples/graphicsproxy/core/scenemodel.h
+++ b/examples/graphicsproxy/core/scenemodel.h
@@ -1,0 +1,35 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_SCENEMODEL_H
+#define GRAPHICSPROXY_SCENEMODEL_H
+
+#include <mvvm/model/sessionmodel.h>
+
+namespace ModelView
+{
+class ContainerItem;
+}
+
+//! Main application model with data for graphics scene.
+
+class SceneModel : public ModelView::SessionModel
+{
+public:
+    SceneModel();
+
+    void update_data(double scale);
+
+private:
+    ModelView::ContainerItem* data_container();
+    void init_model();
+    void add_colormap();
+};
+
+#endif // GRAPHICSPROXY_SCENEMODEL_H

--- a/examples/graphicsproxy/core/scenemodel.h
+++ b/examples/graphicsproxy/core/scenemodel.h
@@ -27,9 +27,9 @@ public:
     void update_data(double scale);
 
 private:
-    ModelView::ContainerItem* data_container();
-    void init_model();
-    void add_colormap();
+    void create_roi();
+    void create_data();
+    void create_colormap();
 };
 
 #endif // GRAPHICSPROXY_SCENEMODEL_H

--- a/examples/graphicsproxy/core/scenepropertywidget.cpp
+++ b/examples/graphicsproxy/core/scenepropertywidget.cpp
@@ -1,0 +1,55 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "scenepropertywidget.h"
+#include "scenemodel.h"
+#include <QBoxLayout>
+#include <QPushButton>
+#include <QSlider>
+#include <mvvm/viewmodel/abstractviewmodel.h>
+#include <mvvm/viewmodel/standardviewmodels.h>
+#include <mvvm/widgets/itemstreeview.h>
+
+using namespace ModelView;
+
+ScenePropertyWidget::ScenePropertyWidget(SceneModel* model, QWidget* parent)
+    : QWidget(parent), m_slider(new QSlider), m_treeView(new ItemsTreeView), m_model(model)
+{
+    auto mainLayout = new QVBoxLayout;
+
+    mainLayout->addWidget(m_slider);
+    mainLayout->addWidget(m_treeView);
+
+    setLayout(mainLayout);
+    setModel(model);
+
+    setup_slider();
+}
+
+void ScenePropertyWidget::setModel(SceneModel* model)
+{
+    if (!model)
+        return;
+
+    m_model = model;
+
+    m_treeView->setViewModel(Utils::CreateDefaultViewModel(model));
+}
+
+//! Slider to regenerate the data in the model.
+
+void ScenePropertyWidget::setup_slider()
+{
+    m_slider->setOrientation(Qt::Horizontal);
+    m_slider->setRange(0, 100);
+    m_slider->setValue(50.0);
+
+    auto on_value_changed = [this](int value) { m_model->update_data(value / 10.0); };
+    connect(m_slider, &QSlider::valueChanged, on_value_changed);
+}

--- a/examples/graphicsproxy/core/scenepropertywidget.h
+++ b/examples/graphicsproxy/core/scenepropertywidget.h
@@ -1,0 +1,48 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_SCENEPROPERTYWIDGET_H
+#define GRAPHICSPROXY_SCENEPROPERTYWIDGET_H
+
+#include <QWidget>
+#include <memory>
+
+class QBoxLayout;
+class SceneModel;
+class QBoxLayout;
+class QSlider;
+
+namespace ModelView
+{
+class ItemsTreeView;
+} // namespace ModelView
+
+/*!
+@class ColorMapPropertyWidget
+@brief Shows model content in standard tree view.
+*/
+
+class ScenePropertyWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ScenePropertyWidget(SceneModel* model = nullptr, QWidget* parent = nullptr);
+
+    void setModel(SceneModel* model);
+
+private:
+    void setup_slider();
+
+    QBoxLayout* create_button_layout();
+    QSlider* m_slider;
+    ModelView::ItemsTreeView* m_treeView;
+    SceneModel* m_model;
+};
+
+#endif // GRAPHICSPROXY_SCENEPROPERTYWIDGET_H

--- a/examples/graphicsproxy/core/scenewidget.cpp
+++ b/examples/graphicsproxy/core/scenewidget.cpp
@@ -10,6 +10,8 @@
 #include "scenewidget.h"
 #include "scenemodel.h"
 #include "scenepropertywidget.h"
+#include "graphicsscene.h"
+#include "graphicsview.h"
 #include <QAction>
 #include <QBoxLayout>
 #include <QToolBar>
@@ -23,6 +25,8 @@ using namespace ModelView;
 SceneWidget::SceneWidget(SceneModel* model, QWidget* parent)
     : QWidget(parent), m_toolBar(new QToolBar), m_resetViewportAction(nullptr),
       m_propertyWidget(new ScenePropertyWidget), m_colorMapCanvas(new ColorMapCanvas),
+      graphics_scene(new GraphicsScene(this)),
+      graphics_view(new GraphicsView(graphics_scene, this)),
       m_model(model)
 {
     auto mainLayout = new QVBoxLayout;
@@ -61,7 +65,7 @@ void SceneWidget::init_actions()
 QBoxLayout* SceneWidget::create_left_layout()
 {
     auto result = new QVBoxLayout;
-    result->addWidget(m_colorMapCanvas);
+    result->addWidget(graphics_view);
     return result;
 }
 

--- a/examples/graphicsproxy/core/scenewidget.cpp
+++ b/examples/graphicsproxy/core/scenewidget.cpp
@@ -47,8 +47,7 @@ SceneWidget::SceneWidget(SceneModel* model, QWidget* parent)
     m_colorMapCanvas->setItem(Utils::TopItem<ColorMapViewportItem>(model));
     init_actions();
 
-    graphics_scene->setColorMap(m_colorMapCanvas);
-    graphics_scene->setRegionOfInterest(Utils::TopItem<RegionOfInterestItem>(model));
+    graphics_scene->setContext(m_colorMapCanvas, Utils::TopItem<RegionOfInterestItem>(model));
 }
 
 void SceneWidget::init_actions()

--- a/examples/graphicsproxy/core/scenewidget.cpp
+++ b/examples/graphicsproxy/core/scenewidget.cpp
@@ -9,6 +9,7 @@
 
 #include "scenewidget.h"
 #include "scenemodel.h"
+#include "sceneitems.h"
 #include "scenepropertywidget.h"
 #include "graphicsscene.h"
 #include "graphicsview.h"
@@ -47,6 +48,7 @@ SceneWidget::SceneWidget(SceneModel* model, QWidget* parent)
     init_actions();
 
     graphics_scene->setColorMap(m_colorMapCanvas);
+    graphics_scene->setRegionOfInterest(Utils::TopItem<RegionOfInterestItem>(model));
 }
 
 void SceneWidget::init_actions()

--- a/examples/graphicsproxy/core/scenewidget.cpp
+++ b/examples/graphicsproxy/core/scenewidget.cpp
@@ -1,0 +1,73 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "scenewidget.h"
+#include "scenemodel.h"
+#include "scenepropertywidget.h"
+#include <QAction>
+#include <QBoxLayout>
+#include <QToolBar>
+#include <QToolButton>
+#include <mvvm/model/modelutils.h>
+#include <mvvm/plotting/colormapcanvas.h>
+#include <mvvm/standarditems/colormapviewportitem.h>
+
+using namespace ModelView;
+
+SceneWidget::SceneWidget(SceneModel* model, QWidget* parent)
+    : QWidget(parent), m_toolBar(new QToolBar), m_resetViewportAction(nullptr),
+      m_propertyWidget(new ScenePropertyWidget), m_colorMapCanvas(new ColorMapCanvas),
+      m_model(model)
+{
+    auto mainLayout = new QVBoxLayout;
+    mainLayout->setSpacing(10);
+
+    auto centralLayout = new QHBoxLayout;
+
+    centralLayout->addLayout(create_left_layout(), 3);
+    centralLayout->addLayout(create_right_layout(), 1);
+
+    mainLayout->addWidget(m_toolBar);
+    mainLayout->addLayout(centralLayout);
+
+    setLayout(mainLayout);
+
+    m_propertyWidget->setModel(model);
+    m_colorMapCanvas->setItem(Utils::TopItem<ColorMapViewportItem>(model));
+    init_actions();
+}
+
+void SceneWidget::init_actions()
+{
+    const int toolbar_icon_size = 24;
+    m_toolBar->setIconSize(QSize(toolbar_icon_size, toolbar_icon_size));
+
+    m_resetViewportAction = new QAction("Reset view", this);
+    auto on_reset = [this]() {
+        auto viewport = Utils::TopItem<ColorMapViewportItem>(m_model);
+        viewport->update_viewport();
+    };
+    connect(m_resetViewportAction, &QAction::triggered, on_reset);
+
+    m_toolBar->addAction(m_resetViewportAction);
+}
+
+QBoxLayout* SceneWidget::create_left_layout()
+{
+    auto result = new QVBoxLayout;
+    result->addWidget(m_colorMapCanvas);
+    return result;
+}
+
+QBoxLayout* SceneWidget::create_right_layout()
+{
+    auto result = new QVBoxLayout;
+    result->addWidget(m_propertyWidget);
+    return result;
+}

--- a/examples/graphicsproxy/core/scenewidget.cpp
+++ b/examples/graphicsproxy/core/scenewidget.cpp
@@ -45,6 +45,8 @@ SceneWidget::SceneWidget(SceneModel* model, QWidget* parent)
     m_propertyWidget->setModel(model);
     m_colorMapCanvas->setItem(Utils::TopItem<ColorMapViewportItem>(model));
     init_actions();
+
+    graphics_scene->setColorMap(m_colorMapCanvas);
 }
 
 void SceneWidget::init_actions()

--- a/examples/graphicsproxy/core/scenewidget.h
+++ b/examples/graphicsproxy/core/scenewidget.h
@@ -17,6 +17,8 @@ class ScenePropertyWidget;
 class QToolBar;
 class QAction;
 class SceneModel;
+class GraphicsScene;
+class GraphicsView;
 
 namespace ModelView
 {
@@ -42,6 +44,8 @@ private:
 
     ScenePropertyWidget* m_propertyWidget;
     ModelView::ColorMapCanvas* m_colorMapCanvas;
+    GraphicsScene* graphics_scene;
+    GraphicsView* graphics_view;
     SceneModel* m_model;
 };
 

--- a/examples/graphicsproxy/core/scenewidget.h
+++ b/examples/graphicsproxy/core/scenewidget.h
@@ -1,0 +1,48 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_SCENEWIDGET_H
+#define GRAPHICSPROXY_SCENEWIDGET_H
+
+#include <QWidget>
+
+class QBoxLayout;
+class ScenePropertyWidget;
+class QToolBar;
+class QAction;
+class SceneModel;
+
+namespace ModelView
+{
+class ColorMapCanvas;
+} // namespace ModelView
+
+//! Shows canvas with plots on the left and property editor on the right.
+
+class SceneWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit SceneWidget(SceneModel* model = nullptr, QWidget* parent = nullptr);
+
+private:
+    void init_actions();
+
+    QBoxLayout* create_left_layout();
+    QBoxLayout* create_right_layout();
+
+    QToolBar* m_toolBar;
+    QAction* m_resetViewportAction;
+
+    ScenePropertyWidget* m_propertyWidget;
+    ModelView::ColorMapCanvas* m_colorMapCanvas;
+    SceneModel* m_model;
+};
+
+#endif // GRAPHICSPROXY_SCENEWIDGET_H

--- a/examples/graphicsproxy/main/CMakeLists.txt
+++ b/examples/graphicsproxy/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(executable_name graphicsproxy)
+
+add_executable(${executable_name} main.cpp)
+target_link_libraries(${executable_name} PRIVATE graphicsproxycore)

--- a/examples/graphicsproxy/main/main.cpp
+++ b/examples/graphicsproxy/main/main.cpp
@@ -1,0 +1,24 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "mainwindow.h"
+#include <QApplication>
+#include <QLocale>
+
+int main(int argc, char** argv)
+{
+    QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
+
+    QApplication app(argc, argv);
+
+    MainWindow win;
+    win.show();
+
+    return app.exec();
+}

--- a/source/libmvvm_viewmodel/mvvm/plotting/CMakeLists.txt
+++ b/source/libmvvm_viewmodel/mvvm/plotting/CMakeLists.txt
@@ -33,4 +33,5 @@ target_sources(mvvm_viewmodel PRIVATE
     statusstringreporterfactory.h
     viewportaxisplotcontroller.cpp
     viewportaxisplotcontroller.h
+    sceneadapterinterface.h
 )

--- a/source/libmvvm_viewmodel/mvvm/plotting/CMakeLists.txt
+++ b/source/libmvvm_viewmodel/mvvm/plotting/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(mvvm_viewmodel PRIVATE
     colormapviewportplotcontroller.h
     colorscaleplotcontroller.cpp
     colorscaleplotcontroller.h
+    customplotsceneadapter.cpp
+    customplotsceneadapter.h
     customplotutils.cpp
     customplotutils.h
     data1dplotcontroller.cpp
@@ -26,6 +28,7 @@ target_sources(mvvm_viewmodel PRIVATE
     mousemovereporter.cpp
     mousemovereporter.h
     mouseposinfo.h
+    sceneadapterinterface.h
     statusstringformatterinterface.h
     statusstringreporter.cpp
     statusstringreporter.h
@@ -33,5 +36,4 @@ target_sources(mvvm_viewmodel PRIVATE
     statusstringreporterfactory.h
     viewportaxisplotcontroller.cpp
     viewportaxisplotcontroller.h
-    sceneadapterinterface.h
 )

--- a/source/libmvvm_viewmodel/mvvm/plotting/colormapcanvas.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/colormapcanvas.cpp
@@ -12,6 +12,7 @@
 #include <mvvm/plotting/colormapviewportplotcontroller.h>
 #include <mvvm/plotting/statusstringreporter.h>
 #include <mvvm/plotting/statusstringreporterfactory.h>
+#include <mvvm/plotting/customplotsceneadapter.h>
 #include <mvvm/standarditems/colormapviewportitem.h>
 #include <mvvm/widgets/statuslabel.h>
 
@@ -55,4 +56,11 @@ ColorMapCanvas::~ColorMapCanvas() = default;
 void ColorMapCanvas::setItem(ColorMapViewportItem* viewport_item)
 {
     p_impl->viewport_controller->setItem(viewport_item);
+}
+
+//! Creates
+
+std::unique_ptr<SceneAdapterInterface> ColorMapCanvas::createSceneAdapter() const
+{
+    return std::make_unique<CustomPlotSceneAdapter>(p_impl->customPlot());
 }

--- a/source/libmvvm_viewmodel/mvvm/plotting/colormapcanvas.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/colormapcanvas.h
@@ -18,6 +18,7 @@ namespace ModelView
 {
 
 class ColorMapViewportItem;
+class SceneAdapterInterface;
 
 /*!
 @class ColorMapCanvas
@@ -33,6 +34,8 @@ public:
     ~ColorMapCanvas() override;
 
     void setItem(ColorMapViewportItem* viewport_item);
+
+    std::unique_ptr<SceneAdapterInterface> createSceneAdapter() const;
 
 private:
     struct ColorMapCanvasImpl;

--- a/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.cpp
@@ -9,35 +9,60 @@
 
 #include "customplotsceneadapter.h"
 #include "qcustomplot.h"
-
+#include <QObject>
 
 using namespace ModelView;
 
+struct CustomPlotSceneAdapter::CustomPlotSceneAdapterImpl {
+    QCustomPlot* custom_plot{nullptr};
+    CustomPlotSceneAdapterImpl(QCustomPlot* custom_plot) : custom_plot(custom_plot) {}
+
+    double toSceneX(double customplot_x) const
+    {
+        return custom_plot ? custom_plot->xAxis->coordToPixel(customplot_x) : customplot_x;
+    }
+
+    double toSceneY(double customplot_y) const
+    {
+        return custom_plot ? custom_plot->yAxis->coordToPixel(customplot_y) : customplot_y;
+    }
+
+    double fromSceneX(double scene_x) const
+    {
+        return custom_plot ? custom_plot->xAxis->pixelToCoord(scene_x) : scene_x;
+    }
+
+    double fromSceneY(double scene_y) const
+    {
+        return custom_plot ? custom_plot->yAxis->pixelToCoord(scene_y) : scene_y;
+    }
+};
+
 CustomPlotSceneAdapter::CustomPlotSceneAdapter(QCustomPlot* custom_plot)
+    : p_impl(std::make_unique<CustomPlotSceneAdapterImpl>(custom_plot))
 {
-
+    auto on_customplot_destroy = [this]() { p_impl->custom_plot = nullptr; };
+    QObject::connect(custom_plot, &QCustomPlot::destroyed, on_customplot_destroy);
 }
 
-CustomPlotSceneAdapter::~CustomPlotSceneAdapter()
-{
-}
+CustomPlotSceneAdapter::~CustomPlotSceneAdapter() {}
 
 double CustomPlotSceneAdapter::toSceneX(double customplot_x) const
 {
-    return customplot_x;
+    return p_impl->toSceneX(customplot_x);
 }
 
 double CustomPlotSceneAdapter::toSceneY(double customplot_y) const
 {
-    return customplot_y;
+    return p_impl->toSceneY(customplot_y);
 }
 
 double CustomPlotSceneAdapter::fromSceneX(double scene_x) const
 {
-    return scene_x;
+    return p_impl->fromSceneX(scene_x);
 }
 
 double CustomPlotSceneAdapter::fromSceneY(double scene_y) const
 {
-    return scene_y;
+    return p_impl->fromSceneX(scene_y);
 }

--- a/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.cpp
@@ -1,0 +1,43 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "customplotsceneadapter.h"
+#include "qcustomplot.h"
+
+
+using namespace ModelView;
+
+CustomPlotSceneAdapter::CustomPlotSceneAdapter(QCustomPlot* custom_plot)
+{
+
+}
+
+CustomPlotSceneAdapter::~CustomPlotSceneAdapter()
+{
+}
+
+double CustomPlotSceneAdapter::toSceneX(double customplot_x) const
+{
+    return customplot_x;
+}
+
+double CustomPlotSceneAdapter::toSceneY(double customplot_y) const
+{
+    return customplot_y;
+}
+
+double CustomPlotSceneAdapter::fromSceneX(double scene_x) const
+{
+    return scene_x;
+}
+
+double CustomPlotSceneAdapter::fromSceneY(double scene_y) const
+{
+    return scene_y;
+}

--- a/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.cpp
@@ -36,6 +36,19 @@ struct CustomPlotSceneAdapter::CustomPlotSceneAdapterImpl {
     {
         return custom_plot ? custom_plot->yAxis->pixelToCoord(scene_y) : scene_y;
     }
+
+    QRectF viewportRectangle() const
+    {
+        if (!custom_plot)
+            return {};
+
+        auto xrange = custom_plot->xAxis->range();
+        auto yrange = custom_plot->yAxis->range();
+
+        return QRectF(toSceneX(xrange.lower), toSceneY(yrange.upper),
+                      toSceneX(xrange.upper) - toSceneX(xrange.lower),
+                      toSceneY(yrange.lower) - toSceneY(yrange.upper));
+    }
 };
 
 CustomPlotSceneAdapter::CustomPlotSceneAdapter(QCustomPlot* custom_plot)
@@ -65,4 +78,9 @@ double CustomPlotSceneAdapter::fromSceneX(double scene_x) const
 double CustomPlotSceneAdapter::fromSceneY(double scene_y) const
 {
     return p_impl->fromSceneX(scene_y);
+}
+
+QRectF CustomPlotSceneAdapter::viewportRectangle() const
+{
+    return p_impl->viewportRectangle();
 }

--- a/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.h
@@ -11,6 +11,7 @@
 #define MVVM_PLOTTING_CUSTOMPLOTSCENEADAPTER_H
 
 #include <mvvm/plotting/sceneadapterinterface.h>
+#include <memory>
 
 class QCustomPlot;
 
@@ -36,6 +37,10 @@ public:
     double fromSceneX(double scene_x) const override;
 
     double fromSceneY(double scene_y) const override;
+
+private:
+    struct CustomPlotSceneAdapterImpl;
+    std::unique_ptr<CustomPlotSceneAdapterImpl> p_impl;
 };
 
 } // namespace ModelView

--- a/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.h
@@ -38,6 +38,8 @@ public:
 
     double fromSceneY(double scene_y) const override;
 
+    QRectF viewportRectangle() const override;
+
 private:
     struct CustomPlotSceneAdapterImpl;
     std::unique_ptr<CustomPlotSceneAdapterImpl> p_impl;

--- a/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/customplotsceneadapter.h
@@ -1,0 +1,43 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MVVM_PLOTTING_CUSTOMPLOTSCENEADAPTER_H
+#define MVVM_PLOTTING_CUSTOMPLOTSCENEADAPTER_H
+
+#include <mvvm/plotting/sceneadapterinterface.h>
+
+class QCustomPlot;
+
+namespace ModelView
+{
+
+/*!
+@class CustomPlotSceneAdapter
+@brief Converts QGraphicsScene coordinates in the coordinates of local system of QCustomPlot
+and vice versa.
+*/
+
+class CORE_EXPORT CustomPlotSceneAdapter : public SceneAdapterInterface
+{
+public:
+    explicit CustomPlotSceneAdapter(QCustomPlot* custom_plot);
+    ~CustomPlotSceneAdapter() override;
+
+    double toSceneX(double customplot_x) const override;
+
+    double toSceneY(double customplot_y) const override;
+
+    double fromSceneX(double scene_x) const override;
+
+    double fromSceneY(double scene_y) const override;
+};
+
+} // namespace ModelView
+
+#endif // MVVM_PLOTTING_CUSTOMPLOTSCENEADAPTER_H

--- a/source/libmvvm_viewmodel/mvvm/plotting/graphcanvas.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/graphcanvas.cpp
@@ -9,6 +9,7 @@
 
 #include "qcustomplot.h"
 #include <QBoxLayout>
+#include <mvvm/plotting/customplotsceneadapter.h>
 #include <mvvm/plotting/graphcanvas.h>
 #include <mvvm/plotting/graphviewportplotcontroller.h>
 #include <mvvm/plotting/statusstringreporter.h>
@@ -56,6 +57,11 @@ GraphCanvas::GraphCanvas(QWidget* parent)
 void GraphCanvas::setItem(GraphViewportItem* viewport_item)
 {
     p_impl->viewport_controller->setItem(viewport_item);
+}
+
+std::unique_ptr<SceneAdapterInterface> GraphCanvas::createSceneAdapter() const
+{
+    return std::make_unique<CustomPlotSceneAdapter>(p_impl->customPlot());
 }
 
 GraphCanvas::~GraphCanvas() = default;

--- a/source/libmvvm_viewmodel/mvvm/plotting/graphcanvas.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/graphcanvas.h
@@ -18,6 +18,7 @@ namespace ModelView
 {
 
 class GraphViewportItem;
+class SceneAdapterInterface;
 
 /*!
 @class GraphCanvas
@@ -33,6 +34,8 @@ public:
     ~GraphCanvas() override;
 
     void setItem(GraphViewportItem* viewport_item);
+
+    std::unique_ptr<SceneAdapterInterface> createSceneAdapter() const;
 
 private:
     struct GraphCanvasImpl;

--- a/source/libmvvm_viewmodel/mvvm/plotting/sceneadapterinterface.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/sceneadapterinterface.h
@@ -7,8 +7,8 @@
 //
 // ************************************************************************** //
 
-#ifndef GRAPHICSPROXY_SCENEADAPTERINTERFACE_H
-#define GRAPHICSPROXY_SCENEADAPTERINTERFACE_H
+#ifndef MVVM_PLOTTING_SCENEADAPTERINTERFACE_H
+#define MVVM_PLOTTING_SCENEADAPTERINTERFACE_H
 
 #include <mvvm/core/export.h>
 
@@ -25,6 +25,7 @@ coordinates in the coordinates of local system of QCustomPlot and vice versa.
 
 class CORE_EXPORT SceneAdapterInterface
 {
+public:
     virtual ~SceneAdapterInterface() = default;
 
     //! convert local x-coordinate to scene coordinate
@@ -42,4 +43,4 @@ class CORE_EXPORT SceneAdapterInterface
 
 } // namespace ModelView
 
-#endif // GRAPHICSPROXY_SCENEADAPTERINTERFACE_H
+#endif // MVVM_PLOTTING_SCENEADAPTERINTERFACE_H

--- a/source/libmvvm_viewmodel/mvvm/plotting/sceneadapterinterface.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/sceneadapterinterface.h
@@ -12,6 +12,8 @@
 
 #include <mvvm/core/export.h>
 
+class QRectF;
+
 namespace ModelView
 {
 
@@ -39,6 +41,9 @@ public:
 
     //! convert scene y-coordinate to local axis coordinate
     virtual double fromSceneY(double) const = 0;
+
+    //! returns viewport rectangle in scene coordinates
+    virtual QRectF viewportRectangle() const = 0;
 };
 
 } // namespace ModelView

--- a/source/libmvvm_viewmodel/mvvm/plotting/sceneadapterinterface.h
+++ b/source/libmvvm_viewmodel/mvvm/plotting/sceneadapterinterface.h
@@ -1,0 +1,45 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef GRAPHICSPROXY_SCENEADAPTERINTERFACE_H
+#define GRAPHICSPROXY_SCENEADAPTERINTERFACE_H
+
+#include <mvvm/core/export.h>
+
+namespace ModelView
+{
+
+/*!
+@class SceneAdapterInterface
+@brief Interface to convert coordinates of "scene" to coordinates of "widget".
+
+Used in the context of QCustomPlot being embedded into QGraphicsScene. Converts QGraphicsScene
+coordinates in the coordinates of local system of QCustomPlot and vice versa.
+*/
+
+class CORE_EXPORT SceneAdapterInterface
+{
+    virtual ~SceneAdapterInterface() = default;
+
+    //! convert local x-coordinate to scene coordinate
+    virtual double toSceneX(double) const = 0;
+
+    //! convert local y-coordinate to scene coordinate
+    virtual double toSceneY(double) const = 0;
+
+    //! convert scene x-coordinate to local axis coordinate
+    virtual double fromSceneX(double) const = 0;
+
+    //! convert scene y-coordinate to local axis coordinate
+    virtual double fromSceneY(double) const = 0;
+};
+
+} // namespace ModelView
+
+#endif // GRAPHICSPROXY_SCENEADAPTERINTERFACE_H


### PR DESCRIPTION
User example demonstrates how to embed QCustomPlot into the QGraphicsScene using proxy widget and to plot complex objects on top of it.
In the next pull request I will finalize the logic of RegionOfInterestView to provide live resize of fancy ROI area.