### PR TITLE
Relatively light-weighted replacement of QStandardItemModel

### DIFF
--- a/source/libmvvm_model/mvvm/model/sessionitemcontainer.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitemcontainer.cpp
@@ -65,7 +65,7 @@ SessionItem* SessionItemContainer::takeItem(int index)
 
     SessionItem* result = itemAt(index);
     if (result)
-        m_items.erase(m_items.begin() + index);
+        m_items.erase(std::next(m_items.begin(), index));
 
     return result;
 }

--- a/source/libmvvm_model/mvvm/utils/containerutils.h
+++ b/source/libmvvm_model/mvvm/utils/containerutils.h
@@ -29,6 +29,17 @@ template <typename C, typename T> int IndexOfItem(const C& container, const T& i
     return pos == container.end() ? -1 : static_cast<int>(std::distance(container.begin(), pos));
 }
 
+
+//! Returns index corresponding to the first occurance of the item in the container.
+//! If item doesn't exist, will return -1.
+
+template <typename It, typename T> int IndexOfItem(It begin, It end, const T& item)
+{
+    auto pos = find(begin, end, item);
+    return pos == end ? -1 : static_cast<int>(std::distance(begin, pos));
+}
+
+
 } // namespace Utils
 
 } // namespace ModelView

--- a/source/libmvvm_model/mvvm/utils/containerutils.h
+++ b/source/libmvvm_model/mvvm/utils/containerutils.h
@@ -11,8 +11,10 @@
 #define MVVM_UTILS_CONTAINERUTILS_H
 
 #include <iterator>
+#include <memory>
 #include <mvvm/core/export.h>
 #include <string>
+#include <type_traits>
 
 namespace ModelView
 {
@@ -20,25 +22,33 @@ namespace ModelView
 namespace Utils
 {
 
-//! Returns index corresponding to the first occurance of the item in the container.
-//! If item doesn't exist, will return -1.
+template <class T> struct is_unique_ptr : std::false_type {
+};
 
-template <typename C, typename T> int IndexOfItem(const C& container, const T& item)
-{
-    auto pos = find(container.begin(), container.end(), item);
-    return pos == container.end() ? -1 : static_cast<int>(std::distance(container.begin(), pos));
-}
-
+template <class T, class D> struct is_unique_ptr<std::unique_ptr<T, D>> : std::true_type {
+};
 
 //! Returns index corresponding to the first occurance of the item in the container.
-//! If item doesn't exist, will return -1.
+//! If item doesn't exist, will return -1. Works with containers containing unique_ptr.
 
 template <typename It, typename T> int IndexOfItem(It begin, It end, const T& item)
 {
-    auto pos = find(begin, end, item);
+    It pos;
+    if constexpr (is_unique_ptr<typename std::iterator_traits<It>::value_type>::value)
+        pos = find_if(begin, end, [&item](const auto& x) { return x.get() == item; });
+    else
+        pos = find_if(begin, end, [&item](const auto& x) { return x == item; });
+
     return pos == end ? -1 : static_cast<int>(std::distance(begin, pos));
 }
 
+//! Returns index corresponding to the first occurance of the item in the container.
+//! If item doesn't exist, will return -1. Works with containers containing unique_ptr.
+
+template <typename C, typename T> int IndexOfItem(const C& container, const T& item)
+{
+    return IndexOfItem(container.begin(), container.end(), item);
+}
 
 } // namespace Utils
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/CMakeLists.txt
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/CMakeLists.txt
@@ -19,6 +19,10 @@ target_sources(mvvm_viewmodel PRIVATE
     propertyflatviewmodel.h
     propertyviewmodel.cpp
     propertyviewmodel.h
+    refviewmodel.cpp
+    refviewmodel.h
+    refviewitem.cpp
+    refviewitem.h
     rowstrategyinterface.h
     standardchildrenstrategies.cpp
     standardchildrenstrategies.h

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
@@ -39,11 +39,25 @@ struct RefViewItem::RefViewItemImpl {
         if (row < 0 || row > rows)
             throw std::runtime_error("Error in RefViewItem: invalid row index.");
 
-        children.insert(std::next(children.begin(), row*columns), std::make_move_iterator(items.begin()),
+        children.insert(std::next(children.begin(), row * columns),
+                        std::make_move_iterator(items.begin()),
                         std::make_move_iterator(items.end()));
 
         columns = static_cast<int>(items.size());
         ++rows;
+    }
+
+    void removeRow(int row)
+    {
+        if (row < 0 || row >= rows)
+            throw std::runtime_error("Error in RefViewItem: invalid row index.");
+
+        auto begin = std::next(children.begin(), row * columns);
+        auto end = std::next(begin, columns);
+        children.erase(begin, end);
+        --rows;
+        if (rows == 0)
+            columns = 0;
     }
 
     RefViewItem* child(int row, int column) const
@@ -103,6 +117,13 @@ void RefViewItem::insertRow(int row, std::vector<std::unique_ptr<RefViewItem>> i
     for (auto& x : items)
         x.get()->setParent(this);
     p_impl->insertRow(row, std::move(items));
+}
+
+//! Removes row of items at given 'row'. Items will be deleted.
+
+void RefViewItem::removeRow(int row)
+{
+    p_impl->removeRow(row);
 }
 
 void RefViewItem::clear()

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
@@ -1,0 +1,60 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include <mvvm/viewmodel/refviewitem.h>
+#include <vector>
+
+using namespace ModelView;
+
+struct RefViewItem::RefViewItemImpl {
+    std::vector<std::unique_ptr<RefViewItem>> children;
+    int rows{0};
+    int columns{0};
+    RefViewItemImpl() {}
+
+    void appendRow(std::vector<std::unique_ptr<RefViewItem>> items)
+    {
+        if (items.empty())
+            throw std::runtime_error("Error in RefViewItem: attempt to cappend empty row");
+
+        if (columns > 0 && items.size() != static_cast<size_t>(columns))
+            throw std::runtime_error("Error in RefViewItem: wrong number of columns.");
+
+        children.insert(children.end(), std::make_move_iterator(items.begin()),
+                        std::make_move_iterator(items.end()));
+        columns = static_cast<int>(items.size());
+        ++rows;
+    }
+};
+
+RefViewItem::RefViewItem() : p_impl(std::make_unique<RefViewItemImpl>()) {}
+
+RefViewItem::~RefViewItem() = default;
+
+int RefViewItem::rowCount() const
+{
+    return p_impl->rows;
+}
+
+int RefViewItem::columnCount() const
+{
+    return p_impl->columns;
+}
+
+void RefViewItem::appendRow(std::vector<std::unique_ptr<RefViewItem>> items)
+{
+    p_impl->appendRow(std::move(items));
+}
+
+void RefViewItem::clear()
+{
+    p_impl->children.clear();
+    p_impl->rows = 0;
+    p_impl->columns = 0;
+}

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
@@ -16,12 +16,14 @@ struct RefViewItem::RefViewItemImpl {
     std::vector<std::unique_ptr<RefViewItem>> children;
     int rows{0};
     int columns{0};
-    RefViewItemImpl() {}
+    SessionItem* item;
+    int role;
+    RefViewItemImpl(SessionItem* item, int role) : item(item), role(role) {}
 
     void appendRow(std::vector<std::unique_ptr<RefViewItem>> items)
     {
         if (items.empty())
-            throw std::runtime_error("Error in RefViewItem: attempt to cappend empty row");
+            throw std::runtime_error("Error in RefViewItem: attempt to append empty row");
 
         if (columns > 0 && items.size() != static_cast<size_t>(columns))
             throw std::runtime_error("Error in RefViewItem: wrong number of columns.");
@@ -31,9 +33,23 @@ struct RefViewItem::RefViewItemImpl {
         columns = static_cast<int>(items.size());
         ++rows;
     }
+
+    RefViewItem* child(int row, int column) const
+    {
+        if (row < 0 || row >= rows)
+            throw std::runtime_error("Error in RefViewItem: wrong row)");
+
+        if (column < 0 || column >= columns)
+            throw std::runtime_error("Error in RefViewItem: wrong column)");
+
+        return children.at(static_cast<size_t>(column + row * columns)).get();
+    }
 };
 
-RefViewItem::RefViewItem() : p_impl(std::make_unique<RefViewItemImpl>()) {}
+RefViewItem::RefViewItem(SessionItem* item, int role)
+    : p_impl(std::make_unique<RefViewItemImpl>(item, role))
+{
+}
 
 RefViewItem::~RefViewItem() = default;
 
@@ -57,4 +73,19 @@ void RefViewItem::clear()
     p_impl->children.clear();
     p_impl->rows = 0;
     p_impl->columns = 0;
+}
+
+RefViewItem* RefViewItem::child(int row, int column) const
+{
+    return p_impl->child(row, column);
+}
+
+SessionItem* RefViewItem::item() const
+{
+    return p_impl->item;
+}
+
+int RefViewItem::item_role() const
+{
+    return p_impl->role;
 }

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.cpp
@@ -9,6 +9,7 @@
 
 #include <mvvm/viewmodel/refviewitem.h>
 #include <vector>
+#include <algorithm>
 
 using namespace ModelView;
 
@@ -16,8 +17,9 @@ struct RefViewItem::RefViewItemImpl {
     std::vector<std::unique_ptr<RefViewItem>> children;
     int rows{0};
     int columns{0};
-    SessionItem* item;
-    int role;
+    SessionItem* item{nullptr};
+    int role{0};
+    RefViewItem* parent_view_item{nullptr};
     RefViewItemImpl(SessionItem* item, int role) : item(item), role(role) {}
 
     void appendRow(std::vector<std::unique_ptr<RefViewItem>> items)
@@ -44,6 +46,11 @@ struct RefViewItem::RefViewItemImpl {
 
         return children.at(static_cast<size_t>(column + row * columns)).get();
     }
+
+    RefViewItem* parent()
+    {
+        return parent_view_item;
+    }
 };
 
 RefViewItem::RefViewItem(SessionItem* item, int role)
@@ -65,6 +72,8 @@ int RefViewItem::columnCount() const
 
 void RefViewItem::appendRow(std::vector<std::unique_ptr<RefViewItem>> items)
 {
+    for(auto& x : items)
+        x.get()->setParent(this);
     p_impl->appendRow(std::move(items));
 }
 
@@ -73,6 +82,11 @@ void RefViewItem::clear()
     p_impl->children.clear();
     p_impl->rows = 0;
     p_impl->columns = 0;
+}
+
+RefViewItem* RefViewItem::parent() const
+{
+    return p_impl->parent();
 }
 
 RefViewItem* RefViewItem::child(int row, int column) const
@@ -88,4 +102,9 @@ SessionItem* RefViewItem::item() const
 int RefViewItem::item_role() const
 {
     return p_impl->role;
+}
+
+void RefViewItem::setParent(RefViewItem* parent)
+{
+    p_impl->parent_view_item = parent;
 }

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
@@ -33,6 +33,8 @@ public:
 
     void appendRow(std::vector<std::unique_ptr<RefViewItem>> items);
 
+    void insertRow(int row, std::vector<std::unique_ptr<RefViewItem>> items);
+
     void clear();
 
     RefViewItem* parent() const;

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
@@ -35,11 +35,16 @@ public:
 
     void clear();
 
+    RefViewItem* parent() const;
+
     RefViewItem* child(int row, int column) const;
 
     SessionItem* item() const;
 
     int item_role() const;
+
+protected:
+    void setParent(RefViewItem* parent);
 
 private:
     struct RefViewItemImpl;

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
@@ -17,12 +17,14 @@
 namespace ModelView
 {
 
+class SessionItem;
+
 //! Represents the view of SessionItem's data in single cell of ViewModel.
 
 class CORE_EXPORT RefViewItem
 {
 public:
-    RefViewItem();
+    explicit RefViewItem(SessionItem* item = nullptr, int role = 0);
     virtual ~RefViewItem();
 
     int rowCount() const;
@@ -32,6 +34,12 @@ public:
     void appendRow(std::vector<std::unique_ptr<RefViewItem>> items);
 
     void clear();
+
+    RefViewItem* child(int row, int column) const;
+
+    SessionItem* item() const;
+
+    int item_role() const;
 
 private:
     struct RefViewItemImpl;

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
@@ -1,0 +1,43 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MVVM_VIEWMODEL_REFVIEWITEM_H
+#define MVVM_VIEWMODEL_REFVIEWITEM_H
+
+#include <memory>
+#include <mvvm/core/export.h>
+#include <vector>
+
+namespace ModelView
+{
+
+//! Represents the view of SessionItem's data in single cell of ViewModel.
+
+class CORE_EXPORT RefViewItem
+{
+public:
+    RefViewItem();
+    virtual ~RefViewItem();
+
+    int rowCount() const;
+
+    int columnCount() const;
+
+    void appendRow(std::vector<std::unique_ptr<RefViewItem>> items);
+
+    void clear();
+
+private:
+    struct RefViewItemImpl;
+    std::unique_ptr<RefViewItemImpl> p_impl;
+};
+
+}; // namespace ModelView
+
+#endif // MVVM_VIEWMODEL_REFVIEWITEM_H

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
@@ -35,6 +35,8 @@ public:
 
     void insertRow(int row, std::vector<std::unique_ptr<RefViewItem>> items);
 
+    void removeRow(int row);
+
     void clear();
 
     RefViewItem* parent() const;

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewitem.h
@@ -43,6 +43,10 @@ public:
 
     int item_role() const;
 
+    int row() const;
+
+    int column() const;
+
 protected:
     void setParent(RefViewItem* parent);
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -26,10 +26,12 @@ RefViewModel::~RefViewModel() = default;
 
 QModelIndex RefViewModel::index(int row, int column, const QModelIndex& parent) const
 {
-    Q_UNUSED(row)
-    Q_UNUSED(column)
-    Q_UNUSED(parent)
-    return QModelIndex();
+    auto parent_item = itemForIndex(parent);
+    const bool is_valid_row = row >= 0 && row < rowCount(parent);
+    const bool is_valid_column = column >= 0 && column < columnCount(parent);
+    return is_valid_row && is_valid_column
+               ? createIndex(row, column, parent_item->child(row, column))
+               : QModelIndex();
 }
 
 QModelIndex RefViewModel::parent(const QModelIndex& child) const
@@ -64,4 +66,9 @@ RefViewItem* RefViewModel::itemForIndex(const QModelIndex& index) const
 {
     return index.isValid() ? static_cast<RefViewItem*>(index.internalPointer())
                            : p_impl->root.get();
+}
+
+void RefViewModel::appendRow(RefViewItem* parent, std::vector<std::unique_ptr<RefViewItem>> items)
+{
+    parent->appendRow(std::move(items));
 }

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -89,11 +89,16 @@ QModelIndex RefViewModel::indexFromItem(const RefViewItem* item) const
                : QModelIndex();
 }
 
-void RefViewModel::appendRow(const QModelIndex& parent,
+//! Appends row of items to given parent.
+
+void RefViewModel::appendRow(RefViewItem* parent,
                              std::vector<std::unique_ptr<RefViewItem>> items)
 {
-    auto parent_item = itemFromIndex(parent) ? itemFromIndex(parent) : rootItem();
-    beginInsertRows(parent, parent_item->rowCount(), parent_item->rowCount());
-    parent_item->appendRow(std::move(items));
+    const bool parent_belongs_to_model = indexFromItem(parent).isValid() || parent == rootItem();
+    if (!parent_belongs_to_model)
+        throw std::runtime_error("Error in RefViewModel: attempt to use parent from another model");
+
+    beginInsertRows(indexFromItem(parent), parent->rowCount(), parent->rowCount());
+    parent->appendRow(std::move(items));
     endInsertRows();
 }

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -7,11 +7,22 @@
 //
 // ************************************************************************** //
 
+#include <mvvm/viewmodel/refviewitem.h>
 #include <mvvm/viewmodel/refviewmodel.h>
 
 using namespace ModelView;
 
-RefViewModel::RefViewModel(QObject* parent) : QAbstractItemModel(parent) {}
+struct RefViewModel::RefViewModelImpl {
+    std::unique_ptr<RefViewItem> root;
+    RefViewModelImpl() : root(std::make_unique<RefViewItem>()) {}
+};
+
+RefViewModel::RefViewModel(QObject* parent)
+    : QAbstractItemModel(parent), p_impl(std::make_unique<RefViewModelImpl>())
+{
+}
+
+RefViewModel::~RefViewModel() = default;
 
 QModelIndex RefViewModel::index(int row, int column, const QModelIndex& parent) const
 {
@@ -29,14 +40,12 @@ QModelIndex RefViewModel::parent(const QModelIndex& child) const
 
 int RefViewModel::rowCount(const QModelIndex& parent) const
 {
-    Q_UNUSED(parent)
-    return 0;
+    return itemForIndex(parent)->rowCount();
 }
 
 int RefViewModel::columnCount(const QModelIndex& parent) const
 {
-    Q_UNUSED(parent)
-    return 0;
+    return itemForIndex(parent)->columnCount();
 }
 
 QVariant RefViewModel::data(const QModelIndex& index, int role) const
@@ -44,4 +53,15 @@ QVariant RefViewModel::data(const QModelIndex& index, int role) const
     Q_UNUSED(index)
     Q_UNUSED(role)
     return QVariant();
+}
+
+RefViewItem* RefViewModel::rootItem() const
+{
+    return p_impl->root.get();
+}
+
+RefViewItem* RefViewModel::itemForIndex(const QModelIndex& index) const
+{
+    return index.isValid() ? static_cast<RefViewItem*>(index.internalPointer())
+                           : p_impl->root.get();
 }

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -1,0 +1,47 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include <mvvm/viewmodel/refviewmodel.h>
+
+using namespace ModelView;
+
+RefViewModel::RefViewModel(QObject* parent) : QAbstractItemModel(parent) {}
+
+QModelIndex RefViewModel::index(int row, int column, const QModelIndex& parent) const
+{
+    Q_UNUSED(row)
+    Q_UNUSED(column)
+    Q_UNUSED(parent)
+    return QModelIndex();
+}
+
+QModelIndex RefViewModel::parent(const QModelIndex& child) const
+{
+    Q_UNUSED(child)
+    return QModelIndex();
+}
+
+int RefViewModel::rowCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return 0;
+}
+
+int RefViewModel::columnCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return 0;
+}
+
+QVariant RefViewModel::data(const QModelIndex& index, int role) const
+{
+    Q_UNUSED(index)
+    Q_UNUSED(role)
+    return QVariant();
+}

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -68,7 +68,11 @@ RefViewItem* RefViewModel::itemForIndex(const QModelIndex& index) const
                            : p_impl->root.get();
 }
 
-void RefViewModel::appendRow(RefViewItem* parent, std::vector<std::unique_ptr<RefViewItem>> items)
+void RefViewModel::appendRow(const QModelIndex& parent,
+                             std::vector<std::unique_ptr<RefViewItem>> items)
 {
-    parent->appendRow(std::move(items));
+    auto parent_item = itemForIndex(parent);
+    beginInsertRows(parent, parent_item->rowCount(), parent_item->rowCount());
+    parent_item->appendRow(std::move(items));
+    endInsertRows();
 }

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -36,7 +36,13 @@ QModelIndex RefViewModel::index(int row, int column, const QModelIndex& parent) 
 
 QModelIndex RefViewModel::parent(const QModelIndex& child) const
 {
-    Q_UNUSED(child)
+    if (auto child_item = itemFromIndex(child); child_item) {
+        auto parent_item = child_item->parent();
+        return parent_item == rootItem()
+                   ? QModelIndex()
+                   : createIndex(parent_item->row(), parent_item->column(), parent_item);
+    }
+
     return QModelIndex();
 }
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.cpp
@@ -80,6 +80,15 @@ RefViewItem* RefViewModel::itemFromIndex(const QModelIndex& index) const
     return index.isValid() ? static_cast<RefViewItem*>(index.internalPointer()) : nullptr;
 }
 
+//! Returns the QModelIndex associated with the given item.
+
+QModelIndex RefViewModel::indexFromItem(const RefViewItem* item) const
+{
+    return item && item->parent()
+               ? createIndex(item->row(), item->column(), const_cast<RefViewItem*>(item))
+               : QModelIndex();
+}
+
 void RefViewModel::appendRow(const QModelIndex& parent,
                              std::vector<std::unique_ptr<RefViewItem>> items)
 {

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -50,6 +50,8 @@ public:
 
     QModelIndex indexFromItem(const RefViewItem *item) const;
 
+    void removeRow(RefViewItem* parent, int row);
+
     void appendRow(RefViewItem* parent, std::vector<std::unique_ptr<RefViewItem>> items);
 
 private:

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -12,9 +12,12 @@
 
 #include <QAbstractItemModel>
 #include <mvvm/core/export.h>
+#include <memory>
 
 namespace ModelView
 {
+
+class RefViewItem;
 
 /*!
 @class RefViewModel
@@ -29,6 +32,7 @@ class CORE_EXPORT RefViewModel : public QAbstractItemModel
     Q_OBJECT
 public:
     explicit RefViewModel(QObject* parent = nullptr);
+    ~RefViewModel();
 
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
 
@@ -39,6 +43,14 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    RefViewItem* rootItem() const;
+
+    RefViewItem* itemForIndex(const QModelIndex& index) const;
+
+private:
+    struct RefViewModelImpl;
+    std::unique_ptr<RefViewModelImpl> p_impl;
 };
 
 }; // namespace ModelView

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -48,6 +48,8 @@ public:
 
     RefViewItem* itemFromIndex(const QModelIndex& index) const;
 
+    QModelIndex indexFromItem(const RefViewItem *item) const;
+
     void appendRow(const QModelIndex& parent, std::vector<std::unique_ptr<RefViewItem>> items);
 
 private:

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -48,6 +48,8 @@ public:
 
     RefViewItem* itemForIndex(const QModelIndex& index) const;
 
+    void appendRow(RefViewItem* parent, std::vector<std::unique_ptr<RefViewItem>> items);
+
 private:
     struct RefViewModelImpl;
     std::unique_ptr<RefViewModelImpl> p_impl;

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -1,0 +1,46 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MVVM_VIEWMODEL_REFVIEWMODEL_H
+#define MVVM_VIEWMODEL_REFVIEWMODEL_H
+
+#include <QAbstractItemModel>
+#include <mvvm/core/export.h>
+
+namespace ModelView
+{
+
+/*!
+@class RefViewModel
+@brief Base class for all view models to show content of SessionModel in Qt views.
+
+ViewModel is made of ViewItems, where each ViewItem represents some concrete data role
+of SessionItem.
+*/
+
+class CORE_EXPORT RefViewModel : public QAbstractItemModel
+{
+    Q_OBJECT
+public:
+    explicit RefViewModel(QObject* parent = nullptr);
+
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+
+    QModelIndex parent(const QModelIndex &child) const override;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+};
+
+}; // namespace ModelView
+
+#endif // MVVM_VIEWMODEL_REFVIEWMODEL_H

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -46,7 +46,7 @@ public:
 
     RefViewItem* rootItem() const;
 
-    RefViewItem* itemForIndex(const QModelIndex& index) const;
+    RefViewItem* itemFromIndex(const QModelIndex& index) const;
 
     void appendRow(const QModelIndex& parent, std::vector<std::unique_ptr<RefViewItem>> items);
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -50,7 +50,7 @@ public:
 
     QModelIndex indexFromItem(const RefViewItem *item) const;
 
-    void appendRow(const QModelIndex& parent, std::vector<std::unique_ptr<RefViewItem>> items);
+    void appendRow(RefViewItem* parent, std::vector<std::unique_ptr<RefViewItem>> items);
 
 private:
     struct RefViewModelImpl;

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -32,7 +32,7 @@ class CORE_EXPORT RefViewModel : public QAbstractItemModel
     Q_OBJECT
 public:
     explicit RefViewModel(QObject* parent = nullptr);
-    ~RefViewModel();
+    ~RefViewModel() override;
 
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/refviewmodel.h
@@ -48,7 +48,7 @@ public:
 
     RefViewItem* itemForIndex(const QModelIndex& index) const;
 
-    void appendRow(RefViewItem* parent, std::vector<std::unique_ptr<RefViewItem>> items);
+    void appendRow(const QModelIndex& parent, std::vector<std::unique_ptr<RefViewItem>> items);
 
 private:
     struct RefViewModelImpl;

--- a/tests/testmodel/containerutils.test.cpp
+++ b/tests/testmodel/containerutils.test.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include "google_test.h"
+#include <mvvm/model/sessionitem.h>
 #include <mvvm/utils/containerutils.h>
 
 using namespace ModelView;
@@ -22,11 +23,36 @@ public:
 
 ContainerUtilsTest::~ContainerUtilsTest() = default;
 
+TEST_F(ContainerUtilsTest, isUniquePtr)
+{
+    EXPECT_FALSE(Utils::is_unique_ptr<int>::value);
+    EXPECT_TRUE(Utils::is_unique_ptr<std::unique_ptr<int>>::value);
+}
+
 TEST_F(ContainerUtilsTest, IndexOfItem)
 {
+    // searching in vector of integers
     std::vector<int> vv{1, 7, 5};
     EXPECT_EQ(Utils::IndexOfItem(vv, 1), 0);
     EXPECT_EQ(Utils::IndexOfItem(vv, 10), -1);
     EXPECT_EQ(Utils::IndexOfItem(vv, 5), 2);
     EXPECT_EQ(Utils::IndexOfItem(vv.begin(), vv.end(), 7), 1);
+
+    // searching in vector of SessionItem's
+    std::vector<SessionItem*> items{new SessionItem, new SessionItem, new SessionItem};
+    SessionItem other;
+    EXPECT_EQ(Utils::IndexOfItem(items, items[0]), 0);
+    EXPECT_EQ(Utils::IndexOfItem(items, items[1]), 1);
+    EXPECT_EQ(Utils::IndexOfItem(items, items[2]), 2);
+    EXPECT_EQ(Utils::IndexOfItem(items, &other), -1);
+    for (auto x : items)
+        delete x;
+
+    // searching in vector of unique_ptr
+    std::vector<std::unique_ptr<SessionItem>> unique_items;
+    unique_items.emplace_back(std::make_unique<SessionItem>());
+    unique_items.emplace_back(std::make_unique<SessionItem>());
+    EXPECT_EQ(Utils::IndexOfItem(unique_items, unique_items[0].get()), 0);
+    EXPECT_EQ(Utils::IndexOfItem(unique_items, unique_items[1].get()), 1);
+    EXPECT_EQ(Utils::IndexOfItem(unique_items, &other), -1);
 }

--- a/tests/testmodel/containerutils.test.cpp
+++ b/tests/testmodel/containerutils.test.cpp
@@ -1,0 +1,32 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+#include <mvvm/utils/containerutils.h>
+
+using namespace ModelView;
+
+//! Tests of container utils.
+
+class ContainerUtilsTest : public ::testing::Test
+{
+public:
+    ~ContainerUtilsTest();
+};
+
+ContainerUtilsTest::~ContainerUtilsTest() = default;
+
+TEST_F(ContainerUtilsTest, IndexOfItem)
+{
+    std::vector<int> vv{1, 7, 5};
+    EXPECT_EQ(Utils::IndexOfItem(vv, 1), 0);
+    EXPECT_EQ(Utils::IndexOfItem(vv, 10), -1);
+    EXPECT_EQ(Utils::IndexOfItem(vv, 5), 2);
+    EXPECT_EQ(Utils::IndexOfItem(vv.begin(), vv.end(), 7), 1);
+}

--- a/tests/testviewmodel/refviewitem.test.cpp
+++ b/tests/testviewmodel/refviewitem.test.cpp
@@ -30,6 +30,8 @@ TEST_F(RefViewItemTest, initialState)
 
     EXPECT_EQ(view_item.rowCount(), 0);
     EXPECT_EQ(view_item.columnCount(), 0);
+    EXPECT_EQ(view_item.row(), -1);
+    EXPECT_EQ(view_item.column(), -1);
     EXPECT_EQ(view_item.parent(), nullptr);
     EXPECT_THROW(view_item.child(0, 0), std::runtime_error);
 }
@@ -43,14 +45,20 @@ TEST_F(RefViewItemTest, appendRow)
 
     RefViewItem* expected = children[0].get();
 
+    // appending row with single item
     RefViewItem view_item;
     view_item.appendRow(std::move(children));
 
+    // checking parent
     EXPECT_EQ(view_item.rowCount(), 1);
     EXPECT_EQ(view_item.columnCount(), 1);
     EXPECT_EQ(view_item.child(0, 0), expected);
     EXPECT_THROW(view_item.child(0, 1), std::runtime_error);
+
+    // checking appended child
     EXPECT_EQ(expected->parent(), &view_item);
+    EXPECT_EQ(expected->row(), 0);
+    EXPECT_EQ(expected->column(), 0);
 }
 
 //! Append two rows with two items each.
@@ -84,6 +92,16 @@ TEST_F(RefViewItemTest, appendTwoRows)
     EXPECT_EQ(expected_row0[1]->parent(), &view_item);
     EXPECT_EQ(expected_row1[0]->parent(), &view_item);
     EXPECT_EQ(expected_row1[1]->parent(), &view_item);
+
+    // checking row and column of children
+    EXPECT_EQ(expected_row0[0]->row(), 0);
+    EXPECT_EQ(expected_row0[1]->row(), 0);
+    EXPECT_EQ(expected_row1[0]->row(), 1);
+    EXPECT_EQ(expected_row1[1]->row(), 1);
+    EXPECT_EQ(expected_row0[0]->column(), 0);
+    EXPECT_EQ(expected_row0[1]->column(), 1);
+    EXPECT_EQ(expected_row1[0]->column(), 0);
+    EXPECT_EQ(expected_row1[1]->column(), 1);
 
     // attempt to add row with different amount of children should fail
     children_row2.emplace_back(std::make_unique<RefViewItem>());

--- a/tests/testviewmodel/refviewitem.test.cpp
+++ b/tests/testviewmodel/refviewitem.test.cpp
@@ -1,0 +1,27 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+
+using namespace ModelView;
+
+//! Tests for RefViewItem class.
+
+class RefViewItemTest : public ::testing::Test
+{
+public:
+    ~RefViewItemTest();
+};
+
+RefViewItemTest::~RefViewItemTest() = default;
+
+TEST_F(RefViewItemTest, initialState)
+{
+    EXPECT_EQ(1, 1);
+}

--- a/tests/testviewmodel/refviewitem.test.cpp
+++ b/tests/testviewmodel/refviewitem.test.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include "google_test.h"
+#include <mvvm/viewmodel/refviewitem.h>
 
 using namespace ModelView;
 
@@ -21,7 +22,79 @@ public:
 
 RefViewItemTest::~RefViewItemTest() = default;
 
+//! Initial state of RefViewItem.
+
 TEST_F(RefViewItemTest, initialState)
 {
-    EXPECT_EQ(1, 1);
+    RefViewItem view_item;
+
+    EXPECT_EQ(view_item.rowCount(), 0);
+    EXPECT_EQ(view_item.columnCount(), 0);
+    EXPECT_THROW(view_item.child(0, 0), std::runtime_error);
+}
+
+//! Append single item as row.
+
+TEST_F(RefViewItemTest, appendRow)
+{
+    std::vector<std::unique_ptr<RefViewItem>> children;
+    children.emplace_back(std::make_unique<RefViewItem>());
+
+    RefViewItem* expected = children[0].get();
+
+    RefViewItem view_item;
+    view_item.appendRow(std::move(children));
+
+    EXPECT_EQ(view_item.rowCount(), 1);
+    EXPECT_EQ(view_item.columnCount(), 1);
+    EXPECT_EQ(view_item.child(0, 0), expected);
+    EXPECT_THROW(view_item.child(0, 1), std::runtime_error);
+}
+
+//! Append two rows with two items each.
+
+TEST_F(RefViewItemTest, appendTwoRows)
+{
+    std::vector<std::unique_ptr<RefViewItem>> children_row0, children_row1, children_row2;
+
+    children_row0.emplace_back(std::make_unique<RefViewItem>());
+    children_row0.emplace_back(std::make_unique<RefViewItem>());
+    children_row1.emplace_back(std::make_unique<RefViewItem>());
+    children_row1.emplace_back(std::make_unique<RefViewItem>());
+
+    std::vector<RefViewItem*> expected0 = {children_row0[0].get(), children_row0[1].get()};
+    std::vector<RefViewItem*> expected1 = {children_row1[0].get(), children_row1[1].get()};
+
+    RefViewItem view_item;
+    view_item.appendRow(std::move(children_row0));
+    view_item.appendRow(std::move(children_row1));
+
+    EXPECT_EQ(view_item.rowCount(), 2);
+    EXPECT_EQ(view_item.columnCount(), 2);
+    EXPECT_EQ(view_item.child(0, 0), expected0[0]);
+    EXPECT_EQ(view_item.child(0, 1), expected0[1]);
+    EXPECT_EQ(view_item.child(1, 0), expected1[0]);
+    EXPECT_EQ(view_item.child(1, 1), expected1[1]);
+    EXPECT_THROW(view_item.child(2, 2), std::runtime_error);
+
+    // attempt to add row with different amount of children should fail
+    children_row2.emplace_back(std::make_unique<RefViewItem>());
+    EXPECT_THROW(view_item.appendRow(std::move(children_row2)), std::runtime_error);
+    EXPECT_EQ(view_item.rowCount(), 2);
+    EXPECT_EQ(view_item.columnCount(), 2);
+}
+
+//! Append single item as row.
+
+TEST_F(RefViewItemTest, clear)
+{
+    std::vector<std::unique_ptr<RefViewItem>> children;
+    children.emplace_back(std::make_unique<RefViewItem>());
+
+    RefViewItem view_item;
+    view_item.appendRow(std::move(children));
+    view_item.clear();
+
+    EXPECT_EQ(view_item.rowCount(), 0);
+    EXPECT_EQ(view_item.columnCount(), 0);
 }

--- a/tests/testviewmodel/refviewitem.test.cpp
+++ b/tests/testviewmodel/refviewitem.test.cpp
@@ -110,6 +110,60 @@ TEST_F(RefViewItemTest, appendTwoRows)
     EXPECT_EQ(view_item.columnCount(), 2);
 }
 
+//! Append two rows with two items each.
+
+TEST_F(RefViewItemTest, insertRow)
+{
+    // preparing two rows of children, two columns each
+    std::vector<std::unique_ptr<RefViewItem>> children_row0, children_row1, children_row2;
+    children_row0.emplace_back(std::make_unique<RefViewItem>());
+    children_row0.emplace_back(std::make_unique<RefViewItem>());
+    children_row1.emplace_back(std::make_unique<RefViewItem>());
+    children_row1.emplace_back(std::make_unique<RefViewItem>());
+    children_row2.emplace_back(std::make_unique<RefViewItem>());
+    children_row2.emplace_back(std::make_unique<RefViewItem>());
+    std::vector<RefViewItem*> expected_row0 = {children_row0[0].get(), children_row0[1].get()};
+    std::vector<RefViewItem*> expected_row1 = {children_row1[0].get(), children_row1[1].get()};
+    std::vector<RefViewItem*> expected_row2 = {children_row2[0].get(), children_row2[1].get()};
+
+    // appending rows
+    RefViewItem view_item;
+    view_item.appendRow(std::move(children_row0));
+    view_item.appendRow(std::move(children_row1));
+    view_item.insertRow(1, std::move(children_row2)); // inserting in-between
+
+    EXPECT_EQ(view_item.rowCount(), 3);
+    EXPECT_EQ(view_item.columnCount(), 2);
+    EXPECT_EQ(view_item.child(0, 0), expected_row0[0]);
+    EXPECT_EQ(view_item.child(0, 1), expected_row0[1]);
+    EXPECT_EQ(view_item.child(1, 0), expected_row2[0]);
+    EXPECT_EQ(view_item.child(1, 1), expected_row2[1]);
+    EXPECT_EQ(view_item.child(2, 0), expected_row1[0]);
+    EXPECT_EQ(view_item.child(2, 1), expected_row1[1]);
+
+    // checking parents
+    EXPECT_EQ(expected_row0[0]->parent(), &view_item);
+    EXPECT_EQ(expected_row0[1]->parent(), &view_item);
+    EXPECT_EQ(expected_row1[0]->parent(), &view_item);
+    EXPECT_EQ(expected_row1[1]->parent(), &view_item);
+    EXPECT_EQ(expected_row2[0]->parent(), &view_item);
+    EXPECT_EQ(expected_row2[1]->parent(), &view_item);
+
+    // checking row and column of children
+    EXPECT_EQ(expected_row0[0]->row(), 0);
+    EXPECT_EQ(expected_row0[1]->row(), 0);
+    EXPECT_EQ(expected_row1[0]->row(), 2);
+    EXPECT_EQ(expected_row1[1]->row(), 2);
+    EXPECT_EQ(expected_row2[0]->row(), 1);
+    EXPECT_EQ(expected_row2[1]->row(), 1);
+    EXPECT_EQ(expected_row0[0]->column(), 0);
+    EXPECT_EQ(expected_row0[1]->column(), 1);
+    EXPECT_EQ(expected_row1[0]->column(), 0);
+    EXPECT_EQ(expected_row1[1]->column(), 1);
+    EXPECT_EQ(expected_row2[0]->column(), 0);
+    EXPECT_EQ(expected_row2[1]->column(), 1);
+}
+
 //! Clean item's children.
 
 TEST_F(RefViewItemTest, clear)

--- a/tests/testviewmodel/refviewitem.test.cpp
+++ b/tests/testviewmodel/refviewitem.test.cpp
@@ -61,6 +61,24 @@ TEST_F(RefViewItemTest, appendRow)
     EXPECT_EQ(expected->column(), 0);
 }
 
+//! Remove row.
+
+TEST_F(RefViewItemTest, removeRow)
+{
+    std::vector<std::unique_ptr<RefViewItem>> children;
+    children.emplace_back(std::make_unique<RefViewItem>());
+
+    // appending row with single item
+    RefViewItem view_item;
+    view_item.appendRow(std::move(children));
+    view_item.removeRow(0);
+
+    // checking parent
+    EXPECT_EQ(view_item.rowCount(), 0);
+    EXPECT_EQ(view_item.columnCount(), 0);
+}
+
+
 //! Append two rows with two items each.
 
 TEST_F(RefViewItemTest, appendTwoRows)
@@ -112,7 +130,7 @@ TEST_F(RefViewItemTest, appendTwoRows)
 
 //! Append two rows with two items each.
 
-TEST_F(RefViewItemTest, insertRow)
+TEST_F(RefViewItemTest, insertRowsThenRemove)
 {
     // preparing two rows of children, two columns each
     std::vector<std::unique_ptr<RefViewItem>> children_row0, children_row1, children_row2;
@@ -162,6 +180,13 @@ TEST_F(RefViewItemTest, insertRow)
     EXPECT_EQ(expected_row1[1]->column(), 1);
     EXPECT_EQ(expected_row2[0]->column(), 0);
     EXPECT_EQ(expected_row2[1]->column(), 1);
+
+    // removing middle row
+    view_item.removeRow(1);
+    EXPECT_EQ(view_item.child(0, 0), expected_row0[0]);
+    EXPECT_EQ(view_item.child(0, 1), expected_row0[1]);
+    EXPECT_EQ(view_item.child(1, 0), expected_row1[0]);
+    EXPECT_EQ(view_item.child(1, 1), expected_row1[1]);
 }
 
 //! Clean item's children.

--- a/tests/testviewmodel/refviewitem.test.cpp
+++ b/tests/testviewmodel/refviewitem.test.cpp
@@ -30,6 +30,7 @@ TEST_F(RefViewItemTest, initialState)
 
     EXPECT_EQ(view_item.rowCount(), 0);
     EXPECT_EQ(view_item.columnCount(), 0);
+    EXPECT_EQ(view_item.parent(), nullptr);
     EXPECT_THROW(view_item.child(0, 0), std::runtime_error);
 }
 
@@ -49,33 +50,40 @@ TEST_F(RefViewItemTest, appendRow)
     EXPECT_EQ(view_item.columnCount(), 1);
     EXPECT_EQ(view_item.child(0, 0), expected);
     EXPECT_THROW(view_item.child(0, 1), std::runtime_error);
+    EXPECT_EQ(expected->parent(), &view_item);
 }
 
 //! Append two rows with two items each.
 
 TEST_F(RefViewItemTest, appendTwoRows)
 {
+    // preparing two rows of children, two columns each
     std::vector<std::unique_ptr<RefViewItem>> children_row0, children_row1, children_row2;
-
     children_row0.emplace_back(std::make_unique<RefViewItem>());
     children_row0.emplace_back(std::make_unique<RefViewItem>());
     children_row1.emplace_back(std::make_unique<RefViewItem>());
     children_row1.emplace_back(std::make_unique<RefViewItem>());
+    std::vector<RefViewItem*> expected_row0 = {children_row0[0].get(), children_row0[1].get()};
+    std::vector<RefViewItem*> expected_row1 = {children_row1[0].get(), children_row1[1].get()};
 
-    std::vector<RefViewItem*> expected0 = {children_row0[0].get(), children_row0[1].get()};
-    std::vector<RefViewItem*> expected1 = {children_row1[0].get(), children_row1[1].get()};
-
+    // appending rows
     RefViewItem view_item;
     view_item.appendRow(std::move(children_row0));
     view_item.appendRow(std::move(children_row1));
 
     EXPECT_EQ(view_item.rowCount(), 2);
     EXPECT_EQ(view_item.columnCount(), 2);
-    EXPECT_EQ(view_item.child(0, 0), expected0[0]);
-    EXPECT_EQ(view_item.child(0, 1), expected0[1]);
-    EXPECT_EQ(view_item.child(1, 0), expected1[0]);
-    EXPECT_EQ(view_item.child(1, 1), expected1[1]);
+    EXPECT_EQ(view_item.child(0, 0), expected_row0[0]);
+    EXPECT_EQ(view_item.child(0, 1), expected_row0[1]);
+    EXPECT_EQ(view_item.child(1, 0), expected_row1[0]);
+    EXPECT_EQ(view_item.child(1, 1), expected_row1[1]);
     EXPECT_THROW(view_item.child(2, 2), std::runtime_error);
+
+    // checking parents
+    EXPECT_EQ(expected_row0[0]->parent(), &view_item);
+    EXPECT_EQ(expected_row0[1]->parent(), &view_item);
+    EXPECT_EQ(expected_row1[0]->parent(), &view_item);
+    EXPECT_EQ(expected_row1[1]->parent(), &view_item);
 
     // attempt to add row with different amount of children should fail
     children_row2.emplace_back(std::make_unique<RefViewItem>());
@@ -84,7 +92,7 @@ TEST_F(RefViewItemTest, appendTwoRows)
     EXPECT_EQ(view_item.columnCount(), 2);
 }
 
-//! Append single item as row.
+//! Clean item's children.
 
 TEST_F(RefViewItemTest, clear)
 {

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -33,7 +33,9 @@ TEST_F(RefViewModelTest, initialState)
     EXPECT_EQ(viewmodel.columnCount(), 0);
     EXPECT_TRUE(viewmodel.rootItem() != nullptr);
     EXPECT_EQ(viewmodel.rootItem(), viewmodel.itemForIndex(QModelIndex()));
-    EXPECT_FALSE(viewmodel.index(0, 0, QModelIndex()).isValid());
+    auto non_existing_index = viewmodel.index(0, 0, QModelIndex());
+    EXPECT_FALSE(non_existing_index.isValid());
+    EXPECT_EQ(viewmodel.itemForIndex(non_existing_index), nullptr);
 }
 
 TEST_F(RefViewModelTest, appendRow)

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -25,5 +25,8 @@ RefViewModelTest::~RefViewModelTest() = default;
 TEST_F(RefViewModelTest, initialState)
 {
     RefViewModel viewmodel;
-    EXPECT_EQ(1, 1);
+    EXPECT_EQ(viewmodel.rowCount(), 0);
+    EXPECT_EQ(viewmodel.columnCount(), 0);
+    EXPECT_TRUE(viewmodel.rootItem() != nullptr);
+    EXPECT_EQ(viewmodel.rootItem(), viewmodel.itemForIndex(QModelIndex()));
 }

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -29,4 +29,5 @@ TEST_F(RefViewModelTest, initialState)
     EXPECT_EQ(viewmodel.columnCount(), 0);
     EXPECT_TRUE(viewmodel.rootItem() != nullptr);
     EXPECT_EQ(viewmodel.rootItem(), viewmodel.itemForIndex(QModelIndex()));
+    EXPECT_FALSE(viewmodel.index(0, 0, QModelIndex()).isValid());
 }

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -8,6 +8,8 @@
 // ************************************************************************** //
 
 #include "google_test.h"
+#include <QSignalSpy>
+#include <mvvm/viewmodel/refviewitem.h>
 #include <mvvm/viewmodel/refviewmodel.h>
 
 using namespace ModelView;
@@ -22,6 +24,8 @@ public:
 
 RefViewModelTest::~RefViewModelTest() = default;
 
+//! Initial state of empty RefViewModel.
+
 TEST_F(RefViewModelTest, initialState)
 {
     RefViewModel viewmodel;
@@ -30,4 +34,64 @@ TEST_F(RefViewModelTest, initialState)
     EXPECT_TRUE(viewmodel.rootItem() != nullptr);
     EXPECT_EQ(viewmodel.rootItem(), viewmodel.itemForIndex(QModelIndex()));
     EXPECT_FALSE(viewmodel.index(0, 0, QModelIndex()).isValid());
+}
+
+TEST_F(RefViewModelTest, appendRow)
+{
+    RefViewModel viewmodel;
+
+    // item to append
+    std::vector<std::unique_ptr<RefViewItem>> children;
+    children.emplace_back(std::make_unique<RefViewItem>());
+    RefViewItem* expected = children[0].get();
+
+    // appending one row
+    viewmodel.appendRow(QModelIndex(), std::move(children));
+    EXPECT_EQ(viewmodel.rowCount(), 1);
+    EXPECT_EQ(viewmodel.columnCount(), 1);
+
+    // constructing index for child
+    auto index = viewmodel.index(0, 0, QModelIndex());
+    EXPECT_EQ(index.row(), 0);
+    EXPECT_EQ(index.column(), 0);
+    EXPECT_EQ(index.model(), &viewmodel);
+
+    //  getting child from index
+    EXPECT_EQ(viewmodel.itemForIndex(index), expected);
+
+    // no grand-children
+    EXPECT_EQ(viewmodel.rowCount(index), 0);
+    EXPECT_EQ(viewmodel.columnCount(index), 0);
+}
+
+TEST_F(RefViewModelTest, rowsInserted)
+{
+    RefViewModel viewmodel;
+
+    // two items to append as a single row with two columns
+    std::vector<std::unique_ptr<RefViewItem>> children;
+    children.emplace_back(std::make_unique<RefViewItem>());
+    children.emplace_back(std::make_unique<RefViewItem>());
+    std::vector<RefViewItem*> expected = {children[0].get(), children[1].get()};
+
+    QSignalSpy spyInsert(&viewmodel, &RefViewModel::rowsInserted);
+
+    // appending one row
+    viewmodel.appendRow(QModelIndex(), std::move(children));
+    EXPECT_EQ(viewmodel.rowCount(), 1);
+    EXPECT_EQ(viewmodel.columnCount(), 2);
+
+    // checking that signaling is about the parent
+    EXPECT_EQ(spyInsert.count(), 1);
+    QList<QVariant> arguments = spyInsert.takeFirst();
+    EXPECT_EQ(arguments.size(), 3); // QModelIndex &parent, int first, int last
+    EXPECT_EQ(arguments.at(0).value<QModelIndex>(), QModelIndex());
+    EXPECT_EQ(arguments.at(1).value<int>(), 0);
+    EXPECT_EQ(arguments.at(2).value<int>(), 0);
+
+    //  getting child from index
+    auto index0 = viewmodel.index(0, 0, QModelIndex());
+    auto index1 = viewmodel.index(0, 1, QModelIndex());
+    EXPECT_EQ(viewmodel.itemForIndex(index0), expected[0]);
+    EXPECT_EQ(viewmodel.itemForIndex(index1), expected[1]);
 }

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -1,0 +1,29 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+#include <mvvm/viewmodel/refviewmodel.h>
+
+using namespace ModelView;
+
+//! Tests for RefViewModel class.
+
+class RefViewModelTest : public ::testing::Test
+{
+public:
+    ~RefViewModelTest();
+};
+
+RefViewModelTest::~RefViewModelTest() = default;
+
+TEST_F(RefViewModelTest, initialState)
+{
+    RefViewModel viewmodel;
+    EXPECT_EQ(1, 1);
+}

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -81,7 +81,7 @@ TEST_F(RefViewModelTest, appendRow)
     RefViewItem* expected = children[0].get();
 
     // appending one row
-    viewmodel.appendRow(QModelIndex(), std::move(children));
+    viewmodel.appendRow(viewmodel.rootItem(), std::move(children));
     EXPECT_EQ(viewmodel.rowCount(), 1);
     EXPECT_EQ(viewmodel.columnCount(), 1);
 
@@ -119,11 +119,11 @@ TEST_F(RefViewModelTest, appendRowToRow)
     std::vector<RefViewItem*> expected_row1 = {children_row1[0].get(), children_row1[1].get()};
 
     // appending rows to root
-    viewmodel.appendRow(QModelIndex(), std::move(children_row0));
+    viewmodel.appendRow(viewmodel.rootItem(), std::move(children_row0));
     // appending rows to row
     auto child0_index = viewmodel.index(0, 0, QModelIndex());
     auto child1_index = viewmodel.index(0, 1, QModelIndex());
-    viewmodel.appendRow(child0_index, std::move(children_row1));
+    viewmodel.appendRow(expected_row0[0], std::move(children_row1));
 
     // checking results
     EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 1);
@@ -157,7 +157,7 @@ TEST_F(RefViewModelTest, rowsInserted)
     QSignalSpy spyInsert(&viewmodel, &RefViewModel::rowsInserted);
 
     // appending one row
-    viewmodel.appendRow(QModelIndex(), std::move(children));
+    viewmodel.appendRow(viewmodel.rootItem(), std::move(children));
     EXPECT_EQ(viewmodel.rowCount(), 1);
     EXPECT_EQ(viewmodel.columnCount(), 2);
 

--- a/tests/testviewmodel/refviewmodel.test.cpp
+++ b/tests/testviewmodel/refviewmodel.test.cpp
@@ -68,6 +68,7 @@ TEST_F(RefViewModelTest, initialState)
     EXPECT_FALSE(non_existing_index.isValid());
     EXPECT_EQ(viewmodel.itemFromIndex(non_existing_index), nullptr);
     EXPECT_EQ(viewmodel.parent(QModelIndex()), QModelIndex());
+    EXPECT_EQ(viewmodel.indexFromItem(viewmodel.rootItem()), QModelIndex());
 }
 
 TEST_F(RefViewModelTest, appendRow)
@@ -89,6 +90,9 @@ TEST_F(RefViewModelTest, appendRow)
     EXPECT_EQ(child_index.row(), 0);
     EXPECT_EQ(child_index.column(), 0);
     EXPECT_EQ(child_index.model(), &viewmodel);
+
+    // indexFromItem
+    EXPECT_EQ(viewmodel.indexFromItem(expected), child_index);
 
     //  getting child from index
     EXPECT_EQ(viewmodel.itemFromIndex(child_index), expected);
@@ -117,20 +121,27 @@ TEST_F(RefViewModelTest, appendRowToRow)
     // appending rows to root
     viewmodel.appendRow(QModelIndex(), std::move(children_row0));
     // appending rows to row
-    auto parent_index = viewmodel.index(0, 0, QModelIndex());
-    viewmodel.appendRow(parent_index, std::move(children_row1));
+    auto child0_index = viewmodel.index(0, 0, QModelIndex());
+    auto child1_index = viewmodel.index(0, 1, QModelIndex());
+    viewmodel.appendRow(child0_index, std::move(children_row1));
 
     // checking results
     EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 1);
     EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 2);
-    EXPECT_EQ(viewmodel.rowCount(parent_index), 1);
-    EXPECT_EQ(viewmodel.columnCount(parent_index), 2);
+    EXPECT_EQ(viewmodel.rowCount(child0_index), 1);
+    EXPECT_EQ(viewmodel.columnCount(child0_index), 2);
 
     // checking parent index of children in second row
-    auto child0_index = viewmodel.index(0, 0, parent_index);
-    auto child1_index = viewmodel.index(0, 1, parent_index);
-    EXPECT_EQ(viewmodel.parent(child0_index), parent_index);
-    EXPECT_EQ(viewmodel.parent(child1_index), parent_index);
+    auto grandchild0_index = viewmodel.index(0, 0, child0_index);
+    auto grandchild1_index = viewmodel.index(0, 1, child0_index);
+    EXPECT_EQ(viewmodel.parent(grandchild0_index), child0_index);
+    EXPECT_EQ(viewmodel.parent(grandchild1_index), child0_index);
+
+    // index of item
+    EXPECT_EQ(viewmodel.indexFromItem(expected_row0[0]), child0_index);
+    EXPECT_EQ(viewmodel.indexFromItem(expected_row0[1]), child1_index);
+    EXPECT_EQ(viewmodel.indexFromItem(expected_row1[0]), grandchild0_index);
+    EXPECT_EQ(viewmodel.indexFromItem(expected_row1[1]), grandchild1_index);
 }
 
 TEST_F(RefViewModelTest, rowsInserted)


### PR DESCRIPTION
+ Intended to represent SessionModel in Qt's trees and tables. Will replace current QStandardItemModel-based view model.
+ For the moment only insert/remove parts is implemented.
+ Proxying to underlying SessionModel will be implemented in next requests.
