### PR TITLE
Quick simulation (part I)

### DIFF
--- a/examples/collidingmice/collidingmice/mouse.cpp
+++ b/examples/collidingmice/collidingmice/mouse.cpp
@@ -57,10 +57,7 @@
 #include <cmath>
 #include <mvvm/signals/itemmapper.h>
 #include <mvvm/utils/numericutils.h>
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+#include <mvvm/utils/mathconstants.h>
 
 const qreal Pi = M_PI;
 const qreal TwoPi = 2 * M_PI;

--- a/examples/quickrefl/core/CMakeLists.txt
+++ b/examples/quickrefl/core/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(editors/sldeditor/models)
 add_subdirectory(editors/sldeditor/scene)
 add_subdirectory(editors/sldeditor/viewobjects)
 add_subdirectory(editors/sldeditor/widgets)
+add_subdirectory(editors/quicksimeditor)
 add_subdirectory(resources)
 
 target_link_libraries(${library_name} PUBLIC mvvm_viewmodel Qt5::Core Qt5::Gui Qt5::Widgets)

--- a/examples/quickrefl/core/editors/layereditor/layereditor.cpp
+++ b/examples/quickrefl/core/editors/layereditor/layereditor.cpp
@@ -12,6 +12,7 @@
 #include "layereditoractions.h"
 #include "layereditortoolbar.h"
 #include "layereditorwidget.h"
+#include "styleutils.h"
 #include <QVBoxLayout>
 
 LayerEditor::LayerEditor(ApplicationModels* models, QWidget* parent)
@@ -26,6 +27,16 @@ LayerEditor::LayerEditor(ApplicationModels* models, QWidget* parent)
     setLayout(layout);
 
     actions->setSelectionModel(editor_widget->selectionModel());
+}
+
+QSize LayerEditor::sizeHint() const
+{
+    return StyleUtils::DockSizeHint();
+}
+
+QSize LayerEditor::minimumSizeHint() const
+{
+    return StyleUtils::DockMinimumSizeHint();
 }
 
 LayerEditor::~LayerEditor() = default;

--- a/examples/quickrefl/core/editors/layereditor/layereditor.h
+++ b/examples/quickrefl/core/editors/layereditor/layereditor.h
@@ -31,6 +31,9 @@ public:
     LayerEditor(ApplicationModels* models, QWidget* parent = nullptr);
     ~LayerEditor();
 
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
 private:
     LayerEditorActions* actions{nullptr};
     LayerEditorToolBar* toolbar{nullptr};

--- a/examples/quickrefl/core/editors/materialeditor/materialeditor.cpp
+++ b/examples/quickrefl/core/editors/materialeditor/materialeditor.cpp
@@ -12,6 +12,7 @@
 #include "materialeditortoolbar.h"
 #include "materialeditorwidget.h"
 #include "materialmodel.h"
+#include "styleutils.h"
 #include <QVBoxLayout>
 
 MaterialEditor::MaterialEditor(MaterialModel* material_model, QWidget* parent)
@@ -28,6 +29,16 @@ MaterialEditor::MaterialEditor(MaterialModel* material_model, QWidget* parent)
     setLayout(layout);
 
     actions->setMaterialSelectionModel(editor_widget->selectionModel());
+}
+
+QSize MaterialEditor::sizeHint() const
+{
+    return StyleUtils::DockSizeHint();
+}
+
+QSize MaterialEditor::minimumSizeHint() const
+{
+    return StyleUtils::DockMinimumSizeHint();
 }
 
 MaterialEditor::~MaterialEditor() = default;

--- a/examples/quickrefl/core/editors/materialeditor/materialeditor.h
+++ b/examples/quickrefl/core/editors/materialeditor/materialeditor.h
@@ -31,6 +31,9 @@ public:
     MaterialEditor(MaterialModel* material_model, QWidget* parent = nullptr);
     ~MaterialEditor();
 
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
 private:
     MaterialModel* material_model{nullptr};
     MaterialEditorActions* actions{nullptr};

--- a/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
+++ b/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Static library: quickreflcore.
+
+target_sources(quickreflcore PRIVATE
+    quicksimeditor.cpp
+    quicksimeditor.h
+)
+
+target_include_directories(quickreflcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)

--- a/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
+++ b/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Static library: quickreflcore.
 
 target_sources(quickreflcore PRIVATE
+    materialprofile.cpp
+    materialprofile.h
     quicksimcontroller.cpp
     quicksimcontroller.h
     quicksimeditor.cpp

--- a/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
+++ b/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
@@ -3,10 +3,13 @@
 target_sources(quickreflcore PRIVATE
     materialprofile.cpp
     materialprofile.h
+    profilehelper.cpp
+    profilehelper.h
     quicksimcontroller.cpp
     quicksimcontroller.h
     quicksimeditor.cpp
     quicksimeditor.h
+    slice.h
     speculartoysimulation.cpp
     speculartoysimulation.h
 )

--- a/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
+++ b/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Static library: quickreflcore.
 
 target_sources(quickreflcore PRIVATE
-    quicksimeditor.cpp
-    quicksimeditor.h
     quicksimcontroller.cpp
     quicksimcontroller.h
+    quicksimeditor.cpp
+    quicksimeditor.h
+    speculartoysimulation.cpp
+    speculartoysimulation.h
 )
 
 target_include_directories(quickreflcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)

--- a/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
+++ b/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(quickreflcore PRIVATE
     slice.h
     speculartoysimulation.cpp
     speculartoysimulation.h
+    quicksimutils.cpp
+    quicksimutils.h
 )
 
 target_include_directories(quickreflcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)

--- a/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
+++ b/examples/quickrefl/core/editors/quicksimeditor/CMakeLists.txt
@@ -3,6 +3,8 @@
 target_sources(quickreflcore PRIVATE
     quicksimeditor.cpp
     quicksimeditor.h
+    quicksimcontroller.cpp
+    quicksimcontroller.h
 )
 
 target_include_directories(quickreflcore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)

--- a/examples/quickrefl/core/editors/quicksimeditor/materialprofile.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/materialprofile.cpp
@@ -8,4 +8,32 @@
 // ************************************************************************** //
 
 #include "materialprofile.h"
+#include "profilehelper.h"
 
+std::vector<complex_t>
+MaterialProfile::CalculateProfile(const multislice_t& multilayer, int n_points,
+                                  double z_min, double z_max)
+{
+    ProfileHelper helper(multilayer);
+    std::vector<double> z_values = GenerateZValues(n_points, z_min, z_max);
+    return helper.calculateProfile(z_values);
+}
+
+std::pair<double, double>
+MaterialProfile::DefaultMaterialProfileLimits(const multislice_t &multilayer)
+{
+    ProfileHelper helper(multilayer);
+    return helper.defaultLimits();
+}
+
+std::vector<double> MaterialProfile::GenerateZValues(int n_points, double z_min, double z_max)
+{
+    std::vector<double> result;
+    if (n_points < 1)
+        return result;
+    double step = n_points > 1 ? (z_max - z_min) / (n_points - 1) : 0.0;
+    for (int i = 0; i < n_points; ++i) {
+        result.push_back(z_min + i * step);
+    }
+    return result;
+}

--- a/examples/quickrefl/core/editors/quicksimeditor/materialprofile.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/materialprofile.cpp
@@ -1,0 +1,11 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "materialprofile.h"
+

--- a/examples/quickrefl/core/editors/quicksimeditor/materialprofile.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/materialprofile.h
@@ -1,0 +1,27 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MATERIALPROFILE_H
+#define MATERIALPROFILE_H
+
+//! Collection of methods borrowed from BornAgain for material profile calculations.
+
+namespace MaterialProfile
+{
+
+//! Layer parameters. Data structure to feed simulation with input parameters.
+struct Slice {
+    double sld_real{0.0};
+    double thickness{0.0};
+    double top_sigma{0.0};
+};
+
+} // namespace MaterialProfile
+
+#endif

--- a/examples/quickrefl/core/editors/quicksimeditor/materialprofile.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/materialprofile.h
@@ -10,17 +10,22 @@
 #ifndef MATERIALPROFILE_H
 #define MATERIALPROFILE_H
 
+#include "slice.h"
+
 //! Collection of methods borrowed from BornAgain for material profile calculations.
 
 namespace MaterialProfile
 {
 
-//! Layer parameters. Data structure to feed simulation with input parameters.
-struct Slice {
-    double sld_real{0.0};
-    double thickness{0.0};
-    double top_sigma{0.0};
-};
+//! Calculate average material profile for given multilayer
+std::vector<complex_t> CalculateProfile(const multislice_t& multilayer, int n_points, double z_min,
+                                        double z_max);
+
+//! Get default z limits for generating a material profile
+std::pair<double, double> DefaultMaterialProfileLimits(const multislice_t& multilayer);
+
+//! Generate z values (equidistant) for use in MaterialProfile
+std::vector<double> GenerateZValues(int n_points, double z_min, double z_max);
 
 } // namespace MaterialProfile
 

--- a/examples/quickrefl/core/editors/quicksimeditor/profilehelper.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/profilehelper.cpp
@@ -14,6 +14,9 @@
 
 #include "profilehelper.h"
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 namespace
 {
 const double prefactor = std::sqrt(2.0 / M_PI);

--- a/examples/quickrefl/core/editors/quicksimeditor/profilehelper.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/profilehelper.cpp
@@ -13,9 +13,7 @@
 // ************************************************************************** //
 
 #include "profilehelper.h"
-
-#define _USE_MATH_DEFINES
-#include <cmath>
+#include <mvvm/utils/mathconstants.h>
 
 namespace
 {

--- a/examples/quickrefl/core/editors/quicksimeditor/profilehelper.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/profilehelper.cpp
@@ -1,0 +1,88 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Computation/ProfileHelper.cpp
+//! @brief     Implements class ProfileHelper.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "profilehelper.h"
+
+namespace
+{
+const double prefactor = std::sqrt(2.0 / M_PI);
+double Transition(double x, double sigma);
+double TransitionTanh(double x);
+} // namespace
+
+ProfileHelper::ProfileHelper(const multislice_t& sample)
+{
+    auto N = sample.size();
+    m_materialdata.reserve(N);
+    if (N > 1) {
+        m_zlimits.reserve(N - 1);
+        m_sigmas.reserve(N - 1);
+    }
+    double bottom_z{0};
+    for (size_t i = 0; i < N; ++i) {
+        m_materialdata.push_back(sample[i].material);
+        if (i + 1 < N) {
+            m_zlimits.push_back(bottom_z);
+            m_sigmas.push_back(sample[i + 1].sigma);
+        }
+        bottom_z += sample[i].thickness;
+    }
+}
+
+// Note: for refractive index materials, the material interpolation actually happens at the level
+// of n^2. To first order in delta and beta, this implies the same smooth interpolation of delta
+// and beta, as is done here.
+std::vector<complex_t> ProfileHelper::calculateProfile(const std::vector<double>& z_values) const
+{
+    complex_t top_value = m_materialdata.size() ? m_materialdata[0] : 0.0;
+    std::vector<complex_t> result(z_values.size(), top_value);
+    for (size_t i = 0; i < m_zlimits.size(); ++i) {
+        auto sld_diff = m_materialdata[i + 1] - m_materialdata[i];
+        for (size_t j = 0; j < z_values.size(); ++j) {
+            auto arg = (z_values[j] - m_zlimits[i]);
+            auto t = Transition(arg, m_sigmas[i]);
+            result[j] += sld_diff * t;
+        }
+    }
+    return result;
+}
+
+std::pair<double, double> ProfileHelper::defaultLimits() const
+{
+    if (m_zlimits.size() < 1)
+        return {0.0, 0.0};
+    double interface_span = m_zlimits.front() - m_zlimits.back();
+    double default_margin = interface_span > 0.0 ? interface_span / 20.0 : 10.0;
+    double top_margin = m_sigmas.front() > 0.0 ? 5.0 * m_sigmas.front() : default_margin;
+    double bottom_margin = m_sigmas.back() > 0.0 ? 5.0 * m_sigmas.back() : default_margin;
+    double z_min = m_zlimits.back() - bottom_margin;
+    double z_max = m_zlimits.front() + top_margin;
+    return {z_min, z_max};
+}
+
+ProfileHelper::~ProfileHelper() = default;
+
+namespace
+{
+double Transition(double x, double sigma)
+{
+    if (sigma <= 0.0)
+        return x < 0.0 ? 1.0 : 0.0;
+    return TransitionTanh(x / sigma);
+}
+double TransitionTanh(double x)
+{
+    return (1.0 - std::tanh(prefactor * x)) / 2.0;
+}
+} // namespace

--- a/examples/quickrefl/core/editors/quicksimeditor/profilehelper.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/profilehelper.h
@@ -1,0 +1,37 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef PROFILEHELPER_H
+#define PROFILEHELPER_H
+
+#include <utility>
+#include <vector>
+
+#include "slice.h"
+
+//! Object that can generate the material profile of a sample as a function of depth.
+
+class ProcessedSample;
+
+class ProfileHelper
+{
+public:
+    ProfileHelper(const multislice_t& sample);
+    ~ProfileHelper();
+
+    std::vector<complex_t> calculateProfile(const std::vector<double>& z_values) const;
+    std::pair<double, double> defaultLimits() const;
+
+private:
+    std::vector<complex_t> m_materialdata;
+    std::vector<double> m_zlimits;
+    std::vector<double> m_sigmas;
+};
+
+#endif // PROFILEHELPER_H

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimcontroller.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimcontroller.cpp
@@ -1,0 +1,86 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "quicksimcontroller.h"
+#include "applicationmodels.h"
+#include "materialmodel.h"
+#include "samplemodel.h"
+#include <QDebug>
+#include <mvvm/signals/modelmapper.h>
+
+using namespace ModelView;
+
+QuickSimController::QuickSimController(ApplicationModels* app_models, JobModel* job_model,
+                                       QObject* parent)
+    : QObject(parent), sample_model(app_models->sampleModel()),
+      material_model(app_models->materialModel()), job_model(job_model)
+{
+    setup_models_tracking();
+}
+
+QuickSimController::~QuickSimController()
+{
+    if (material_model)
+        material_model->mapper()->unsubscribe(this);
+    if (sample_model)
+        sample_model->mapper()->unsubscribe(this);
+}
+
+//! Submits simulation job.
+
+void QuickSimController::onModelChange()
+{
+    qDebug() << "onModelChange";
+    update_sld_profile();
+    submit_specular_simulation();
+}
+
+//! Setups tracking of SampleModel and MaterialModel.
+
+void QuickSimController::setup_models_tracking()
+{
+    // Setup MaterialModel
+    {
+        auto on_data_change = [this](SessionItem*, int) { onModelChange(); };
+        material_model->mapper()->setOnDataChange(on_data_change, this);
+
+        auto on_item_removed = [this](SessionItem*, TagRow) { onModelChange(); };
+        material_model->mapper()->setOnItemRemoved(on_item_removed, this);
+
+        auto on_model_destroyed = [this](SessionModel*) { material_model = nullptr; };
+        material_model->mapper()->setOnModelDestroyed(on_model_destroyed, this);
+    }
+
+    // Setup SampleModel
+    {
+        auto on_data_change = [this](SessionItem*, int) { onModelChange(); };
+        sample_model->mapper()->setOnDataChange(on_data_change, this);
+
+        auto on_item_removed = [this](SessionItem*, TagRow) { onModelChange(); };
+        sample_model->mapper()->setOnItemRemoved(on_item_removed, this);
+
+        auto on_model_destroyed = [this](SessionModel*) { sample_model = nullptr; };
+        sample_model->mapper()->setOnModelDestroyed(on_model_destroyed, this);
+    }
+
+}
+
+//! Performs update of sld profile for immediate plotting.
+
+void QuickSimController::update_sld_profile()
+{
+    // TODO
+}
+
+//! Submit data to JobManager for consequent specular simulation.
+
+void QuickSimController::submit_specular_simulation()
+{
+    // TODO
+}

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimcontroller.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimcontroller.h
@@ -1,0 +1,48 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef QUICKSIMCONTROLLER_H
+#define QUICKSIMCONTROLLER_H
+
+#include <QObject>
+#include <memory>
+
+class ApplicationModels;
+class MaterialModel;
+class SampleModel;
+class JobModel;
+
+//! Provides quick reflectometry simulations on any change of SampleModel and MaterialModel.
+//! Listens for any change in SampleModel and MaterialModel, extracts the data needed for
+//! the simulation, and then submit simulation request to JobManager. As soon as JobManager reports
+//! about completed simulations, extract results from there and put them into JobModel.
+
+class QuickSimController : public QObject
+{
+    Q_OBJECT
+public:
+    // TODO Move JobModel into ApplicationModels
+    QuickSimController(ApplicationModels* app_models, JobModel* job_model,
+                       QObject* parent = nullptr);
+    ~QuickSimController();
+
+private slots:
+    void onModelChange();
+
+private:
+    void setup_models_tracking();
+    void update_sld_profile();
+    void submit_specular_simulation();
+
+    SampleModel* sample_model{nullptr};
+    MaterialModel* material_model{nullptr};
+    JobModel* job_model{nullptr};
+};
+
+#endif // QUICKSIMCONTROLLER_H

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
@@ -1,0 +1,26 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "quicksimeditor.h"
+#include "styleutils.h"
+
+QuickSimEditor::QuickSimEditor(QWidget* parent) : QWidget(parent)
+{
+    setWindowTitle(QString("Reflectivity plot"));
+}
+
+QSize QuickSimEditor::sizeHint() const
+{
+    return StyleUtils::DockSizeHint();
+}
+
+QSize QuickSimEditor::minimumSizeHint() const
+{
+    return StyleUtils::DockMinimumSizeHint();
+}

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
@@ -9,10 +9,16 @@
 
 #include "quicksimeditor.h"
 #include "styleutils.h"
+#include <QVBoxLayout>
+#include <mvvm/plotting/graphcanvas.h>
 
-QuickSimEditor::QuickSimEditor(QWidget* parent) : QWidget(parent)
+QuickSimEditor::QuickSimEditor(QWidget* parent)
+    : QWidget(parent), graph_canvas(new ModelView::GraphCanvas)
 {
     setWindowTitle(QString("Reflectivity plot"));
+    auto layout = new QVBoxLayout;
+    layout->addWidget(graph_canvas);
+    setLayout(layout);
 }
 
 QSize QuickSimEditor::sizeHint() const

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
@@ -8,18 +8,22 @@
 // ************************************************************************** //
 
 #include "quicksimeditor.h"
+#include "jobmodel.h"
 #include "styleutils.h"
 #include <QVBoxLayout>
 #include <mvvm/plotting/graphcanvas.h>
 
 QuickSimEditor::QuickSimEditor(QWidget* parent)
-    : QWidget(parent), graph_canvas(new ModelView::GraphCanvas)
+    : QWidget(parent), job_model(std::make_unique<JobModel>()),
+      graph_canvas(new ModelView::GraphCanvas)
 {
     setWindowTitle(QString("Reflectivity plot"));
     auto layout = new QVBoxLayout;
     layout->addWidget(graph_canvas);
     setLayout(layout);
 }
+
+QuickSimEditor::~QuickSimEditor() = default;
 
 QSize QuickSimEditor::sizeHint() const
 {

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
@@ -11,6 +11,7 @@
 #include "jobmodel.h"
 #include "styleutils.h"
 #include "applicationmodels.h"
+#include "quicksimcontroller.h"
 #include <QVBoxLayout>
 #include <mvvm/model/modelutils.h>
 #include <mvvm/plotting/graphcanvas.h>
@@ -20,6 +21,7 @@ using namespace ModelView;
 
 QuickSimEditor::QuickSimEditor(ApplicationModels* app_models, QWidget* parent)
     : QWidget(parent), app_models(app_models), job_model(std::make_unique<JobModel>()),
+      sim_controller(new QuickSimController(app_models, job_model.get(), this)),
       graph_canvas(new ModelView::GraphCanvas)
 {
     setWindowTitle(QString("Reflectivity plot"));

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.cpp
@@ -10,17 +10,24 @@
 #include "quicksimeditor.h"
 #include "jobmodel.h"
 #include "styleutils.h"
+#include "applicationmodels.h"
 #include <QVBoxLayout>
+#include <mvvm/model/modelutils.h>
 #include <mvvm/plotting/graphcanvas.h>
+#include <mvvm/standarditems/graphviewportitem.h>
 
-QuickSimEditor::QuickSimEditor(QWidget* parent)
-    : QWidget(parent), job_model(std::make_unique<JobModel>()),
+using namespace ModelView;
+
+QuickSimEditor::QuickSimEditor(ApplicationModels* app_models, QWidget* parent)
+    : QWidget(parent), app_models(app_models), job_model(std::make_unique<JobModel>()),
       graph_canvas(new ModelView::GraphCanvas)
 {
     setWindowTitle(QString("Reflectivity plot"));
     auto layout = new QVBoxLayout;
     layout->addWidget(graph_canvas);
     setLayout(layout);
+
+    graph_canvas->setItem(Utils::TopItem<GraphViewportItem>(job_model.get()));
 }
 
 QuickSimEditor::~QuickSimEditor() = default;

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
@@ -11,11 +11,14 @@
 #define QUICKSIMEDITOR_H
 
 #include <QWidget>
+#include <memory>
 
 namespace ModelView
 {
 class GraphCanvas;
 }
+
+class JobModel;
 
 //! Quick reflectivity simulations.
 
@@ -24,11 +27,13 @@ class QuickSimEditor : public QWidget
     Q_OBJECT
 public:
     QuickSimEditor(QWidget* parent = nullptr);
+    ~QuickSimEditor();
 
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
 private:
+    std::unique_ptr<JobModel> job_model;
     ModelView::GraphCanvas* graph_canvas{nullptr};
 };
 

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
@@ -1,0 +1,27 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef QUICKSIMEDITOR_H
+#define QUICKSIMEDITOR_H
+
+#include <QWidget>
+
+//! Quick reflectivity simulations.
+
+class QuickSimEditor : public QWidget
+{
+    Q_OBJECT
+public:
+    QuickSimEditor(QWidget* parent = nullptr);
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+};
+
+#endif // QUICKSIMEDITOR_H

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
@@ -19,6 +19,7 @@ class GraphCanvas;
 }
 
 class JobModel;
+class ApplicationModels;
 
 //! Quick reflectivity simulations.
 
@@ -26,13 +27,14 @@ class QuickSimEditor : public QWidget
 {
     Q_OBJECT
 public:
-    QuickSimEditor(QWidget* parent = nullptr);
+    QuickSimEditor(ApplicationModels* app_models, QWidget* parent = nullptr);
     ~QuickSimEditor();
 
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
 
 private:
+    ApplicationModels* app_models{nullptr};
     std::unique_ptr<JobModel> job_model;
     ModelView::GraphCanvas* graph_canvas{nullptr};
 };

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
@@ -20,6 +20,7 @@ class GraphCanvas;
 
 class JobModel;
 class ApplicationModels;
+class QuickSimController;
 
 //! Quick reflectivity simulations.
 
@@ -36,6 +37,7 @@ public:
 private:
     ApplicationModels* app_models{nullptr};
     std::unique_ptr<JobModel> job_model;
+    QuickSimController* sim_controller{nullptr};
     ModelView::GraphCanvas* graph_canvas{nullptr};
 };
 

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimeditor.h
@@ -12,6 +12,11 @@
 
 #include <QWidget>
 
+namespace ModelView
+{
+class GraphCanvas;
+}
+
 //! Quick reflectivity simulations.
 
 class QuickSimEditor : public QWidget
@@ -22,6 +27,9 @@ public:
 
     QSize sizeHint() const override;
     QSize minimumSizeHint() const override;
+
+private:
+    ModelView::GraphCanvas* graph_canvas{nullptr};
 };
 
 #endif // QUICKSIMEDITOR_H

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.cpp
@@ -1,0 +1,38 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "quicksimutils.h"
+#include "item_constants.h"
+#include "layeritems.h"
+#include "materialitems.h"
+#include <mvvm/model/externalproperty.h>
+#include <mvvm/model/sessionmodel.h>
+
+multislice_t Utils::CreateMultiSlice(const MultiLayerItem& multilayer)
+{
+    multislice_t result;
+    for (const auto& layer : multilayer.items<LayerItem>(MultiLayerItem::T_LAYERS)) {
+        if (layer->modelType() != Constants::LayerItemType)
+            throw std::runtime_error("Currently supports layers only. FIXME");
+
+        double thickness = layer->property(LayerItem::P_THICKNESS).value<double>();
+        auto roughness = layer->item<RoughnessItem>(LayerItem::P_ROUGHNESS);
+        double sigma = roughness->property(RoughnessItem::P_SIGMA).value<double>();
+
+        auto material = multilayer.model()->findItem(layer->property(LayerItem::P_MATERIAL)
+                                                         .value<ModelView::ExternalProperty>()
+                                                         .identifier());
+        double sld_real = material->property(SLDMaterialItem::P_SLD_REAL).value<double>();
+        double sld_imag = material->property(SLDMaterialItem::P_SLD_IMAG).value<double>();
+
+        result.push_back({complex_t{sld_real, sld_imag}, thickness, sigma});
+    }
+
+    return result;
+}

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.cpp
@@ -28,8 +28,8 @@ multislice_t Utils::CreateMultiSlice(const MultiLayerItem& multilayer)
         auto material = multilayer.model()->findItem(layer->property(LayerItem::P_MATERIAL)
                                                          .value<ModelView::ExternalProperty>()
                                                          .identifier());
-        double sld_real = material->property(SLDMaterialItem::P_SLD_REAL).value<double>();
-        double sld_imag = material->property(SLDMaterialItem::P_SLD_IMAG).value<double>();
+        double sld_real = material ? material->property(SLDMaterialItem::P_SLD_REAL).value<double>() : 0.0;
+        double sld_imag = material ? material->property(SLDMaterialItem::P_SLD_IMAG).value<double>() : 0.0;
 
         result.push_back({complex_t{sld_real, sld_imag}, thickness, sigma});
     }

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.h
@@ -1,0 +1,25 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef QUICKSIMUTILS_H
+#define QUICKSIMUTILS_H
+
+#include "slice.h"
+class MultiLayerItem;
+
+//! Collection of utility funcitons for running quick simulations.
+namespace Utils
+{
+
+//! Creates multi-slice presentation of internal layers structure.
+multislice_t CreateMultiSlice(const MultiLayerItem& multilayer);
+
+} // namespace Utils
+
+#endif // QUICKSIMUTILS_H

--- a/examples/quickrefl/core/editors/quicksimeditor/slice.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/slice.h
@@ -1,0 +1,27 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef SLICE_H
+#define SLICE_H
+
+#include <complex>
+#include <vector>
+
+using complex_t = std::complex<double>;
+
+//! Data structure for simple multilayer representation.
+struct Slice {
+    complex_t material;
+    double thickness{0.0};
+    double sigma{0.0}; // top interface sigma
+};
+
+using multislice_t = std::vector<Slice>;
+
+#endif //  SLICE_H

--- a/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.cpp
@@ -11,18 +11,36 @@
 
 namespace
 {
+const int sld_points_count = 400;
 const int simulation_steps_count = 100;
 }
 
 using namespace ModelView;
 
-SpecularToySimulation::SpecularToySimulation(const SpecularToySimulation::multilayer_t& input_data)
+SpecularToySimulation::SpecularToySimulation(const multilayer_t &input_data)
     : input_data(input_data)
 {
+}
+
+void SpecularToySimulation::runSimulation()
+{
+    // TODO
 }
 
 void SpecularToySimulation::setProgressCallback(ModelView::ProgressHandler::callback_t callback)
 {
     progress_handler.setMaxTicksCount(simulation_steps_count);
     progress_handler.subscribe(callback);
+}
+
+SpecularToySimulation::Result SpecularToySimulation::simulationResult() const
+{
+    return sld_profile;
+}
+
+//! Calculates
+
+void SpecularToySimulation::calculate_sld_profile()
+{
+
 }

--- a/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.cpp
@@ -17,7 +17,7 @@ const int simulation_steps_count = 100;
 
 using namespace ModelView;
 
-SpecularToySimulation::SpecularToySimulation(const multilayer_t &input_data)
+SpecularToySimulation::SpecularToySimulation(const multislice_t &input_data)
     : input_data(input_data)
 {
 }

--- a/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.cpp
@@ -1,0 +1,28 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "speculartoysimulation.h"
+
+namespace
+{
+const int simulation_steps_count = 100;
+}
+
+using namespace ModelView;
+
+SpecularToySimulation::SpecularToySimulation(const SpecularToySimulation::multilayer_t& input_data)
+    : input_data(input_data)
+{
+}
+
+void SpecularToySimulation::setProgressCallback(ModelView::ProgressHandler::callback_t callback)
+{
+    progress_handler.setMaxTicksCount(simulation_steps_count);
+    progress_handler.subscribe(callback);
+}

--- a/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.h
@@ -1,0 +1,39 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef SPECULARTOYSIMULATION_H
+#define SPECULARTOYSIMULATION_H
+
+#include <mvvm/utils/progresshandler.h>
+#include <vector>
+
+//! Toy simulation to calculate "specular reflectivity.
+//! Used by JobManager to run simulation in mylti-threaded mode.
+
+class SpecularToySimulation
+{
+public:
+    //! Layer parameters. Data structure to feed simulation with input parameters.
+    struct Slice {
+        double sld_real{0.0};
+        double thickness{0.0};
+    };
+
+    using multilayer_t = std::vector<Slice>;
+
+    SpecularToySimulation(const multilayer_t& input_data);
+
+    void setProgressCallback(ModelView::ProgressHandler::callback_t callback);
+
+private:
+    ModelView::ProgressHandler progress_handler;
+    multilayer_t input_data;
+};
+
+#endif // SPECULARTOYSIMULATION_H

--- a/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.h
@@ -12,6 +12,7 @@
 
 #include <mvvm/utils/progresshandler.h>
 #include <vector>
+#include "materialprofile.h"
 
 //! Toy simulation to calculate "specular reflectivity.
 //! Used by JobManager to run simulation in mylti-threaded mode.
@@ -19,21 +20,30 @@
 class SpecularToySimulation
 {
 public:
-    //! Layer parameters. Data structure to feed simulation with input parameters.
-    struct Slice {
-        double sld_real{0.0};
-        double thickness{0.0};
-    };
+    //! Data structure representing multi layer.
+    using multilayer_t = std::vector<MaterialProfile::Slice>;
 
-    using multilayer_t = std::vector<Slice>;
+    //! Represents results of the simulation.
+    struct Result {
+        double xmin{0.0};
+        double xmax{5.0};
+        std::vector<double> data;
+    };
 
     SpecularToySimulation(const multilayer_t& input_data);
 
+    void runSimulation();
+
     void setProgressCallback(ModelView::ProgressHandler::callback_t callback);
 
+    Result simulationResult() const;
+
 private:
+    void calculate_sld_profile();
+
     ModelView::ProgressHandler progress_handler;
     multilayer_t input_data;
+    Result sld_profile;
 };
 
 #endif // SPECULARTOYSIMULATION_H

--- a/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.h
+++ b/examples/quickrefl/core/editors/quicksimeditor/speculartoysimulation.h
@@ -20,9 +20,6 @@
 class SpecularToySimulation
 {
 public:
-    //! Data structure representing multi layer.
-    using multilayer_t = std::vector<MaterialProfile::Slice>;
-
     //! Represents results of the simulation.
     struct Result {
         double xmin{0.0};
@@ -30,7 +27,7 @@ public:
         std::vector<double> data;
     };
 
-    SpecularToySimulation(const multilayer_t& input_data);
+    SpecularToySimulation(const multislice_t& input_data);
 
     void runSimulation();
 
@@ -42,7 +39,7 @@ private:
     void calculate_sld_profile();
 
     ModelView::ProgressHandler progress_handler;
-    multilayer_t input_data;
+    multislice_t input_data;
     Result sld_profile;
 };
 

--- a/examples/quickrefl/core/mainwindow/CMakeLists.txt
+++ b/examples/quickrefl/core/mainwindow/CMakeLists.txt
@@ -3,6 +3,8 @@
 target_sources(quickreflcore PRIVATE
     mainwindow.cpp
     mainwindow.h
+    mainbarwidget.cpp
+    mainbarwidget.h
     refldockwindow.cpp
     refldockwindow.h
     dockscontroller.cpp

--- a/examples/quickrefl/core/mainwindow/mainbarwidget.cpp
+++ b/examples/quickrefl/core/mainwindow/mainbarwidget.cpp
@@ -9,9 +9,13 @@
 
 #include "mainbarwidget.h"
 #include <QHBoxLayout>
-#include <QVBoxLayout>
-#include <QStackedWidget>
 #include <QPushButton>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+namespace {
+const int buttonHeight = 60;
+}
 
 MainBarWidget::MainBarWidget(QWidget* parent)
     : QWidget(parent), stacked_widget(new QStackedWidget), button_layout(new QHBoxLayout)
@@ -31,16 +35,25 @@ MainBarWidget::~MainBarWidget() = default;
 void MainBarWidget::addWidget(QWidget* widget, const QString& title)
 {
     auto button = new QPushButton(title);
+    button->setMinimumHeight(buttonHeight);
+
+    QFont font = button->font();
+    font.setPointSize(font.pointSize()*1.25);
+    button->setFont(font);
+
     int index = stacked_widget->addWidget(widget);
-    auto on_button_pressed = [this, index]() {
-        stacked_widget->setCurrentIndex(index);
-    };
+    auto on_button_pressed = [this, index]() { stacked_widget->setCurrentIndex(index); };
     connect(button, &QPushButton::pressed, on_button_pressed);
 
     button_layout->addWidget(button);
+    index_to_button[index] = button;
 }
 
 void MainBarWidget::setCurrentIndex(int index)
 {
-    stacked_widget->setCurrentIndex(index);
+    auto it = index_to_button.find(index);
+    if (it != index_to_button.end()) {
+        auto button = it->second;
+        button->pressed();
+    }
 }

--- a/examples/quickrefl/core/mainwindow/mainbarwidget.cpp
+++ b/examples/quickrefl/core/mainwindow/mainbarwidget.cpp
@@ -1,0 +1,46 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "mainbarwidget.h"
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QStackedWidget>
+#include <QPushButton>
+
+MainBarWidget::MainBarWidget(QWidget* parent)
+    : QWidget(parent), stacked_widget(new QStackedWidget), button_layout(new QHBoxLayout)
+{
+    button_layout->setContentsMargins(0, 0, 0, 0);
+
+    auto layout = new QVBoxLayout;
+    layout->addLayout(button_layout);
+    layout->addWidget(stacked_widget);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    setLayout(layout);
+}
+
+MainBarWidget::~MainBarWidget() = default;
+
+void MainBarWidget::addWidget(QWidget* widget, const QString& title)
+{
+    auto button = new QPushButton(title);
+    int index = stacked_widget->addWidget(widget);
+    auto on_button_pressed = [this, index]() {
+        stacked_widget->setCurrentIndex(index);
+    };
+    connect(button, &QPushButton::pressed, on_button_pressed);
+
+    button_layout->addWidget(button);
+}
+
+void MainBarWidget::setCurrentIndex(int index)
+{
+    stacked_widget->setCurrentIndex(index);
+}

--- a/examples/quickrefl/core/mainwindow/mainbarwidget.h
+++ b/examples/quickrefl/core/mainwindow/mainbarwidget.h
@@ -1,0 +1,36 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MAINBARWIDGET_H
+#define MAINBARWIDGET_H
+
+#include <QWidget>
+class QStackedWidget;
+class QHBoxLayout;
+
+//! Main window with button-bar on top and stacked widget at bottom.
+
+class MainBarWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    MainBarWidget(QWidget* parent = nullptr);
+    ~MainBarWidget();
+
+    void addWidget(QWidget* widget, const QString& title);
+
+    void setCurrentIndex(int index);
+
+private:
+    QStackedWidget* stacked_widget{nullptr};
+    QHBoxLayout* button_layout{nullptr};
+};
+
+#endif // MAINBARWIDGET_H

--- a/examples/quickrefl/core/mainwindow/mainbarwidget.h
+++ b/examples/quickrefl/core/mainwindow/mainbarwidget.h
@@ -11,10 +11,13 @@
 #define MAINBARWIDGET_H
 
 #include <QWidget>
+#include <map>
 class QStackedWidget;
 class QHBoxLayout;
+class QPushButton;
 
-//! Main window with button-bar on top and stacked widget at bottom.
+//! Widget container with functionality similar to QTabWidget. Has large button bar on top,
+//! and stacked widget at bottom.
 
 class MainBarWidget : public QWidget
 {
@@ -31,6 +34,7 @@ public:
 private:
     QStackedWidget* stacked_widget{nullptr};
     QHBoxLayout* button_layout{nullptr};
+    std::map<int, QPushButton*> index_to_button;
 };
 
 #endif // MAINBARWIDGET_H

--- a/examples/quickrefl/core/mainwindow/mainwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/mainwindow.cpp
@@ -14,6 +14,7 @@
 #include <QFileDialog>
 #include <QMenuBar>
 #include <QSettings>
+#include <QTabWidget>
 
 namespace
 {
@@ -22,11 +23,11 @@ const QString size_key = "size";
 const QString pos_key = "pos";
 } // namespace
 
-MainWindow::MainWindow() : m_reflDockWindow(new ReflDockWindow)
+MainWindow::MainWindow() : m_reflDockWindow(new ReflDockWindow), tab_widget(new QTabWidget)
 {
-    setCentralWidget(m_reflDockWindow);
-    create_menus();
     init_application();
+    init_tabs();
+    setCentralWidget(tab_widget);
 }
 
 MainWindow::~MainWindow() = default;
@@ -52,6 +53,12 @@ void MainWindow::init_application()
     }
 }
 
+void MainWindow::init_tabs()
+{
+    tab_widget->addTab(m_reflDockWindow, "Simulation");
+    tab_widget->setCurrentIndex(0);
+}
+
 void MainWindow::write_settings()
 {
     QSettings settings;
@@ -59,11 +66,4 @@ void MainWindow::write_settings()
     settings.setValue(size_key, size());
     settings.setValue(pos_key, pos());
     settings.endGroup();
-}
-
-//! Creates application file menu.
-
-void MainWindow::create_menus()
-{
-    menuBar()->addMenu("&File");
 }

--- a/examples/quickrefl/core/mainwindow/mainwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/mainwindow.cpp
@@ -15,6 +15,7 @@
 #include <QMenuBar>
 #include <QSettings>
 #include <QTabWidget>
+#include "mainbarwidget.h"
 
 namespace
 {
@@ -23,11 +24,21 @@ const QString size_key = "size";
 const QString pos_key = "pos";
 } // namespace
 
-MainWindow::MainWindow() : m_reflDockWindow(new ReflDockWindow), tab_widget(new QTabWidget)
+MainWindow::MainWindow() : m_reflDockWindow(new ReflDockWindow)
 {
     init_application();
-    init_tabs();
-    setCentralWidget(tab_widget);
+
+    auto widget = new MainBarWidget;
+    widget->addWidget(new QWidget, "Project");
+    widget->addWidget(new QWidget, "Data");
+    widget->addWidget(m_reflDockWindow, "Simulation");
+    widget->addWidget(new QWidget, "Fitting");
+    widget->addWidget(new QWidget, "Export");
+    widget->addWidget(new QWidget, "Settings");
+
+//    init_tabs();
+
+    setCentralWidget(widget);
 }
 
 MainWindow::~MainWindow() = default;

--- a/examples/quickrefl/core/mainwindow/mainwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/mainwindow.cpp
@@ -14,7 +14,6 @@
 #include <QFileDialog>
 #include <QMenuBar>
 #include <QSettings>
-#include <QTabWidget>
 #include "mainbarwidget.h"
 
 namespace
@@ -24,21 +23,11 @@ const QString size_key = "size";
 const QString pos_key = "pos";
 } // namespace
 
-MainWindow::MainWindow() : m_reflDockWindow(new ReflDockWindow)
+MainWindow::MainWindow() : m_reflDockWindow(new ReflDockWindow), bar_widget(new MainBarWidget)
 {
     init_application();
-
-    auto widget = new MainBarWidget;
-    widget->addWidget(new QWidget, "Project");
-    widget->addWidget(new QWidget, "Data");
-    widget->addWidget(m_reflDockWindow, "Simulation");
-    widget->addWidget(new QWidget, "Fitting");
-    widget->addWidget(new QWidget, "Export");
-    widget->addWidget(new QWidget, "Settings");
-
-//    init_tabs();
-
-    setCentralWidget(widget);
+    init_tabs();
+    setCentralWidget(bar_widget);
 }
 
 MainWindow::~MainWindow() = default;
@@ -66,8 +55,13 @@ void MainWindow::init_application()
 
 void MainWindow::init_tabs()
 {
-    tab_widget->addTab(m_reflDockWindow, "Simulation");
-    tab_widget->setCurrentIndex(0);
+    bar_widget->addWidget(new QWidget, "Project");
+    bar_widget->addWidget(new QWidget, "Data");
+    bar_widget->addWidget(m_reflDockWindow, "Simulation");
+    bar_widget->addWidget(new QWidget, "Fitting");
+    bar_widget->addWidget(new QWidget, "Export");
+    bar_widget->addWidget(new QWidget, "Settings");
+    bar_widget->setCurrentIndex(2);
 }
 
 void MainWindow::write_settings()

--- a/examples/quickrefl/core/mainwindow/mainwindow.h
+++ b/examples/quickrefl/core/mainwindow/mainwindow.h
@@ -13,6 +13,7 @@
 #include <QMainWindow>
 
 class ReflDockWindow;
+class QTabWidget;
 
 //! Application main window.
 
@@ -28,10 +29,11 @@ protected:
 
 private:
     void init_application();
+    void init_tabs();
     void write_settings();
-    void create_menus();
 
-    ReflDockWindow* m_reflDockWindow;
+    ReflDockWindow* m_reflDockWindow{nullptr};
+    QTabWidget* tab_widget{nullptr};
 };
 
 #endif //  MAINWINDOW_H

--- a/examples/quickrefl/core/mainwindow/mainwindow.h
+++ b/examples/quickrefl/core/mainwindow/mainwindow.h
@@ -13,7 +13,7 @@
 #include <QMainWindow>
 
 class ReflDockWindow;
-class QTabWidget;
+class MainBarWidget;
 
 //! Application main window.
 
@@ -33,7 +33,7 @@ private:
     void write_settings();
 
     ReflDockWindow* m_reflDockWindow{nullptr};
-    QTabWidget* tab_widget{nullptr};
+    MainBarWidget* bar_widget{nullptr};
 };
 
 #endif //  MAINWINDOW_H

--- a/examples/quickrefl/core/mainwindow/refldockwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/refldockwindow.cpp
@@ -27,8 +27,11 @@ ReflDockWindow::ReflDockWindow(QWidget* parent)
                                 Qt::TopDockWidgetArea);
     docks_controller->addWidget(1, new LayerEditor(models.get()), Qt::TopDockWidgetArea);
     docks_controller->addWidget(3, new ReflPlotWidget, Qt::BottomDockWidgetArea);
-    docks_controller->addWidget(4, new SLDViewWidget(models->sldController(), parent),
-                                Qt::BottomDockWidgetArea);
+
+    auto sld_widget = new SLDViewWidget(models->sldController());
+    auto sld_editor = new SLDEditor(sld_widget);
+
+    docks_controller->addWidget(4, sld_editor, Qt::BottomDockWidgetArea);
 }
 
 ReflDockWindow::~ReflDockWindow() = default;

--- a/examples/quickrefl/core/mainwindow/refldockwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/refldockwindow.cpp
@@ -13,6 +13,7 @@
 #include "dockscontroller.h"
 #include "layereditor.h"
 #include "reflwidgets.h"
+#include "quicksimeditor.h"
 #include <QToolBar>
 #include <QLabel>
 
@@ -26,12 +27,12 @@ ReflDockWindow::ReflDockWindow(QWidget* parent)
     docks_controller->addWidget(0, new MaterialEditor(models->materialModel()),
                                 Qt::TopDockWidgetArea);
     docks_controller->addWidget(1, new LayerEditor(models.get()), Qt::TopDockWidgetArea);
-    docks_controller->addWidget(3, new ReflPlotWidget, Qt::BottomDockWidgetArea);
 
     auto sld_widget = new SLDViewWidget(models->sldController());
     auto sld_editor = new SLDEditor(sld_widget);
+    docks_controller->addWidget(3, sld_editor, Qt::BottomDockWidgetArea);
 
-    docks_controller->addWidget(4, sld_editor, Qt::BottomDockWidgetArea);
+    docks_controller->addWidget(4, new QuickSimEditor, Qt::BottomDockWidgetArea);
 }
 
 ReflDockWindow::~ReflDockWindow() = default;

--- a/examples/quickrefl/core/mainwindow/refldockwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/refldockwindow.cpp
@@ -13,22 +13,41 @@
 #include "dockscontroller.h"
 #include "layereditor.h"
 #include "reflwidgets.h"
+#include <QToolBar>
 #include <QLabel>
 
 ReflDockWindow::ReflDockWindow(QWidget* parent)
-    : QMainWindow(parent), docks_controller(new DocksController(this)),
+    : QMainWindow(parent), toolbar(new QToolBar), docks_controller(new DocksController(this)),
       models(std::make_unique<ApplicationModels>())
 {
-    setCentralWidget(new QLabel("Reflectometry docks"));
+    setup_toolbar();
+    setup_centralwidget();
 
     docks_controller->addWidget(0, new MaterialEditor(models->materialModel()),
                                 Qt::TopDockWidgetArea);
     docks_controller->addWidget(1, new LayerEditor(models.get()), Qt::TopDockWidgetArea);
-    docks_controller->addWidget(2, new LayerCanvas, Qt::LeftDockWidgetArea);
-    docks_controller->addWidget(3, new SLDViewWidget(models->sldController(), parent),
-                                Qt::RightDockWidgetArea);
-    docks_controller->addWidget(4, new ReflPlotWidget, Qt::BottomDockWidgetArea);
-    docks_controller->addWidget(5, new InstrumentEditor, Qt::BottomDockWidgetArea);
+    docks_controller->addWidget(3, new ReflPlotWidget, Qt::BottomDockWidgetArea);
+    docks_controller->addWidget(4, new SLDViewWidget(models->sldController(), parent),
+                                Qt::BottomDockWidgetArea);
 }
 
 ReflDockWindow::~ReflDockWindow() = default;
+
+void ReflDockWindow::setup_toolbar()
+{
+    const int toolbar_icon_size = 24;
+    toolbar->setIconSize(QSize(toolbar_icon_size, toolbar_icon_size));
+    addToolBar(toolbar);
+    //    setCentralWidget(toolbar);
+}
+
+//! Central widget as horizontal thin line.
+
+void ReflDockWindow::setup_centralwidget()
+{
+    auto central_widget = new QWidget;
+    central_widget->setStyleSheet("background-color:red;");
+    central_widget->setMinimumHeight(2);
+    central_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setCentralWidget(central_widget);
+}

--- a/examples/quickrefl/core/mainwindow/refldockwindow.cpp
+++ b/examples/quickrefl/core/mainwindow/refldockwindow.cpp
@@ -32,7 +32,7 @@ ReflDockWindow::ReflDockWindow(QWidget* parent)
     auto sld_editor = new SLDEditor(sld_widget);
     docks_controller->addWidget(3, sld_editor, Qt::BottomDockWidgetArea);
 
-    docks_controller->addWidget(4, new QuickSimEditor, Qt::BottomDockWidgetArea);
+    docks_controller->addWidget(4, new QuickSimEditor(models.get()), Qt::BottomDockWidgetArea);
 }
 
 ReflDockWindow::~ReflDockWindow() = default;

--- a/examples/quickrefl/core/mainwindow/refldockwindow.h
+++ b/examples/quickrefl/core/mainwindow/refldockwindow.h
@@ -15,6 +15,7 @@
 
 class DocksController;
 class ApplicationModels;
+class QToolBar;
 
 //! Main reflectometry window with all components for quick sample editing and simulations.
 
@@ -26,6 +27,10 @@ public:
     ~ReflDockWindow();
 
 private:
+    void setup_toolbar();
+    void setup_centralwidget();
+
+    QToolBar* toolbar{nullptr};
     DocksController* docks_controller{nullptr};
     std::unique_ptr<ApplicationModels> models;
 };

--- a/examples/quickrefl/core/mainwindow/reflwidgets.cpp
+++ b/examples/quickrefl/core/mainwindow/reflwidgets.cpp
@@ -39,22 +39,6 @@ QSize SLDEditor::minimumSizeHint() const
     return StyleUtils::DockMinimumSizeHint();
 }
 
-//! ---------------------------------------------------------------------------
-
-ReflPlotWidget::ReflPlotWidget(QWidget* parent) : QWidget(parent)
-{
-    setWindowTitle(QString("Reflectivity plot"));
-}
-
-QSize ReflPlotWidget::sizeHint() const
-{
-    return StyleUtils::DockSizeHint();
-}
-
-QSize ReflPlotWidget::minimumSizeHint() const
-{
-    return StyleUtils::DockMinimumSizeHint();
-}
 
 //! ---------------------------------------------------------------------------
 

--- a/examples/quickrefl/core/mainwindow/reflwidgets.cpp
+++ b/examples/quickrefl/core/mainwindow/reflwidgets.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include "reflwidgets.h"
+#include "styleutils.h"
 
 //! ---------------------------------------------------------------------------
 
@@ -28,6 +29,16 @@ SLDEditor::SLDEditor(QWidget* parent) : QWidget(parent)
 ReflPlotWidget::ReflPlotWidget(QWidget* parent) : QWidget(parent)
 {
     setWindowTitle(QString("Reflectivity plot"));
+}
+
+QSize ReflPlotWidget::sizeHint() const
+{
+    return StyleUtils::DockSizeHint();
+}
+
+QSize ReflPlotWidget::minimumSizeHint() const
+{
+    return StyleUtils::DockMinimumSizeHint();
 }
 
 //! ---------------------------------------------------------------------------

--- a/examples/quickrefl/core/mainwindow/reflwidgets.cpp
+++ b/examples/quickrefl/core/mainwindow/reflwidgets.cpp
@@ -9,6 +9,8 @@
 
 #include "reflwidgets.h"
 #include "styleutils.h"
+#include "SLDViewWidget.h"
+#include <QVBoxLayout>
 
 //! ---------------------------------------------------------------------------
 
@@ -19,9 +21,22 @@ LayerCanvas::LayerCanvas(QWidget* parent) : QWidget(parent)
 
 //! ---------------------------------------------------------------------------
 
-SLDEditor::SLDEditor(QWidget* parent) : QWidget(parent)
+SLDEditor::SLDEditor(class SLDViewWidget* sld_view, QWidget* parent) : QWidget(parent)
 {
     setWindowTitle(QString("SLD Editor"));
+    auto layout = new QVBoxLayout;
+    layout->addWidget(sld_view);
+    setLayout(layout);
+}
+
+QSize SLDEditor::sizeHint() const
+{
+    return StyleUtils::DockSizeHint();
+}
+
+QSize SLDEditor::minimumSizeHint() const
+{
+    return StyleUtils::DockMinimumSizeHint();
 }
 
 //! ---------------------------------------------------------------------------

--- a/examples/quickrefl/core/mainwindow/reflwidgets.h
+++ b/examples/quickrefl/core/mainwindow/reflwidgets.h
@@ -42,6 +42,9 @@ class ReflPlotWidget : public QWidget
     Q_OBJECT
 public:
     ReflPlotWidget(QWidget* parent = nullptr);
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
 };
 
 //! Instrument editor.

--- a/examples/quickrefl/core/mainwindow/reflwidgets.h
+++ b/examples/quickrefl/core/mainwindow/reflwidgets.h
@@ -28,11 +28,17 @@ public:
 
 //! SLD editor.
 
+// FIXME Move title and sizeHints on board of SLDViewWidget and get rid of SLDEditor class.
+
 class SLDEditor : public QWidget
 {
     Q_OBJECT
 public:
-    SLDEditor(QWidget* parent = nullptr);
+    SLDEditor(class SLDViewWidget* sld_view, QWidget* parent = nullptr);
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
 };
 
 //! Reflectivity plot.

--- a/examples/quickrefl/core/mainwindow/reflwidgets.h
+++ b/examples/quickrefl/core/mainwindow/reflwidgets.h
@@ -41,18 +41,6 @@ public:
 
 };
 
-//! Reflectivity plot.
-
-class ReflPlotWidget : public QWidget
-{
-    Q_OBJECT
-public:
-    ReflPlotWidget(QWidget* parent = nullptr);
-
-    QSize sizeHint() const override;
-    QSize minimumSizeHint() const override;
-};
-
 //! Instrument editor.
 
 class InstrumentEditor : public QWidget

--- a/examples/quickrefl/core/mainwindow/styleutils.cpp
+++ b/examples/quickrefl/core/mainwindow/styleutils.cpp
@@ -14,3 +14,13 @@ QSize StyleUtils::ToolBarIconSize()
 {
     return QSize(24, 24);
 }
+
+QSize StyleUtils::DockSizeHint()
+{
+    return QSize(480, 360);
+}
+
+QSize StyleUtils::DockMinimumSizeHint()
+{
+    return QSize(320, 240);
+}

--- a/examples/quickrefl/core/mainwindow/styleutils.h
+++ b/examples/quickrefl/core/mainwindow/styleutils.h
@@ -16,7 +16,16 @@ class QSize;
 
 namespace StyleUtils
 {
+
+//! Size of tolbar icons for LayerEditor, MaterialEditor and similar.
 QSize ToolBarIconSize();
+
+//! Hint on size of docks on main reflectometry window.
+QSize DockSizeHint();
+
+//! Hint on minimum size of docks on main reflectometry window.
+QSize DockMinimumSizeHint();
+
 };
 
 #endif // STYLEUTILS_H

--- a/examples/quickrefl/core/model/CMakeLists.txt
+++ b/examples/quickrefl/core/model/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(quickreflcore PRIVATE
     applicationmodels.cpp
     applicationmodels.h
     item_constants.h
+    jobmodel.cpp
+    jobmodel.h
     layeritems.cpp
     layeritems.h
     materialitems.cpp

--- a/examples/quickrefl/core/model/applicationmodels.cpp
+++ b/examples/quickrefl/core/model/applicationmodels.cpp
@@ -18,6 +18,7 @@
 #include <mvvm/model/modelutils.h>
 #include <mvvm/model/sessionitem.h>
 #include <mvvm/serialization/jsondocument.h>
+#include <mvvm/model/itempool.h>
 
 using namespace ModelView;
 
@@ -28,11 +29,13 @@ struct ApplicationModels::ApplicationModelsImpl {
     std::unique_ptr<MaterialPropertyController> m_property_controller;
     std::unique_ptr<SLDController> m_sld_controller;
     std::unique_ptr<JsonDocument> m_document;
+    std::shared_ptr<ItemPool> item_pool;
 
     ApplicationModelsImpl()
     {
-        m_material_model = std::make_unique<MaterialModel>();
-        m_sample_model = std::make_unique<SampleModel>();
+        item_pool = std::make_shared<ItemPool>();
+        m_material_model = std::make_unique<MaterialModel>(item_pool);
+        m_sample_model = std::make_unique<SampleModel>(item_pool);
         m_sld_view_model = std::make_unique<SLDViewModel>();
         m_property_controller = std::make_unique<MaterialPropertyController>(m_material_model.get(),
                                                                              m_sample_model.get());

--- a/examples/quickrefl/core/model/jobmodel.cpp
+++ b/examples/quickrefl/core/model/jobmodel.cpp
@@ -1,0 +1,29 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "jobmodel.h"
+#include <mvvm/standarditems/axisitems.h>
+#include <mvvm/standarditems/data1ditem.h>
+#include <mvvm/standarditems/graphitem.h>
+#include <mvvm/standarditems/graphviewportitem.h>
+
+using namespace ModelView;
+
+JobModel::JobModel() : SessionModel("MaterialModel")
+{
+    init_model();
+}
+
+void JobModel::init_model()
+{
+    auto viewport = insertItem<GraphViewportItem>();
+    auto data = insertItem<Data1DItem>();
+    auto graph = insertItem<GraphItem>(viewport);
+    graph->setDataItem(data);
+}

--- a/examples/quickrefl/core/model/jobmodel.h
+++ b/examples/quickrefl/core/model/jobmodel.h
@@ -1,0 +1,26 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef JOBMODEL_H
+#define JOBMODEL_H
+
+#include <mvvm/model/sessionmodel.h>
+
+//! Contains results of quick reflectometry simulations.
+
+class JobModel : public ModelView::SessionModel
+{
+public:
+    JobModel();
+
+private:
+    void init_model();
+};
+
+#endif //  JOBMODEL_H

--- a/examples/quickrefl/core/model/jobmodel.h
+++ b/examples/quickrefl/core/model/jobmodel.h
@@ -13,6 +13,7 @@
 #include <mvvm/model/sessionmodel.h>
 
 //! Contains results of quick reflectometry simulations.
+// TODO make JobModel part of ApplicationModels
 
 class JobModel : public ModelView::SessionModel
 {

--- a/examples/quickrefl/core/model/layeritems.cpp
+++ b/examples/quickrefl/core/model/layeritems.cpp
@@ -58,33 +58,6 @@ void MultiLayerItem::activate()
     mapper()->setOnItemRemoved(on_item_removed, this);
 }
 
-//! Creates multi-slice presentation of internal layers structure. Used as simulation input.
-//! TODO Provide unit tests, provide support for nested MultiLayers
-
-multislice_t MultiLayerItem::multislice() const
-{
-    multislice_t result;
-    auto layers = items<LayerItem>(T_LAYERS);
-    for (const auto& layer : items<LayerItem>(T_LAYERS)) {
-        if (layer->modelType() != Constants::LayerItemType)
-            throw std::runtime_error("Currently supports layers only. FIXME");
-
-        double thickness = layer->property(LayerItem::P_THICKNESS).value<double>();
-        auto roughness = layer->item<RoughnessItem>(LayerItem::P_ROUGHNESS);
-        double sigma = roughness->property(RoughnessItem::P_SIGMA).value<double>();
-
-        auto material = model()->findItem(layer->property(LayerItem::P_MATERIAL)
-                                              .value<ModelView::ExternalProperty>()
-                                              .identifier());
-        double sld_real = material->property(SLDMaterialItem::P_SLD_REAL).value<double>();
-        double sld_imag = material->property(SLDMaterialItem::P_SLD_IMAG).value<double>();
-
-        result.push_back({complex_t{sld_real, sld_imag}, thickness, sigma});
-    }
-
-    return result;
-}
-
 //! Sets thickness property of top and bottom layers to disabled state.
 //! Reset thickness of top and bottom layer to 0.
 

--- a/examples/quickrefl/core/model/layeritems.cpp
+++ b/examples/quickrefl/core/model/layeritems.cpp
@@ -9,6 +9,7 @@
 
 #include "layeritems.h"
 #include "item_constants.h"
+#include "materialitems.h"
 #include "materialmodel.h"
 #include <QVariant>
 #include <mvvm/model/externalproperty.h>
@@ -55,6 +56,33 @@ void MultiLayerItem::activate()
         update_layer_appearance();
     };
     mapper()->setOnItemRemoved(on_item_removed, this);
+}
+
+//! Creates multi-slice presentation of internal layers structure. Used as simulation input.
+//! TODO Provide unit tests, provide support for nested MultiLayers
+
+multislice_t MultiLayerItem::multislice() const
+{
+    multislice_t result;
+    auto layers = items<LayerItem>(T_LAYERS);
+    for (const auto& layer : items<LayerItem>(T_LAYERS)) {
+        if (layer->modelType() != Constants::LayerItemType)
+            throw std::runtime_error("Currently supports layers only. FIXME");
+
+        double thickness = layer->property(LayerItem::P_THICKNESS).value<double>();
+        auto roughness = layer->item<RoughnessItem>(LayerItem::P_ROUGHNESS);
+        double sigma = roughness->property(RoughnessItem::P_SIGMA).value<double>();
+
+        auto material = model()->findItem(layer->property(LayerItem::P_MATERIAL)
+                                              .value<ModelView::ExternalProperty>()
+                                              .identifier());
+        double sld_real = material->property(SLDMaterialItem::P_SLD_REAL).value<double>();
+        double sld_imag = material->property(SLDMaterialItem::P_SLD_IMAG).value<double>();
+
+        result.push_back({complex_t{sld_real, sld_imag}, thickness, sigma});
+    }
+
+    return result;
 }
 
 //! Sets thickness property of top and bottom layers to disabled state.

--- a/examples/quickrefl/core/model/layeritems.h
+++ b/examples/quickrefl/core/model/layeritems.h
@@ -14,6 +14,7 @@
 //! Collection of layer and multi-layer items to populate SampleModel.
 
 #include <mvvm/model/compounditem.h>
+#include "slice.h"
 
 //! Item to represent the roughness of the layer.
 
@@ -37,7 +38,7 @@ public:
     static inline const std::string P_THICKNESS = "P_THICKNESS";
     static inline const std::string P_ROUGHNESS = "P_ROUGHNESS";
 
-    LayerItem();
+    LayerItem();    
 };
 
 //! Multi layer capable of holding layers and other multi-layers.
@@ -52,6 +53,8 @@ public:
     MultiLayerItem();
 
     void activate() override;
+
+    multislice_t multislice() const;
 
 private:
     void update_layer_appearance();

--- a/examples/quickrefl/core/model/layeritems.h
+++ b/examples/quickrefl/core/model/layeritems.h
@@ -54,8 +54,6 @@ public:
 
     void activate() override;
 
-    multislice_t multislice() const;
-
 private:
     void update_layer_appearance();
 };

--- a/examples/quickrefl/core/model/materialmodel.cpp
+++ b/examples/quickrefl/core/model/materialmodel.cpp
@@ -20,6 +20,8 @@ using namespace ModelView;
 
 namespace
 {
+
+const std::string model_name{"MaterialModel"};
 std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 {
     auto result = std::make_unique<ModelView::ItemCatalogue>();
@@ -63,9 +65,14 @@ QColor suggestMaterialColor(const std::string& name)
 
 } // namespace
 
-MaterialModel::MaterialModel() : SessionModel("MaterialModel")
+MaterialModel::MaterialModel() : SessionModel(model_name)
 {
-    setItemCatalogue(CreateItemCatalogue());
+    init_model();
+}
+
+MaterialModel::MaterialModel(std::shared_ptr<ModelView::ItemPool> pool)
+    : SessionModel(model_name, pool)
+{
     init_model();
 }
 
@@ -135,6 +142,8 @@ SLDMaterialItem* MaterialModel::addDefaultMaterial(const ModelView::TagRow& tagr
 
 void MaterialModel::init_model()
 {
+    setItemCatalogue(CreateItemCatalogue());
+
     auto container = insertItem<MaterialContainerItem>();
     auto material = insertItem<SLDMaterialItem>(container);
     material->set_properties(air_material_name, suggestMaterialColor(air_material_name), 0.0, 0.0);

--- a/examples/quickrefl/core/model/materialmodel.h
+++ b/examples/quickrefl/core/model/materialmodel.h
@@ -32,6 +32,7 @@ class MaterialModel : public ModelView::SessionModel
 {
 public:
     MaterialModel();
+    MaterialModel(std::shared_ptr<ModelView::ItemPool> pool);
 
     static ModelView::ExternalProperty undefined_material();
 

--- a/examples/quickrefl/core/model/samplemodel.cpp
+++ b/examples/quickrefl/core/model/samplemodel.cpp
@@ -33,6 +33,7 @@ SampleModel::SampleModel() : SessionModel(model_name)
 
 SampleModel::SampleModel(std::shared_ptr<ModelView::ItemPool> pool) : SessionModel(model_name, pool)
 {
+    init_model();
 }
 
 //! Populate the model with default MultiLayer with 3 layers.

--- a/examples/quickrefl/core/model/samplemodel.cpp
+++ b/examples/quickrefl/core/model/samplemodel.cpp
@@ -15,6 +15,7 @@ using namespace ModelView;
 
 namespace
 {
+const std::string model_name{"SampleModel"};
 std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 {
     auto result = std::make_unique<ItemCatalogue>();
@@ -25,9 +26,13 @@ std::unique_ptr<ItemCatalogue> CreateItemCatalogue()
 }
 } // namespace
 
-SampleModel::SampleModel() : SessionModel("SampleModel")
+SampleModel::SampleModel() : SessionModel(model_name)
 {
-    setItemCatalogue(CreateItemCatalogue());
+    init_model();
+}
+
+SampleModel::SampleModel(std::shared_ptr<ModelView::ItemPool> pool) : SessionModel(model_name, pool)
+{
 }
 
 //! Populate the model with default MultiLayer with 3 layers.
@@ -44,4 +49,9 @@ void SampleModel::create_default_multilayer()
     substrate->setProperty(LayerItem::P_NAME, QVariant::fromValue(std::string("Substrate")));
 
     middle->setProperty(LayerItem::P_THICKNESS, 42.0);
+}
+
+void SampleModel::init_model()
+{
+    setItemCatalogue(CreateItemCatalogue());
 }

--- a/examples/quickrefl/core/model/samplemodel.h
+++ b/examples/quickrefl/core/model/samplemodel.h
@@ -17,8 +17,12 @@ class SampleModel : public ModelView::SessionModel
 {
 public:
     SampleModel();
+    SampleModel(std::shared_ptr<ModelView::ItemPool> pool);
 
     void create_default_multilayer();
+
+private:
+    void init_model();
 };
 
 #endif //  SAMPLEMODEL_H

--- a/examples/quickrefl/tests/quicksimutils.test.cpp
+++ b/examples/quickrefl/tests/quicksimutils.test.cpp
@@ -1,0 +1,97 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+#include "layeritems.h"
+#include "materialitems.h"
+#include "materialmodel.h"
+#include "quicksimutils.h"
+#include "samplemodel.h"
+#include <QColor>
+#include <mvvm/model/externalproperty.h>
+#include <mvvm/model/itempool.h>
+
+using namespace ModelView;
+
+//! Tests of QuickSimUtils namespace functions.
+
+class QuickSimUtilsTest : public ::testing::Test
+{
+public:
+    ~QuickSimUtilsTest();
+};
+
+QuickSimUtilsTest::~QuickSimUtilsTest() = default;
+
+//! Multi-slice of empty MultiLayer.
+
+TEST_F(QuickSimUtilsTest, emptySlice)
+{
+    SampleModel model;
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto multislice = ::Utils::CreateMultiSlice(*multilayer);
+    EXPECT_EQ(multislice.size(), 0);
+}
+
+//! Multi-slice of MultiLayer with single layer without material.
+
+TEST_F(QuickSimUtilsTest, layerSlice)
+{
+    SampleModel model;
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    model.insertItem<LayerItem>(multilayer);
+    auto multislice = ::Utils::CreateMultiSlice(*multilayer);
+
+    ASSERT_EQ(multislice.size(), 1);
+    EXPECT_EQ(multislice[0].material.real(), 0.0);
+    EXPECT_EQ(multislice[0].material.imag(), 0.0);
+    EXPECT_EQ(multislice[0].thickness, 0.0);
+    EXPECT_EQ(multislice[0].sigma, 0.0);
+}
+
+//! Multi-slice of MultiLayer with single layer with defined material and roughness.
+
+TEST_F(QuickSimUtilsTest, definedLayerSlice)
+{
+    // common pool
+    auto pool = std::make_shared<ItemPool>();
+
+    // initializing MaterialModel with single material
+    MaterialModel material_model(pool);
+    auto material = material_model.insertItem<SLDMaterialItem>();
+    const double sld_real{1.0};
+    const double sld_imag{2.0};
+    material->set_properties("gold", QColor(), sld_real, sld_imag);
+    ModelView::ExternalProperty material_property("gold", QColor(), material->identifier());
+
+    // initializing SampleModel
+    SampleModel model(pool);
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(multilayer);
+
+    // checking that pool is working
+    EXPECT_EQ(model.findItem(material->identifier()), material);
+    EXPECT_EQ(model.findItem(material_property.identifier()), material);
+
+    // setting thickness, roughness and material to layer
+    const double thickness{43.0};
+    layer->setProperty(LayerItem::P_THICKNESS, thickness);
+    auto roughness = layer->item<RoughnessItem>(LayerItem::P_ROUGHNESS);
+    const double sigma{42.0};
+    roughness->setProperty(RoughnessItem::P_SIGMA, sigma);
+    layer->setProperty(LayerItem::P_MATERIAL, QVariant::fromValue(material_property));
+
+    auto multislice = ::Utils::CreateMultiSlice(*multilayer);
+
+    ASSERT_EQ(multislice.size(), 1);
+    EXPECT_EQ(multislice[0].material.real(), sld_real);
+    EXPECT_EQ(multislice[0].material.imag(), sld_imag);
+    EXPECT_EQ(multislice[0].thickness, thickness);
+    EXPECT_EQ(multislice[0].sigma, sigma);
+}

--- a/source/libmvvm_model/mvvm/utils/CMakeLists.txt
+++ b/source/libmvvm_model/mvvm/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(mvvm_model PRIVATE
     fileutils.cpp
     fileutils.h
     ifactory.h
+    mathconstants.h
     numericutils.cpp
     numericutils.h
     progresshandler.cpp

--- a/source/libmvvm_model/mvvm/utils/mathconstants.h
+++ b/source/libmvvm_model/mvvm/utils/mathconstants.h
@@ -1,0 +1,15 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MVVM_UTILS_MATHCONSTANTS_H
+#define MVVM_UTILS_MATHCONSTANTS_H
+
+#define M_PI 3.14159265358979323846 /* pi */
+
+#endif


### PR DESCRIPTION
+ Introduce new layout for the main window of `quickrefl` example.
  + Dedicated placeholders for Welcome, Import, Simulation, etc.
  + Nicer dock positioning on the SLD window.
+  Introduce QuickSimController for running simulations in the background
  + Implement auxiliary machinery for SLD profile generation.
  + Calculate the SLD profile on every change in MaterialModel and SampleModel.

Further tasks:
+ Provide JobItem which will hold current data for the SLD profile and the result of reflectometry simulation.
+ Make QuickSimController updating this item on every model change.
+ Update of SLD profile will go in the current thread, reflectometry simulation will go through job system.
  
The final task will be to make an SLD editor use the SLD profile from JobItem, and QuickSimEditor use reflectometry plot  from JobItem.

