### PR TITLE
Property refactoring

### DIFF
--- a/examples/collidingmice/collidingmice/mouse.cpp
+++ b/examples/collidingmice/collidingmice/mouse.cpp
@@ -56,8 +56,8 @@
 #include <QStyleOption>
 #include <cmath>
 #include <mvvm/signals/itemmapper.h>
-#include <mvvm/utils/numericutils.h>
 #include <mvvm/utils/mathconstants.h>
+#include <mvvm/utils/numericutils.h>
 
 const qreal Pi = M_PI;
 const qreal TwoPi = 2 * M_PI;
@@ -73,25 +73,23 @@ static qreal normalizeAngle(qreal angle)
 
 //! [0]
 Mouse::Mouse(MouseItem* item)
-    : mouseEyeDirection(0), color(item->property(MouseItem::P_COLOR).value<QColor>()),
-      mouse_item(item)
+    : mouseEyeDirection(0), color(item->property<QColor>(MouseItem::P_COLOR)), mouse_item(item)
 {
     auto on_property_change = [this](ModelView::SessionItem*, std::string property_name) {
         if (property_name == MouseItem::P_XPOS)
-            setX(mouse_item->property(MouseItem::P_XPOS).toDouble());
+            setX(mouse_item->property<double>(MouseItem::P_XPOS));
         if (property_name == MouseItem::P_YPOS)
-            setY(mouse_item->property(MouseItem::P_YPOS).toDouble());
+            setY(mouse_item->property<double>(MouseItem::P_YPOS));
         if (property_name == MouseItem::P_COLOR)
-            color = mouse_item->property(MouseItem::P_COLOR).value<QColor>();
+            color = mouse_item->property<QColor>(MouseItem::P_COLOR);
         if (property_name == MouseItem::P_ANGLE) {
-            qreal dx = std::sin(mouse_item->property(MouseItem::P_ANGLE).value<double>()) * 10;
+            qreal dx = std::sin(mouse_item->property<double>(MouseItem::P_ANGLE)) * 10;
             setRotation(rotation() + dx);
         }
     };
     mouse_item->mapper()->setOnPropertyChange(on_property_change, this);
 
-    setPos(item->property(MouseItem::P_XPOS).toDouble(),
-           item->property(MouseItem::P_YPOS).toDouble());
+    setPos(item->property<double>(MouseItem::P_XPOS), item->property<double>(MouseItem::P_YPOS));
     setRotation(ModelView::Utils::RandInt(0, 360 * 16));
 }
 //! [0]
@@ -157,7 +155,7 @@ void Mouse::advance(int step)
     // Don't move too far away
     //! [5]
 
-    qreal angle = mouse_item->property(MouseItem::P_ANGLE).value<double>();
+    qreal angle = mouse_item->property<double>(MouseItem::P_ANGLE);
 
     QLineF lineToCenter(QPointF(0, 0), mapFromScene(0, 0));
     if (lineToCenter.length() > 150) {
@@ -215,7 +213,7 @@ void Mouse::advance(int step)
 
     //! [11]
 
-    qreal speed = mouse_item->property(MouseItem::P_SPEED).value<double>();
+    qreal speed = mouse_item->property<double>(MouseItem::P_SPEED);
     speed += (-50 + ModelView::Utils::RandInt(0, 100)) / 100.0;
 
     qreal dx = ::sin(angle) * 10;

--- a/examples/flateditor/core/items.cpp
+++ b/examples/flateditor/core/items.cpp
@@ -52,13 +52,12 @@ void BeamItem::activate()
 void BeamItem::update_appearance()
 {
     auto polarized_property = getItem(P_IS_POLARIZED);
-    auto beam_type = property(P_BEAM_TYPE).value<ComboProperty>().value();
+    auto beam_type = property<ComboProperty>(P_BEAM_TYPE).value();
 
     if (beam_type == xrays)
         setProperty(P_IS_POLARIZED, false);
 
-    polarized_property->setEnabled(property(P_BEAM_TYPE).value<ComboProperty>().value()
-                                   == neutrons);
+    polarized_property->setEnabled(property<ComboProperty>(P_BEAM_TYPE).value() == neutrons);
 }
 
 // ----------------------------------------------------------------------------

--- a/examples/graphicsproxy/core/regionofinterestcontroller.cpp
+++ b/examples/graphicsproxy/core/regionofinterestcontroller.cpp
@@ -102,7 +102,7 @@ struct RegionOfInterestController::RegionOfInterestControllerImpl {
     //! Returns the y-coordinate of the rectangle's bottom edge.
     double bottom() const { return scene_adapter->toSceneY(par(RegionOfInterestItem::P_YLOW)); }
 
-    double par(const std::string& name) const { return roi_item->property(name).value<double>(); }
+    double par(const std::string& name) const { return roi_item->property<double>(name); }
 };
 
 RegionOfInterestController::RegionOfInterestController(

--- a/examples/graphicsproxy/core/scenewidget.cpp
+++ b/examples/graphicsproxy/core/scenewidget.cpp
@@ -67,10 +67,10 @@ void SceneWidget::init_actions()
     auto on_set_to_roi = [this]() {
         auto viewport = Utils::TopItem<ColorMapViewportItem>(m_model);
         auto roi = Utils::TopItem<RegionOfInterestItem>(m_model);
-        viewport->xAxis()->set_range(roi->property(RegionOfInterestItem::P_XLOW).value<double>(),
-                                     roi->property(RegionOfInterestItem::P_XUP).value<double>());
-        viewport->yAxis()->set_range(roi->property(RegionOfInterestItem::P_YLOW).value<double>(),
-                                     roi->property(RegionOfInterestItem::P_YUP).value<double>());
+        viewport->xAxis()->set_range(roi->property<double>(RegionOfInterestItem::P_XLOW),
+                                     roi->property<double>(RegionOfInterestItem::P_XUP));
+        viewport->yAxis()->set_range(roi->property<double>(RegionOfInterestItem::P_YLOW),
+                                     roi->property<double>(RegionOfInterestItem::P_YUP));
     };
     connect(m_setViewportToRoiAction, &QAction::triggered, on_set_to_roi);
     m_toolBar->addAction(m_setViewportToRoiAction);

--- a/examples/layereditor/core/model/MaterialModel.cpp
+++ b/examples/layereditor/core/model/MaterialModel.cpp
@@ -50,8 +50,8 @@ std::vector<ExternalProperty> MaterialModel::material_data()
     for (auto container : rootItem()->children()) {
         for (auto item : container->children()) {
             if (auto material = dynamic_cast<SLDMaterialItem*>(item)) {
-                auto text = material->property(SLDMaterialItem::P_NAME).value<std::string>();
-                auto color = material->property(SLDMaterialItem::P_COLOR).value<QColor>();
+                auto text = material->property<std::string>(SLDMaterialItem::P_NAME);
+                auto color = material->property<QColor>(SLDMaterialItem::P_COLOR);
                 auto id = material->identifier();
                 result.push_back(ExternalProperty(text, color, id));
             }

--- a/examples/layereditor/core/model/MaterialPropertyController.cpp
+++ b/examples/layereditor/core/model/MaterialPropertyController.cpp
@@ -51,7 +51,7 @@ void MaterialPropertyController::update_all()
 {
     auto layers = Utils::FindItems<LayerItem>(m_sample_model);
     for (auto layer : Utils::FindItems<LayerItem>(m_sample_model)) {
-        auto property = layer->property(LayerItem::P_MATERIAL).value<ModelView::ExternalProperty>();
+        auto property = layer->property<ExternalProperty>(LayerItem::P_MATERIAL);
         auto updated = m_material_model->material_property(property.identifier());
         if (property != updated)
             layer->setProperty(LayerItem::P_MATERIAL, updated);

--- a/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.cpp
+++ b/examples/quickrefl/core/editors/quicksimeditor/quicksimutils.cpp
@@ -23,18 +23,15 @@ Slice create_slice(const ModelView::SessionItem& layer)
     if (layer.modelType() != Constants::LayerItemType)
         throw std::runtime_error("Error in create_slice(): not a layer.");
 
-    double thickness = layer.property(LayerItem::P_THICKNESS).value<double>();
+    double thickness = layer.property<double>(LayerItem::P_THICKNESS);
     auto roughness = layer.item<RoughnessItem>(LayerItem::P_ROUGHNESS);
-    double sigma = roughness->property(RoughnessItem::P_SIGMA).value<double>();
+    double sigma = roughness->property<double>(RoughnessItem::P_SIGMA);
 
-    auto material_property =
-        layer.property(LayerItem::P_MATERIAL).value<ModelView::ExternalProperty>();
+    auto material_property = layer.property<ModelView::ExternalProperty>(LayerItem::P_MATERIAL);
     auto material = layer.model()->findItem(material_property.identifier());
     // layer which is not linked with material will get (0,0) as SLD material.
-    double sld_real =
-        material ? material->property(SLDMaterialItem::P_SLD_REAL).value<double>() : 0.0;
-    double sld_imag =
-        material ? material->property(SLDMaterialItem::P_SLD_IMAG).value<double>() : 0.0;
+    double sld_real = material ? material->property<double>(SLDMaterialItem::P_SLD_REAL) : 0.0;
+    double sld_imag = material ? material->property<double>(SLDMaterialItem::P_SLD_IMAG) : 0.0;
     return {complex_t{sld_real, sld_imag}, thickness, sigma};
 }
 
@@ -46,7 +43,7 @@ void AddToMultiSlice(multislice_t& result, const ModelView::SessionItem& multila
         if (item->modelType() == Constants::LayerItemType) {
             result.push_back(create_slice(*item));
         } else if (item->modelType() == Constants::MultiLayerItemType) {
-            const int rep_count = item->property(MultiLayerItem::P_NREPETITIONS).value<int>();
+            const int rep_count = item->property<int>(MultiLayerItem::P_NREPETITIONS);
             for (int i_rep = 0; i_rep < rep_count; ++i_rep)
                 AddToMultiSlice(result, *item);
         } else {

--- a/examples/quickrefl/core/editors/sldeditor/layerelementcontroller.cpp
+++ b/examples/quickrefl/core/editors/sldeditor/layerelementcontroller.cpp
@@ -89,12 +89,12 @@ void LayerElementController::connectToModel() const
             if (layerBelow())
                 layerBelow()->layerElementItem()->setProperty(
                     LayerElementItem::P_X_POS,
-                    layerElementItem()->property(LayerElementItem::P_X_POS).toDouble()
-                        + layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble());
+                    layerElementItem()->property<double>(LayerElementItem::P_X_POS)
+                        + layerElementItem()->property<double>(LayerElementItem::P_WIDTH));
         }
         if (property_name == LayerElementItem::P_HEIGHT) {
             emit heightChanged(m_sample_item_id,
-                               layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble());
+                               layerElementItem()->property<double>(LayerElementItem::P_HEIGHT));
             updateSideSegment();
             updateTopSegment();
             updateSegmentHandles();
@@ -107,7 +107,7 @@ void LayerElementController::connectToModel() const
         }
         if (property_name == LayerElementItem::P_WIDTH) {
             emit widthChanged(m_sample_item_id,
-                              layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble());
+                              layerElementItem()->property<double>(LayerElementItem::P_WIDTH));
             updateSideSegment();
             updateTopSegment();
             updateSegmentHandles();
@@ -115,13 +115,12 @@ void LayerElementController::connectToModel() const
             if (layerBelow())
                 layerBelow()->layerElementItem()->setProperty(
                     LayerElementItem::P_X_POS,
-                    layerElementItem()->property(LayerElementItem::P_X_POS).toDouble()
-                        + layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble());
+                    layerElementItem()->property<double>(LayerElementItem::P_X_POS)
+                        + layerElementItem()->property<double>(LayerElementItem::P_WIDTH));
         }
         if (property_name == LayerElementItem::P_ROUGHNESS) {
-            emit roughnessChanged(
-                m_sample_item_id,
-                layerElementItem()->property(LayerElementItem::P_ROUGHNESS).toDouble());
+            emit roughnessChanged(m_sample_item_id, layerElementItem()->property<double>(
+                                                        LayerElementItem::P_ROUGHNESS));
             updateRoughness();
         }
 
@@ -271,8 +270,8 @@ void LayerElementController::setLayerAbove(LayerElementController* layer_view_co
         layer_view_controller->setLayerBelow(this);
 
     double pos =
-        p_controller_above->layerElementItem()->property(LayerElementItem::P_X_POS).toDouble()
-        + p_controller_above->layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble();
+        p_controller_above->layerElementItem()->property<double>(LayerElementItem::P_X_POS)
+        + p_controller_above->layerElementItem()->property<double>(LayerElementItem::P_WIDTH);
     layerElementItem()->setProperty(LayerElementItem::P_X_POS, pos);
 }
 
@@ -392,13 +391,12 @@ void LayerElementController::updateSideSegment() const
         return;
 
     auto pen = QPen();
-    pen.setColor(layerElementItem()->property(LayerElementItem::P_SIDE_PEN_COLOR).value<QColor>());
-    pen.setWidthF(layerElementItem()->property(LayerElementItem::P_SIDE_PEN_WIDTH).toDouble());
+    pen.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_SIDE_PEN_COLOR));
+    pen.setWidthF(layerElementItem()->property<double>(LayerElementItem::P_SIDE_PEN_WIDTH));
     m_segment_views.at(0)->setPen(pen);
 
     auto brush = QBrush(Qt::SolidPattern);
-    brush.setColor(
-        layerElementItem()->property(LayerElementItem::P_SIDE_BRUSH_COLOR).value<QColor>());
+    brush.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_SIDE_BRUSH_COLOR));
     m_segment_views.at(0)->setBrush(brush);
 
     m_segment_views.at(0)->setRectangle(sideSegmentRect());
@@ -411,13 +409,12 @@ void LayerElementController::updateTopSegment() const
         return;
 
     auto pen = QPen();
-    pen.setColor(layerElementItem()->property(LayerElementItem::P_TOP_PEN_COLOR).value<QColor>());
-    pen.setWidthF(layerElementItem()->property(LayerElementItem::P_TOP_PEN_WIDTH).toDouble());
+    pen.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_TOP_PEN_COLOR));
+    pen.setWidthF(layerElementItem()->property<double>(LayerElementItem::P_TOP_PEN_WIDTH));
     m_segment_views.at(1)->setPen(pen);
 
     auto brush = QBrush(Qt::SolidPattern);
-    brush.setColor(
-        layerElementItem()->property(LayerElementItem::P_TOP_BRUSH_COLOR).value<QColor>());
+    brush.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_TOP_BRUSH_COLOR));
     m_segment_views.at(1)->setBrush(brush);
 
     m_segment_views.at(1)->setRectangle(topSegmentRect());
@@ -426,15 +423,15 @@ void LayerElementController::updateTopSegment() const
 //! Return the side segment rectangle
 QRectF LayerElementController::sideSegmentRect() const
 {
-    double this_pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double this_height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
+    double this_pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double this_height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
     double this_thickness =
-        layerElementItem()->property(LayerElementItem::P_SIDE_THICKNESS).toDouble();
+        layerElementItem()->property<double>(LayerElementItem::P_SIDE_THICKNESS);
 
     double above_height = 0;
     if (layerAbove()) {
         above_height =
-            layerAbove()->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
+            layerAbove()->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
     }
 
     if (above_height > this_height) {
@@ -449,10 +446,10 @@ QRectF LayerElementController::sideSegmentRect() const
 //! Return the top segment rectangle
 QRectF LayerElementController::topSegmentRect() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
-    double width = layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble();
-    double thickness = layerElementItem()->property(LayerElementItem::P_TOP_THICKNESS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
+    double width = layerElementItem()->property<double>(LayerElementItem::P_WIDTH);
+    double thickness = layerElementItem()->property<double>(LayerElementItem::P_TOP_THICKNESS);
     return QRectF(pos, height - thickness / 2., width, thickness);
 }
 
@@ -485,10 +482,10 @@ void LayerElementController::sideSegmentMoved() const
     if (layerAbove()) {
         double w = 0;
         auto item = layerAbove()->layerElementItem();
-        if (x < item->property(LayerElementItem::P_X_POS).toDouble()) {
-            x = item->property(LayerElementItem::P_X_POS).toDouble() + w;
+        if (x < item->property<double>(LayerElementItem::P_X_POS)) {
+            x = item->property<double>(LayerElementItem::P_X_POS) + w;
         } else {
-            w = x - item->property(LayerElementItem::P_X_POS).toDouble();
+            w = x - item->property<double>(LayerElementItem::P_X_POS);
         }
         item->setProperty(LayerElementItem::P_WIDTH, w);
     }
@@ -558,13 +555,11 @@ void LayerElementController::handleViewMoved(HandleElementView* handle_view)
 void LayerElementController::updateSegmentHandles() const
 {
     auto pen = QPen();
-    pen.setColor(
-        layerElementItem()->property(LayerElementItem::P_HANDLE_PEN_COLOR).value<QColor>());
-    pen.setWidthF(layerElementItem()->property(LayerElementItem::P_HANDLE_PEN_WIDTH).toDouble());
+    pen.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_HANDLE_PEN_COLOR));
+    pen.setWidthF(layerElementItem()->property<double>(LayerElementItem::P_HANDLE_PEN_WIDTH));
 
     auto brush = QBrush(Qt::SolidPattern);
-    brush.setColor(
-        layerElementItem()->property(LayerElementItem::P_HANDLE_BRUSH_COLOR).value<QColor>());
+    brush.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_HANDLE_BRUSH_COLOR));
 
     if (m_handle_views[0]) {
         m_handle_views.at(0)->setPen(pen);
@@ -581,13 +576,13 @@ void LayerElementController::updateSegmentHandles() const
 //! Get the first segment handle rectangle
 QRectF LayerElementController::firstSegmentHandleRect() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double radius = layerElementItem()->property(LayerElementItem::P_HANDLE_RADIUS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double radius = layerElementItem()->property<double>(LayerElementItem::P_HANDLE_RADIUS);
 
     double above_height = 0;
     if (layerAbove()) {
         above_height =
-            layerAbove()->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
+            layerAbove()->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
     }
 
     return QRectF(pos - radius, above_height - radius, 2 * radius, 2 * radius);
@@ -596,9 +591,9 @@ QRectF LayerElementController::firstSegmentHandleRect() const
 //! Get the second segment handle rectangle
 QRectF LayerElementController::secondSegmentHandleRect() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
-    double radius = layerElementItem()->property(LayerElementItem::P_HANDLE_RADIUS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
+    double radius = layerElementItem()->property<double>(LayerElementItem::P_HANDLE_RADIUS);
     return QRectF(pos - radius, height - radius, 2 * radius, 2 * radius);
 }
 
@@ -695,8 +690,8 @@ void LayerElementController::unsetRoughnessHandles()
 void LayerElementController::updateRoughness() const
 {
     // Test the roughness
-    double roughness = layerElementItem()->property(LayerElementItem::P_ROUGHNESS).toDouble();
-    double width = layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble();
+    double roughness = layerElementItem()->property<double>(LayerElementItem::P_ROUGHNESS);
+    double width = layerElementItem()->property<double>(LayerElementItem::P_WIDTH);
     setRoughnessInLimits(roughness, false);
 
     // Perform the painting
@@ -705,11 +700,9 @@ void LayerElementController::updateRoughness() const
 
     // Take care of the rounghnessview
     pen.setStyle(Qt::PenStyle::DashLine);
-    pen.setColor(
-        layerElementItem()->property(LayerElementItem::P_ROUGHNESS_PEN_COLOR).value<QColor>());
-    pen.setWidthF(layerElementItem()->property(LayerElementItem::P_ROUGHNESS_PEN_WIDTH).toDouble());
-    brush.setColor(
-        layerElementItem()->property(LayerElementItem::P_ROUGHNESS_BRUSH_COLOR).value<QColor>());
+    pen.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_ROUGHNESS_PEN_COLOR));
+    pen.setWidthF(layerElementItem()->property<double>(LayerElementItem::P_ROUGHNESS_PEN_WIDTH));
+    brush.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_ROUGHNESS_BRUSH_COLOR));
     if (p_roughness_view) {
         p_roughness_view->setPen(pen);
         p_roughness_view->setBrush(brush);
@@ -719,11 +712,9 @@ void LayerElementController::updateRoughness() const
 
     // Take care of the handles
     pen.setStyle(Qt::PenStyle::SolidLine);
-    pen.setColor(
-        layerElementItem()->property(LayerElementItem::P_R_HANDLE_PEN_COLOR).value<QColor>());
-    pen.setWidthF(layerElementItem()->property(LayerElementItem::P_R_HANDLE_PEN_WIDTH).toDouble());
-    brush.setColor(
-        layerElementItem()->property(LayerElementItem::P_R_HANDLE_BRUSH_COLOR).value<QColor>());
+    pen.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_R_HANDLE_PEN_COLOR));
+    pen.setWidthF(layerElementItem()->property<double>(LayerElementItem::P_R_HANDLE_PEN_WIDTH));
+    brush.setColor(layerElementItem()->property<QColor>(LayerElementItem::P_R_HANDLE_BRUSH_COLOR));
     brush.setStyle(Qt::SolidPattern);
 
     if (m_rough_handles_views[0]) {
@@ -741,9 +732,9 @@ void LayerElementController::updateRoughness() const
 //! get the left painter path for the roughness view
 QPainterPath LayerElementController::leftRoughnessPath() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
-    double roughness = layerElementItem()->property(LayerElementItem::P_ROUGHNESS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
+    double roughness = layerElementItem()->property<double>(LayerElementItem::P_ROUGHNESS);
 
     auto path = QPainterPath();
 
@@ -752,9 +743,8 @@ QPainterPath LayerElementController::leftRoughnessPath() const
         path.moveTo(pos, 0);
         path.lineTo(pos - roughness, 0);
     } else {
-        path.moveTo(
-            pos - roughness,
-            layer_above->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble());
+        path.moveTo(pos - roughness,
+                    layer_above->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT));
     }
     path.lineTo(pos - roughness, height);
     path.lineTo(pos, height);
@@ -765,9 +755,9 @@ QPainterPath LayerElementController::leftRoughnessPath() const
 //! get the right painter path for the roughness view
 QPainterPath LayerElementController::rightRoughnessPath() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
-    double roughness = layerElementItem()->property(LayerElementItem::P_ROUGHNESS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
+    double roughness = layerElementItem()->property<double>(LayerElementItem::P_ROUGHNESS);
 
     auto path = QPainterPath();
 
@@ -776,11 +766,10 @@ QPainterPath LayerElementController::rightRoughnessPath() const
         path.moveTo(pos, 0);
         path.lineTo(pos + roughness, 0);
     } else {
-        path.moveTo(
-            pos, layer_above->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble());
-        path.lineTo(
-            pos + roughness,
-            layer_above->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble());
+        path.moveTo(pos,
+                    layer_above->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT));
+        path.lineTo(pos + roughness,
+                    layer_above->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT));
     }
     path.lineTo(pos + roughness, height);
 
@@ -790,16 +779,16 @@ QPainterPath LayerElementController::rightRoughnessPath() const
 //! get the rectangle for the left roughness handles
 QRectF LayerElementController::leftRoughnessHandleRect() const
 {
-    double pos_x = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
-    double radius = layerElementItem()->property(LayerElementItem::P_R_HANDLE_RADIUS).toDouble();
-    double roughness = layerElementItem()->property(LayerElementItem::P_ROUGHNESS).toDouble();
+    double pos_x = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
+    double radius = layerElementItem()->property<double>(LayerElementItem::P_R_HANDLE_RADIUS);
+    double roughness = layerElementItem()->property<double>(LayerElementItem::P_ROUGHNESS);
 
     auto layer_above = layerAbove();
     double lower_height = 0;
     if (layer_above) {
         lower_height =
-            layer_above->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
+            layer_above->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
     }
     double pos_y = (lower_height - height) / 2 + height;
 
@@ -809,16 +798,16 @@ QRectF LayerElementController::leftRoughnessHandleRect() const
 //! get the rectangle for the right roughness handles
 QRectF LayerElementController::rightRoughnessHandleRect() const
 {
-    double pos_x = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
-    double height = layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
-    double radius = layerElementItem()->property(LayerElementItem::P_R_HANDLE_RADIUS).toDouble();
-    double roughness = layerElementItem()->property(LayerElementItem::P_ROUGHNESS).toDouble();
+    double pos_x = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
+    double height = layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
+    double radius = layerElementItem()->property<double>(LayerElementItem::P_R_HANDLE_RADIUS);
+    double roughness = layerElementItem()->property<double>(LayerElementItem::P_ROUGHNESS);
 
     auto layer_above = layerAbove();
     double lower_height = 0;
     if (layer_above) {
         lower_height =
-            layer_above->layerElementItem()->property(LayerElementItem::P_HEIGHT).toDouble();
+            layer_above->layerElementItem()->property<double>(LayerElementItem::P_HEIGHT);
     }
     double pos_y = (lower_height - height) / 2 + height;
 
@@ -868,7 +857,7 @@ void LayerElementController::removeRoughnessHandlesFromScene() const
 //! Handle the position variation of the left handle
 void LayerElementController::leftHandleMoved() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
     double roughness = pos - leftRoughnessHandle()->getLastPos().x();
     setRoughnessInLimits(roughness);
 }
@@ -876,7 +865,7 @@ void LayerElementController::leftHandleMoved() const
 //! Handle the position variation of the right handle
 void LayerElementController::rightHandleMoved() const
 {
-    double pos = layerElementItem()->property(LayerElementItem::P_X_POS).toDouble();
+    double pos = layerElementItem()->property<double>(LayerElementItem::P_X_POS);
     double roughness = rightRoughnessHandle()->getLastPos().x() - pos;
     setRoughnessInLimits(roughness);
 }
@@ -889,14 +878,14 @@ void LayerElementController::setRoughnessInLimits(double roughness, bool active)
         return;
     }
 
-    double width = layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble();
+    double width = layerElementItem()->property<double>(LayerElementItem::P_WIDTH);
     if (width == 0)
         width = 1e6;
 
     auto layer_above = layerAbove();
     if (layer_above) {
         double second_width =
-            layer_above->layerElementItem()->property(LayerElementItem::P_WIDTH).toDouble();
+            layer_above->layerElementItem()->property<double>(LayerElementItem::P_WIDTH);
         if (second_width == 0)
             second_width = 1e6;
 

--- a/examples/quickrefl/core/editors/sldeditor/sldelementcontroller.cpp
+++ b/examples/quickrefl/core/editors/sldeditor/sldelementcontroller.cpp
@@ -155,7 +155,7 @@ string_vec SLDElementController::getIdentifierVector(SessionItem* item)
     for (int i = 0; i < item->childrenCount(); ++i) {
         if (dynamic_cast<MultiLayerItem*>(children.at(i))) {
             auto child = dynamic_cast<MultiLayerItem*>(children.at(i));
-            for (int j = 0; j < child->property(MultiLayerItem::P_NREPETITIONS).toInt(); ++j) {
+            for (int j = 0; j < child->property<int>(MultiLayerItem::P_NREPETITIONS); ++j) {
                 auto child_output = getIdentifierVector(child);
                 output.insert(output.end(), child_output.begin(), child_output.end());
             }
@@ -233,26 +233,25 @@ void SLDElementController::updateToView(SessionItem* item)
         auto layer_item =
             dynamic_cast<LayerItem*>(p_sample_model->findItem(layer_controller->sampleItemId()));
         auto roughness_item = layer_item->item<RoughnessItem>(LayerItem::P_ROUGHNESS);
-        auto material_item = dynamic_cast<SLDMaterialItem*>(
-            p_material_model->findItem(layer_item->property(LayerItem::P_MATERIAL)
-                                           .value<ModelView::ExternalProperty>()
-                                           .identifier()));
+        auto material_item = dynamic_cast<SLDMaterialItem*>(p_material_model->findItem(
+            layer_item->property<ExternalProperty>(LayerItem::P_MATERIAL).identifier()));
 
         layer_controller->layerElementItem()->setProperty(
-            LayerElementItem::P_ROUGHNESS, roughness_item->property(RoughnessItem::P_SIGMA));
+            LayerElementItem::P_ROUGHNESS,
+            roughness_item->property<double>(RoughnessItem::P_SIGMA));
         layer_controller->layerElementItem()->setProperty(
-            LayerElementItem::P_WIDTH, layer_item->property(LayerItem::P_THICKNESS).toDouble());
+            LayerElementItem::P_WIDTH, layer_item->property<double>(LayerItem::P_THICKNESS));
 
         if (material_item) {
             layer_controller->layerElementItem()->setProperty(
                 LayerElementItem::P_HEIGHT,
-                material_item->property(SLDMaterialItem::P_SLD_REAL).toDouble());
+                material_item->property<double>(SLDMaterialItem::P_SLD_REAL));
             layer_controller->layerElementItem()->setProperty(
                 LayerElementItem::P_TOP_BRUSH_COLOR,
-                material_item->property(SLDMaterialItem::P_COLOR));
+                material_item->property<QColor>(SLDMaterialItem::P_COLOR));
             layer_controller->layerElementItem()->setProperty(
                 LayerElementItem::P_SIDE_BRUSH_COLOR,
-                material_item->property(SLDMaterialItem::P_COLOR));
+                material_item->property<QColor>(SLDMaterialItem::P_COLOR));
         } else {
             layer_controller->layerElementItem()->setProperty(LayerElementItem::P_HEIGHT, 1e-6);
             layer_controller->layerElementItem()->setProperty(LayerElementItem::P_TOP_BRUSH_COLOR,
@@ -274,10 +273,8 @@ void SLDElementController::updateThicknessFromView(std::string identifier, doubl
 void SLDElementController::updateSLDFromView(std::string identifier, double value)
 {
     auto layer_item = dynamic_cast<LayerItem*>(p_sample_model->findItem(identifier));
-    auto material_item = dynamic_cast<SLDMaterialItem*>(
-        p_material_model->findItem(layer_item->property(LayerItem::P_MATERIAL)
-                                       .value<ModelView::ExternalProperty>()
-                                       .identifier()));
+    auto material_item = dynamic_cast<SLDMaterialItem*>(p_material_model->findItem(
+        layer_item->property<ExternalProperty>(LayerItem::P_MATERIAL).identifier()));
     if (material_item)
         material_item->setProperty(SLDMaterialItem::P_SLD_REAL, value);
 }

--- a/examples/quickrefl/core/model/materialitems.cpp
+++ b/examples/quickrefl/core/model/materialitems.cpp
@@ -34,8 +34,8 @@ MaterialBaseItem::MaterialBaseItem(const std::string& model_type)
 
 ModelView::ExternalProperty MaterialBaseItem::external_property() const
 {
-    QColor color = isTag(P_COLOR) ? property(P_COLOR).value<QColor>() : QColor(Qt::red);
-    std::string name = isTag(P_NAME) ? property(P_NAME).value<std::string>() : std::string();
+    QColor color = isTag(P_COLOR) ? property<QColor>(P_COLOR) : QColor(Qt::red);
+    std::string name = isTag(P_NAME) ? property<std::string>(P_NAME) : std::string();
     return ModelView::ExternalProperty(name, color, identifier());
 }
 

--- a/examples/quickrefl/core/model/materialpropertycontroller.cpp
+++ b/examples/quickrefl/core/model/materialpropertycontroller.cpp
@@ -51,7 +51,7 @@ void MaterialPropertyController::update_all()
 {
     auto layers = Utils::FindItems<LayerItem>(m_sample_model);
     for (auto layer : Utils::FindItems<LayerItem>(m_sample_model)) {
-        auto property = layer->property(LayerItem::P_MATERIAL).value<ModelView::ExternalProperty>();
+        auto property = layer->property<ExternalProperty>(LayerItem::P_MATERIAL);
         auto updated = m_material_model->material_property(property.identifier());
         if (property != updated)
             layer->setProperty(LayerItem::P_MATERIAL, updated);

--- a/examples/quickrefl/tests/layerelements.test.cpp
+++ b/examples/quickrefl/tests/layerelements.test.cpp
@@ -847,12 +847,12 @@ TEST_F(LayerElementTest, testpropagation)
 
     // #############################################################################s
     // Test propagation for the contruction
-    EXPECT_EQ(0., item_above->property(LayerElementItem::P_X_POS).toDouble());
-    EXPECT_EQ(10., item_above->property(LayerElementItem::P_WIDTH).toDouble());
-    EXPECT_EQ(10., item_middle->property(LayerElementItem::P_X_POS).toDouble());
-    EXPECT_EQ(10., item_middle->property(LayerElementItem::P_WIDTH).toDouble());
-    EXPECT_EQ(20., item_below->property(LayerElementItem::P_X_POS).toDouble());
-    EXPECT_EQ(10., item_below->property(LayerElementItem::P_WIDTH).toDouble());
+    EXPECT_EQ(0., item_above->property<double>(LayerElementItem::P_X_POS));
+    EXPECT_EQ(10., item_above->property<double>(LayerElementItem::P_WIDTH));
+    EXPECT_EQ(10., item_middle->property<double>(LayerElementItem::P_X_POS));
+    EXPECT_EQ(10., item_middle->property<double>(LayerElementItem::P_WIDTH));
+    EXPECT_EQ(20., item_below->property<double>(LayerElementItem::P_X_POS));
+    EXPECT_EQ(10., item_below->property<double>(LayerElementItem::P_WIDTH));
 
     // #############################################################################s
     // Test signaling for property changes
@@ -873,8 +873,8 @@ TEST_F(LayerElementTest, testpropagation)
 
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "above");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 8);
-    EXPECT_EQ(8., item_above->property(LayerElementItem::P_WIDTH).toDouble());
-    EXPECT_EQ(8., item_middle->property(LayerElementItem::P_X_POS).toDouble());
+    EXPECT_EQ(8., item_above->property<double>(LayerElementItem::P_WIDTH));
+    EXPECT_EQ(8., item_middle->property<double>(LayerElementItem::P_X_POS));
     EXPECT_EQ(3., first_handle_middle->rectangle().x());
     EXPECT_EQ(5., first_handle_middle->rectangle().y());
     EXPECT_EQ(3., second_handle_middle->rectangle().x());
@@ -883,7 +883,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 4);
-    EXPECT_EQ(4, item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(4, item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 
     // Try limit x move
     mouse_move_event->setPos(QPointF(adapter->toSceneX(1), adapter->toSceneY(0)));
@@ -892,8 +892,8 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_above_width.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "above");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 0);
-    EXPECT_EQ(0, item_above->property(LayerElementItem::P_WIDTH).toDouble());
-    EXPECT_EQ(0, item_middle->property(LayerElementItem::P_X_POS).toDouble());
+    EXPECT_EQ(0, item_above->property<double>(LayerElementItem::P_WIDTH));
+    EXPECT_EQ(0, item_middle->property<double>(LayerElementItem::P_X_POS));
     EXPECT_EQ(-5, first_handle_middle->rectangle().x());
     EXPECT_EQ(5., first_handle_middle->rectangle().y());
     EXPECT_EQ(-5, second_handle_middle->rectangle().x());
@@ -906,8 +906,8 @@ TEST_F(LayerElementTest, testpropagation)
 
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "above");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 10);
-    EXPECT_EQ(10., item_above->property(LayerElementItem::P_WIDTH).toDouble());
-    EXPECT_EQ(10., item_middle->property(LayerElementItem::P_X_POS).toDouble());
+    EXPECT_EQ(10., item_above->property<double>(LayerElementItem::P_WIDTH));
+    EXPECT_EQ(10., item_middle->property<double>(LayerElementItem::P_X_POS));
     EXPECT_EQ(5., first_handle_middle->rectangle().x());
     EXPECT_EQ(5., first_handle_middle->rectangle().y());
     EXPECT_EQ(5., second_handle_middle->rectangle().x());
@@ -920,7 +920,7 @@ TEST_F(LayerElementTest, testpropagation)
 
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 8);
-    EXPECT_EQ(8., item_middle->property(LayerElementItem::P_HEIGHT).toDouble());
+    EXPECT_EQ(8., item_middle->property<double>(LayerElementItem::P_HEIGHT));
     EXPECT_EQ(5., first_handle_middle->rectangle().x());
     EXPECT_EQ(5., first_handle_middle->rectangle().y());
     EXPECT_EQ(5., second_handle_middle->rectangle().x());
@@ -933,7 +933,7 @@ TEST_F(LayerElementTest, testpropagation)
 
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 0);
-    EXPECT_EQ(0, item_middle->property(LayerElementItem::P_HEIGHT).toDouble());
+    EXPECT_EQ(0, item_middle->property<double>(LayerElementItem::P_HEIGHT));
     EXPECT_EQ(5., first_handle_middle->rectangle().x());
     EXPECT_EQ(5., first_handle_middle->rectangle().y());
     EXPECT_EQ(5., second_handle_middle->rectangle().x());
@@ -946,7 +946,7 @@ TEST_F(LayerElementTest, testpropagation)
 
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 10);
-    EXPECT_EQ(10., item_middle->property(LayerElementItem::P_HEIGHT).toDouble());
+    EXPECT_EQ(10., item_middle->property<double>(LayerElementItem::P_HEIGHT));
     EXPECT_EQ(5., first_handle_middle->rectangle().x());
     EXPECT_EQ(5., first_handle_middle->rectangle().y());
     EXPECT_EQ(5., second_handle_middle->rectangle().x());
@@ -959,7 +959,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 3.);
-    EXPECT_EQ(3., item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(3., item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 
     // Try limit roughness move left handle
     mouse_move_event->setPos(QPointF(adapter->toSceneX(-2), adapter->toSceneY(0)));
@@ -968,7 +968,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 5.);
-    EXPECT_EQ(5., item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(5., item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 
     // Try standard roughness move left handle
     mouse_move_event->setPos(QPointF(adapter->toSceneX(-8), adapter->toSceneY(0)));
@@ -977,7 +977,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 2.);
-    EXPECT_EQ(2., item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(2., item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 
     // Try standard roughness move right handle
     mouse_move_event->setPos(QPointF(adapter->toSceneX(-13), adapter->toSceneY(0)));
@@ -986,7 +986,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 3.);
-    EXPECT_EQ(3., item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(3., item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 
     // Try limit roughness move right handle
     mouse_move_event->setPos(QPointF(adapter->toSceneX(-8), adapter->toSceneY(0)));
@@ -995,7 +995,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 0);
-    EXPECT_EQ(0, item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(0, item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 
     // Try standard roughness move right handle
     mouse_move_event->setPos(QPointF(adapter->toSceneX(-13), adapter->toSceneY(0)));
@@ -1004,7 +1004,7 @@ TEST_F(LayerElementTest, testpropagation)
     move_arguments = spy_ctr_middle_roughness.takeLast();
     EXPECT_EQ(move_arguments.at(0).value<std::string>(), "middle");
     EXPECT_EQ(move_arguments.at(1).value<double>(), 3);
-    EXPECT_EQ(3, item_middle->property(LayerElementItem::P_ROUGHNESS).toDouble());
+    EXPECT_EQ(3, item_middle->property<double>(LayerElementItem::P_ROUGHNESS));
 }
 TEST_F(LayerElementTest, moveelements)
 {

--- a/examples/quickrefl/tests/layeritems.test.cpp
+++ b/examples/quickrefl/tests/layeritems.test.cpp
@@ -32,53 +32,52 @@ LayerItemsTest::~LayerItemsTest() = default;
 
 TEST_F(LayerItemsTest, layerAppearanceTwoLayerSystem)
 {
-   SampleModel model;
+    SampleModel model;
 
-   auto multilayer = model.insertItem<MultiLayerItem>();
+    auto multilayer = model.insertItem<MultiLayerItem>();
 
-   auto top = model.insertItem<LayerItem>(multilayer);
-   auto bottom = model.insertItem<LayerItem>(multilayer);
+    auto top = model.insertItem<LayerItem>(multilayer);
+    auto bottom = model.insertItem<LayerItem>(multilayer);
 
-   // check appearance of thickness properties
-   EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
-   EXPECT_FALSE(bottom->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    // check appearance of thickness properties
+    EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    EXPECT_FALSE(bottom->getItem(LayerItem::P_THICKNESS)->isEnabled());
 
-   // check that thickness of top and bottom layer is 0.
-   EXPECT_EQ(top->property(LayerItem::P_THICKNESS).value<double>(), 0.0);
-   EXPECT_EQ(bottom->property(LayerItem::P_THICKNESS).value<double>(), 0.0);
+    // check that thickness of top and bottom layer is 0.
+    EXPECT_EQ(top->property<double>(LayerItem::P_THICKNESS), 0.0);
+    EXPECT_EQ(bottom->property<double>(LayerItem::P_THICKNESS), 0.0);
 }
 
 TEST_F(LayerItemsTest, layerAppearanceThreeLayerSystem)
 {
-   SampleModel model;
+    SampleModel model;
 
-   auto multilayer = model.insertItem<MultiLayerItem>();
+    auto multilayer = model.insertItem<MultiLayerItem>();
 
-   auto top = model.insertItem<LayerItem>(multilayer);
-   auto middle = model.insertItem<LayerItem>(multilayer);
-   auto bottom = model.insertItem<LayerItem>(multilayer);
+    auto top = model.insertItem<LayerItem>(multilayer);
+    auto middle = model.insertItem<LayerItem>(multilayer);
+    auto bottom = model.insertItem<LayerItem>(multilayer);
 
-   // check appearance of thickness properties
-   EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
-   EXPECT_TRUE(middle->getItem(LayerItem::P_THICKNESS)->isEnabled());
-   EXPECT_FALSE(bottom->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    // check appearance of thickness properties
+    EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    EXPECT_TRUE(middle->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    EXPECT_FALSE(bottom->getItem(LayerItem::P_THICKNESS)->isEnabled());
 
-   middle->setProperty(LayerItem::P_THICKNESS, 42.0);
+    middle->setProperty(LayerItem::P_THICKNESS, 42.0);
 
-   // moving middle layer on top
-   model.moveItem(middle, multilayer, {MultiLayerItem::T_LAYERS, 0});
+    // moving middle layer on top
+    model.moveItem(middle, multilayer, {MultiLayerItem::T_LAYERS, 0});
 
-   auto new_top = middle;
-   auto new_middle = top;
-   auto new_bottom = bottom;
+    auto new_top = middle;
+    auto new_middle = top;
+    auto new_bottom = bottom;
 
-   EXPECT_FALSE(new_top->getItem(LayerItem::P_THICKNESS)->isEnabled());
-   EXPECT_TRUE(new_middle->getItem(LayerItem::P_THICKNESS)->isEnabled());
-   EXPECT_FALSE(new_bottom->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    EXPECT_FALSE(new_top->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    EXPECT_TRUE(new_middle->getItem(LayerItem::P_THICKNESS)->isEnabled());
+    EXPECT_FALSE(new_bottom->getItem(LayerItem::P_THICKNESS)->isEnabled());
 
-   // check the value of thickness
-   EXPECT_EQ(new_top->property(LayerItem::P_THICKNESS).value<double>(),
-             0.0); // was reset during move
-   EXPECT_EQ(new_middle->property(LayerItem::P_THICKNESS).value<double>(), 0.0);
-   EXPECT_EQ(new_bottom->property(LayerItem::P_THICKNESS).value<double>(), 0.0);
+    // check the value of thickness
+    EXPECT_EQ(new_top->property<double>(LayerItem::P_THICKNESS), 0.0); // was reset during move
+    EXPECT_EQ(new_middle->property<double>(LayerItem::P_THICKNESS), 0.0);
+    EXPECT_EQ(new_bottom->property<double>(LayerItem::P_THICKNESS), 0.0);
 }

--- a/examples/quickrefl/tests/quicksimutils.test.cpp
+++ b/examples/quickrefl/tests/quicksimutils.test.cpp
@@ -88,15 +88,15 @@ TEST_F(QuickSimUtilsTest, testData)
 
     // checking that layer got necessary parameters
     auto layer = test_data.multilayer->item<LayerItem>(MultiLayerItem::T_LAYERS);
-    EXPECT_EQ(layer->property(LayerItem::P_THICKNESS).value<double>(), thickness);
+    EXPECT_EQ(layer->property<double>(LayerItem::P_THICKNESS), thickness);
     auto roughness = layer->item<RoughnessItem>(LayerItem::P_ROUGHNESS);
-    EXPECT_EQ(roughness->property(RoughnessItem::P_SIGMA).value<double>(), sigma);
+    EXPECT_EQ(roughness->property<double>(RoughnessItem::P_SIGMA), sigma);
 
     // checking that layer is linked to material with necessary parameters
-    auto material_property = layer->property(LayerItem::P_MATERIAL).value<ExternalProperty>();
+    auto material_property = layer->property<ExternalProperty>(LayerItem::P_MATERIAL);
     auto material = test_data.sample_model.findItem(material_property.identifier());
-    EXPECT_EQ(material->property(SLDMaterialItem::P_SLD_REAL), sld.real());
-    EXPECT_EQ(material->property(SLDMaterialItem::P_SLD_IMAG), sld.imag());
+    EXPECT_EQ(material->property<double>(SLDMaterialItem::P_SLD_REAL), sld.real());
+    EXPECT_EQ(material->property<double>(SLDMaterialItem::P_SLD_IMAG), sld.imag());
 }
 
 //! Multi-slice of empty MultiLayer.

--- a/examples/sampleview/core/model/MaterialModel.cpp
+++ b/examples/sampleview/core/model/MaterialModel.cpp
@@ -58,8 +58,8 @@ std::vector<ExternalProperty> MaterialModel::material_data(std::string container
             continue;
         for (auto item : container->children()) {
             if (auto material = dynamic_cast<MaterialBaseItem*>(item)) {
-                auto text = material->property(MaterialBaseItem::P_NAME).value<std::string>();
-                auto color = material->property(MaterialBaseItem::P_COLOR).value<QColor>();
+                auto text = material->property<std::string>(MaterialBaseItem::P_NAME);
+                auto color = material->property<QColor>(MaterialBaseItem::P_COLOR);
                 auto id = material->identifier();
                 result.push_back(ExternalProperty(text, color, id));
             }

--- a/examples/sampleview/core/model/MaterialPropertyController.cpp
+++ b/examples/sampleview/core/model/MaterialPropertyController.cpp
@@ -51,7 +51,7 @@ void MaterialPropertyController::update_all()
 {
     auto layers = Utils::FindItems<LayerItem>(m_sample_model);
     for (auto layer : Utils::FindItems<LayerItem>(m_sample_model)) {
-        auto property = layer->property(LayerItem::P_MATERIAL).value<ModelView::ExternalProperty>();
+        auto property = layer->property<ExternalProperty>(LayerItem::P_MATERIAL);
         auto updated = m_material_model->material_property(property.identifier());
         if (property != updated)
             layer->setProperty(LayerItem::P_MATERIAL, updated);

--- a/examples/sampleview/core/sampledesigner/IView.cpp
+++ b/examples/sampleview/core/sampledesigner/IView.cpp
@@ -38,8 +38,8 @@ void IView::subscribe(SessionItem* item)
     if (toolTip().isEmpty())
         setToolTip(QString::fromStdString(item->displayName()));
 
-    setX(m_item->property(LocatedItem::P_X_POS).toReal());
-    setY(m_item->property(LocatedItem::P_Y_POS).toReal());
+    setX(m_item->property<double>(LocatedItem::P_X_POS));
+    setY(m_item->property<double>(LocatedItem::P_Y_POS));
 
     auto on_property_change = [this](SessionItem*, std::string property) {
         onPropertyChange(property);
@@ -83,7 +83,7 @@ void IView::onPropertyChange(const std::string& propertyName)
 {
     Q_ASSERT(m_item);
     if (propertyName == LocatedItem::P_X_POS)
-        setX(m_item->property(LocatedItem::P_X_POS).toReal());
+        setX(m_item->property<double>(LocatedItem::P_X_POS));
     else if (propertyName == LocatedItem::P_Y_POS)
-        setY(m_item->property(LocatedItem::P_Y_POS).toReal());
+        setY(m_item->property<double>(LocatedItem::P_Y_POS));
 }

--- a/examples/sampleview/core/sampledesigner/LayerView.cpp
+++ b/examples/sampleview/core/sampledesigner/LayerView.cpp
@@ -83,7 +83,7 @@ void LayerView::updateHeight()
     if (!getItem()->isTag(LayerItem::P_THICKNESS))
         return;
 
-    const double thickness = getItem()->property(LayerItem::P_THICKNESS).value<double>();
+    const double thickness = getItem()->property<double>(LayerItem::P_THICKNESS);
     const qreal height = thicknessToHeight(thickness);
     m_rect.setTop(-height / 2.0);
     m_rect.setHeight(height);

--- a/examples/sampleview/core/sampledesigner/LayerView.cpp
+++ b/examples/sampleview/core/sampledesigner/LayerView.cpp
@@ -95,7 +95,7 @@ void LayerView::updateHeight()
 void LayerView::updateColor()
 {
     if (getItem()->isTag(LayerItem::P_MATERIAL)) {
-        QVariant v = getItem()->getItem(LayerItem::P_MATERIAL)->data();
+        QVariant v = getItem()->getItem(LayerItem::P_MATERIAL)->data<QVariant>();
         if (v.isValid()) {
             auto mp = v.value<ExternalProperty>();
             setColor(mp.color());
@@ -115,7 +115,7 @@ void LayerView::updateLabel()
 
     QString material = "";
     if (getItem()->isTag(LayerItem::P_MATERIAL)) {
-        QVariant v = getItem()->getItem(LayerItem::P_MATERIAL)->data();
+        QVariant v = getItem()->getItem(LayerItem::P_MATERIAL)->data<QVariant>();
         if (v.isValid()) {
             ExternalProperty mp = v.value<ExternalProperty>();
             material = QString::fromStdString(mp.text());

--- a/examples/sampleview/tests/TestLayerView.cpp
+++ b/examples/sampleview/tests/TestLayerView.cpp
@@ -64,8 +64,8 @@ TEST_F(TestlayerView, testChangeThickness)
     auto layer = model.insertNewItem(::Constants::LayerType);
     auto view = scene->getViewForItem(layer);
 
-    double x_pos = layer->property(LocatedItem::P_X_POS).value<double>();
-    double y_pos = layer->property(LocatedItem::P_Y_POS).value<double>();
+    double x_pos = layer->property<double>(LocatedItem::P_X_POS);
+    double y_pos = layer->property<double>(LocatedItem::P_Y_POS);
 
     layer->setProperty(LayerItem::P_THICKNESS, 100.0);
 
@@ -75,8 +75,8 @@ TEST_F(TestlayerView, testChangeThickness)
     EXPECT_DOUBLE_EQ(bound.top(), -65.0);
     EXPECT_DOUBLE_EQ(bound.bottom(), 65.0);
 
-    EXPECT_DOUBLE_EQ(x_pos, layer->property(LocatedItem::P_X_POS).value<double>());
-    EXPECT_DOUBLE_EQ(y_pos, layer->property(LocatedItem::P_Y_POS).value<double>());
+    EXPECT_DOUBLE_EQ(x_pos, layer->property<double>(LocatedItem::P_X_POS));
+    EXPECT_DOUBLE_EQ(y_pos, layer->property<double>(LocatedItem::P_Y_POS));
 
     QRectF frame = makeFrame(view->sceneBoundingRect());
     auto item_list = scene->items(frame, Qt::ContainsItemBoundingRect);

--- a/examples/sampleview/tests/TestMultilayerView.cpp
+++ b/examples/sampleview/tests/TestMultilayerView.cpp
@@ -78,8 +78,8 @@ TEST_F(TestMultilayerView, testInsertLayer)
     QPointF mpos = mview->pos(); // position in parent coordinates (i.e. scene)
     EXPECT_DOUBLE_EQ(initial_pos.x(), mpos.x());
     EXPECT_DOUBLE_EQ(initial_pos.y(), mpos.y());
-    EXPECT_DOUBLE_EQ(mpos.x(), mlayer->property(LocatedItem::P_X_POS).value<double>());
-    EXPECT_DOUBLE_EQ(mpos.y(), mlayer->property(LocatedItem::P_Y_POS).value<double>());
+    EXPECT_DOUBLE_EQ(mpos.x(), mlayer->property<double>(LocatedItem::P_X_POS));
+    EXPECT_DOUBLE_EQ(mpos.y(), mlayer->property<double>(LocatedItem::P_Y_POS));
 
     QRectF lbound = lview->boundingRect();
     EXPECT_DOUBLE_EQ(lbound.left(), -100.0);
@@ -90,8 +90,8 @@ TEST_F(TestMultilayerView, testInsertLayer)
     QPointF lpos = lview->pos(); // position in parent coordinates (i.e. multilayer)
     EXPECT_DOUBLE_EQ(lpos.x(), 0.0);
     EXPECT_DOUBLE_EQ(lpos.y(), 0.0);
-    EXPECT_DOUBLE_EQ(lpos.x(), layer->property(LocatedItem::P_X_POS).value<double>());
-    EXPECT_DOUBLE_EQ(lpos.y(), layer->property(LocatedItem::P_Y_POS).value<double>());
+    EXPECT_DOUBLE_EQ(lpos.x(), layer->property<double>(LocatedItem::P_X_POS));
+    EXPECT_DOUBLE_EQ(lpos.y(), layer->property<double>(LocatedItem::P_Y_POS));
 
     QRectF frame = makeFrame(mview->sceneBoundingRect());
     auto item_list = scene->items(frame, Qt::ContainsItemBoundingRect);
@@ -120,8 +120,8 @@ TEST_F(TestMultilayerView, testRemoveLayer)
     const QPointF pos = view->pos();
     EXPECT_DOUBLE_EQ(initial_pos.x(), pos.x());
     EXPECT_DOUBLE_EQ(initial_pos.y(), pos.y());
-    EXPECT_DOUBLE_EQ(pos.x(), mlayer->property(LocatedItem::P_X_POS).value<double>());
-    EXPECT_DOUBLE_EQ(pos.y(), mlayer->property(LocatedItem::P_Y_POS).value<double>());
+    EXPECT_DOUBLE_EQ(pos.x(), mlayer->property<double>(LocatedItem::P_X_POS));
+    EXPECT_DOUBLE_EQ(pos.y(), mlayer->property<double>(LocatedItem::P_Y_POS));
 
     const QRectF frame = makeFrame(view->sceneBoundingRect());
     auto item_list = scene->items(frame, Qt::ContainsItemBoundingRect);

--- a/examples/treeviews/core/items.cpp
+++ b/examples/treeviews/core/items.cpp
@@ -67,7 +67,7 @@ void InterferenceFunctionItem::activate()
 void InterferenceFunctionItem::update_appearance()
 {
     auto angle_item = getItem(P_ROTATION_ANLE);
-    angle_item->setEnabled(!property(P_INTEGRATION).value<bool>());
+    angle_item->setEnabled(!property<bool>(P_INTEGRATION));
 }
 
 // ----------------------------------------------------------------------------

--- a/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
@@ -55,7 +55,7 @@ void SetValueCommand::execute_command()
 void SetValueCommand::swap_values()
 {
     auto item = itemFromPath(p_impl->m_item_path);
-    QVariant old = item->data(p_impl->m_role);
+    auto old = item->data<QVariant>(p_impl->m_role);
     p_impl->m_result = item->setDataIntern(p_impl->m_value, p_impl->m_role);
     setObsolete(!p_impl->m_result);
     p_impl->m_value = old;

--- a/source/libmvvm_model/mvvm/model/groupitem.cpp
+++ b/source/libmvvm_model/mvvm/model/groupitem.cpp
@@ -26,13 +26,12 @@ GroupItem::GroupItem(model_type modelType)
       m_default_selected_index(0)
 {
     registerTag(TagInfo::universalTag(tag_name), /*set_as_default*/ true);
+    setData(QVariant::fromValue(ComboProperty()));
 }
 
 int GroupItem::currentIndex() const
 {
-    auto variant = data<QVariant>();
-    // FIXME cleanup
-    return variant.isValid() ? variant.value<ComboProperty>().currentIndex() : -1;
+    return data<ComboProperty>().currentIndex();
 }
 
 //! Returns currently selected item.
@@ -62,13 +61,9 @@ void GroupItem::setCurrentType(const std::string& model_type)
 
 void GroupItem::setCurrentIndex(int index)
 {
-    auto variant = data<QVariant>();
-    // FIXME cleanup
-    if (variant.isValid()) {
-        auto combo = variant.value<ComboProperty>();
-        combo.setCurrentIndex(index);
-        setDataIntern(QVariant::fromValue(combo), ItemDataRole::DATA);
-    }
+    auto combo = data<ComboProperty>();
+    combo.setCurrentIndex(index);
+    setDataIntern(QVariant::fromValue(combo), ItemDataRole::DATA);
 }
 
 bool GroupItem::is_valid_index() const

--- a/source/libmvvm_model/mvvm/model/groupitem.cpp
+++ b/source/libmvvm_model/mvvm/model/groupitem.cpp
@@ -30,7 +30,8 @@ GroupItem::GroupItem(model_type modelType)
 
 int GroupItem::currentIndex() const
 {
-    auto variant = data();
+    auto variant = data<QVariant>();
+    // FIXME cleanup
     return variant.isValid() ? variant.value<ComboProperty>().currentIndex() : -1;
 }
 
@@ -61,7 +62,8 @@ void GroupItem::setCurrentType(const std::string& model_type)
 
 void GroupItem::setCurrentIndex(int index)
 {
-    auto variant = data();
+    auto variant = data<QVariant>();
+    // FIXME cleanup
     if (variant.isValid()) {
         auto combo = variant.value<ComboProperty>();
         combo.setCurrentIndex(index);

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -89,6 +89,13 @@ bool SessionItem::setData(const QVariant& variant, int role)
     return setDataIntern(variant, role);
 }
 
+//! Returns true if item has data on board with given role.
+
+bool SessionItem::hasData(int role) const
+{
+    return p_impl->m_data->hasData(role);
+}
+
 //! Returns data in the form of QVariant for given role.
 //! Method invented to hide implementaiton details.
 

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -18,18 +18,17 @@
 #include <mvvm/signals/modelmapper.h>
 #include <stdexcept>
 
+using namespace ModelView;
+
 namespace
 {
 int appearance(const ModelView::SessionItem& item)
 {
-    // FIXME cleanup
-    auto value = item.data<QVariant>(ModelView::ItemDataRole::APPEARANCE);
-    return value.isValid() ? value.value<int>()
-                           : ModelView::Appearance::EDITABLE | ModelView::Appearance::ENABLED;
+    const int default_appearance = Appearance::EDITABLE | Appearance::ENABLED;
+    return item.hasData(ItemDataRole::APPEARANCE) ? item.data<int>(ItemDataRole::APPEARANCE)
+                                                  : default_appearance;
 }
 } // namespace
-
-using namespace ModelView;
 
 struct SessionItem::SessionItemImpl {
     SessionItem* m_parent{nullptr};

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -299,13 +299,6 @@ void SessionItem::setAppearanceFlag(int flag, bool value)
     setDataIntern(flags, ItemDataRole::APPEARANCE);
 }
 
-//! Sets value to property item. Internal method to hide
-
-void SessionItem::set_property_intern(const std::string &tag, const QVariant &variant)
-{
-    getItem(tag)->setData(variant);
-}
-
 SessionItemData* SessionItem::itemData() const
 {
     return p_impl->m_data.get();

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -269,14 +269,6 @@ bool SessionItem::isSinglePropertyTag(const std::string& tag) const
     return p_impl->m_tags->isSinglePropertyTag(tag);
 }
 
-//! Returns data stored in property item.
-//! Property is single item registered under certain tag via CompoundItem::addProperty method.
-
-QVariant SessionItem::property(const std::string& tag) const
-{
-    return getItem(tag)->data();
-}
-
 void SessionItem::setParent(SessionItem* parent)
 {
     p_impl->m_parent = parent;

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -88,7 +88,10 @@ bool SessionItem::setData(const QVariant& variant, int role)
     return setDataIntern(variant, role);
 }
 
-QVariant SessionItem::data(int role) const
+//! Returns data in the form of QVariant for given role.
+//! Method invented to hide implementaiton details.
+
+QVariant SessionItem::data_internal(int role) const
 {
     return p_impl->m_data->data(role);
 }

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -22,7 +22,8 @@ namespace
 {
 int appearance(const ModelView::SessionItem& item)
 {
-    auto value = item.data(ModelView::ItemDataRole::APPEARANCE);
+    // FIXME cleanup
+    auto value = item.data<QVariant>(ModelView::ItemDataRole::APPEARANCE);
     return value.isValid() ? value.value<int>()
                            : ModelView::Appearance::EDITABLE | ModelView::Appearance::ENABLED;
 }
@@ -67,7 +68,7 @@ model_type SessionItem::modelType() const
 
 std::string SessionItem::displayName() const
 {
-    return data(ItemDataRole::DISPLAY).value<std::string>();
+    return data<std::string>(ItemDataRole::DISPLAY);
 }
 
 SessionItem* SessionItem::setDisplayName(const std::string& name)
@@ -78,7 +79,7 @@ SessionItem* SessionItem::setDisplayName(const std::string& name)
 
 std::string SessionItem::identifier() const
 {
-    return data(ItemDataRole::IDENTIFIER).value<std::string>();
+    return data<std::string>(ItemDataRole::IDENTIFIER);
 }
 
 bool SessionItem::setData(const QVariant& variant, int role)

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -87,7 +87,7 @@ public:
 
     bool isSinglePropertyTag(const std::string& tag) const;
 
-    template <typename T = QVariant> T property(const std::string& tag) const;
+    template <typename T> T property(const std::string& tag) const;
 
     template <typename T> void setProperty(const std::string& tag, const T& value);
 

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -44,6 +44,8 @@ public:
     bool setData(const QVariant& variant, int role = ItemDataRole::DATA);
     bool setDataIntern(const QVariant& variant, int role);
 
+    bool hasData(int role = ItemDataRole::DATA) const;
+
     template <typename T> T data(int role = ItemDataRole::DATA) const;
 
     SessionModel* model() const;

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -44,7 +44,7 @@ public:
     bool setData(const QVariant& variant, int role = ItemDataRole::DATA);
     bool setDataIntern(const QVariant& variant, int role);
 
-    template <typename T = QVariant> T data(int role = ItemDataRole::DATA) const;
+    template <typename T> T data(int role = ItemDataRole::DATA) const;
 
     SessionModel* model() const;
 
@@ -126,10 +126,7 @@ template <typename T> inline T SessionItem::data(int role) const
 
 template <typename T> inline T SessionItem::property(const std::string& tag) const
 {
-    auto item_data = getItem(tag)->data();
-    if constexpr (std::is_same<T, QVariant>::value)
-        return item_data;
-    return item_data.value<T>();
+    return getItem(tag)->data<T>();
 }
 
 //! Sets value to property item.

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -44,7 +44,7 @@ public:
     bool setData(const QVariant& variant, int role = ItemDataRole::DATA);
     bool setDataIntern(const QVariant& variant, int role);
 
-    QVariant data(int role = ItemDataRole::DATA) const;
+    template <typename T = QVariant> T data(int role = ItemDataRole::DATA) const;
 
     SessionModel* model() const;
 
@@ -97,6 +97,7 @@ private:
     friend class SessionModel;
     friend class JsonItemConverter;
     virtual void activate() {}
+    QVariant data_internal(int role) const;
     void setParent(SessionItem* parent);
     void setModel(SessionModel* model);
     void setAppearanceFlag(int flag, bool value);
@@ -110,6 +111,15 @@ private:
     struct SessionItemImpl;
     std::unique_ptr<SessionItemImpl> p_impl;
 };
+
+//! Returns data of given type T for given role.
+
+template <typename T> inline T SessionItem::data(int role) const
+{
+    if constexpr (std::is_same<T, QVariant>::value)
+        return data_internal(role);
+    return data_internal(role).value<T>();
+}
 
 //! Returns data stored in property item.
 //! Property is single item registered under certain tag via CompoundItem::addProperty method.

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -100,7 +100,6 @@ private:
     void setParent(SessionItem* parent);
     void setModel(SessionModel* model);
     void setAppearanceFlag(int flag, bool value);
-    void set_property_intern(const std::string& tag, const QVariant& variant);
 
     // FIXME refactor converter access to item internals
     class SessionItemData* itemData() const;
@@ -129,8 +128,12 @@ template <typename T> inline T SessionItem::property(const std::string& tag) con
 
 template <typename T> inline void SessionItem::setProperty(const std::string& tag, const T& value)
 {
-    set_property_intern(tag, QVariant::fromValue(value));
+    getItem(tag)->setData(QVariant::fromValue(value));
 }
+
+//! Sets value to property item (specialized for special "const char *" case).
+//! Property is single item registered under certain tag via CompoundItem::addProperty method, the
+//! value will be assigned to it's data role.
 
 inline void SessionItem::setProperty(const std::string& tag, const char* value)
 {

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -12,10 +12,11 @@
 
 #include <QVariant>
 #include <memory>
-#include <mvvm/model/customvariants.h>
 #include <mvvm/core/export.h>
+#include <mvvm/model/customvariants.h>
 #include <mvvm/model/mvvm_types.h>
 #include <mvvm/model/tagrow.h>
+#include <type_traits>
 #include <vector>
 
 namespace ModelView
@@ -86,10 +87,9 @@ public:
 
     bool isSinglePropertyTag(const std::string& tag) const;
 
-    QVariant property(const std::string& tag) const;
+    template <typename T = QVariant> T property(const std::string& tag) const;
 
-    template<typename T>
-    void setProperty(const std::string& tag, const T& value);
+    template <typename T> void setProperty(const std::string& tag, const T& value);
 
     void setProperty(const std::string& tag, const char* value);
 
@@ -112,17 +112,27 @@ private:
     std::unique_ptr<SessionItemImpl> p_impl;
 };
 
+//! Returns data stored in property item.
+//! Property is single item registered under certain tag via CompoundItem::addProperty method.
+
+template <typename T> inline T SessionItem::property(const std::string& tag) const
+{
+    auto item_data = getItem(tag)->data();
+    if constexpr (std::is_same<T, QVariant>::value)
+        return item_data;
+    return item_data.value<T>();
+}
+
 //! Sets value to property item.
 //! Property is single item registered under certain tag via CompoundItem::addProperty method, the
 //! value will be assigned to it's data role.
 
-template<typename T>
-inline void SessionItem::setProperty(const std::string &tag, const T& value)
+template <typename T> inline void SessionItem::setProperty(const std::string& tag, const T& value)
 {
     set_property_intern(tag, QVariant::fromValue(value));
 }
 
-inline void SessionItem::setProperty(const std::string &tag, const char* value)
+inline void SessionItem::setProperty(const std::string& tag, const char* value)
 {
     setProperty(tag, std::string(value));
 }

--- a/source/libmvvm_model/mvvm/model/sessionitemdata.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitemdata.cpp
@@ -64,9 +64,9 @@ SessionItemData::const_iterator SessionItemData::end() const
     return m_values.end();
 }
 
-//! Returns true
+//! Returns true if item has data with given role.
 
-bool SessionItemData::hasRole(int role) const
+bool SessionItemData::hasData(int role) const
 {
     auto has_role = [role](const auto& x) { return x.m_role == role; };
     return std::find_if(m_values.begin(), m_values.end(), has_role) != m_values.end();

--- a/source/libmvvm_model/mvvm/model/sessionitemdata.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitemdata.cpp
@@ -7,6 +7,7 @@
 //
 // ************************************************************************** //
 
+#include <algorithm>
 #include <mvvm/model/customvariants.h>
 #include <mvvm/model/sessionitemdata.h>
 #include <sstream>
@@ -61,6 +62,14 @@ SessionItemData::const_iterator SessionItemData::begin() const
 SessionItemData::const_iterator SessionItemData::end() const
 {
     return m_values.end();
+}
+
+//! Returns true
+
+bool SessionItemData::hasRole(int role) const
+{
+    auto has_role = [role](const auto& x) { return x.m_role == role; };
+    return std::find_if(m_values.begin(), m_values.end(), has_role) != m_values.end();
 }
 
 //! Check if variant is compatible

--- a/source/libmvvm_model/mvvm/model/sessionitemdata.h
+++ b/source/libmvvm_model/mvvm/model/sessionitemdata.h
@@ -34,7 +34,7 @@ public:
     const_iterator begin() const;
     const_iterator end() const;
 
-    bool hasRole(int role) const;
+    bool hasData(int role) const;
 
 private:
     void assure_validity(const QVariant& variant, int role);

--- a/source/libmvvm_model/mvvm/model/sessionitemdata.h
+++ b/source/libmvvm_model/mvvm/model/sessionitemdata.h
@@ -34,6 +34,8 @@ public:
     const_iterator begin() const;
     const_iterator end() const;
 
+    bool hasRole(int role) const;
+
 private:
     void assure_validity(const QVariant& variant, int role);
     container_type m_values;

--- a/source/libmvvm_model/mvvm/model/sessionmodel.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionmodel.cpp
@@ -81,7 +81,8 @@ SessionItem* SessionModel::rootItem() const
 
 QVariant SessionModel::data(SessionItem* item, int role) const
 {
-    return item->data(role);
+    // FIXME cleanup
+    return item->data<QVariant>(role);
 }
 
 bool SessionModel::setData(SessionItem* item, const QVariant& value, int role)

--- a/source/libmvvm_model/mvvm/model/sessionmodel.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionmodel.cpp
@@ -81,7 +81,6 @@ SessionItem* SessionModel::rootItem() const
 
 QVariant SessionModel::data(SessionItem* item, int role) const
 {
-    // FIXME cleanup
     return item->data<QVariant>(role);
 }
 

--- a/source/libmvvm_model/mvvm/standarditems/axisitems.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/axisitems.cpp
@@ -39,7 +39,7 @@ ViewportAxisItem::ViewportAxisItem(const std::string& model_type) : BasicAxisIte
 
 std::pair<double, double> ViewportAxisItem::range() const
 {
-    return std::make_pair(property(P_MIN).value<double>(), property(P_MAX).value<double>());
+    return std::make_pair(property<double>(P_MIN), property<double>(P_MAX));
 }
 
 //! Sets lower, upper range of axis to given values.
@@ -52,7 +52,7 @@ void ViewportAxisItem::set_range(double lower, double upper)
 
 bool ViewportAxisItem::is_in_log() const
 {
-    return property(P_IS_LOG).value<bool>();
+    return property<bool>(P_IS_LOG);
 }
 
 // --- BinnedAxisItem ------------------------------------------------------
@@ -65,12 +65,12 @@ BinnedAxisItem::BinnedAxisItem(const std::string& model_type) : BasicAxisItem(mo
 
 std::pair<double, double> BinnedAxisItem::range() const
 {
-    return std::make_pair(property(P_MIN).value<double>(), property(P_MAX).value<double>());
+    return std::make_pair(property<double>(P_MIN), property<double>(P_MAX));
 }
 
 int BinnedAxisItem::size() const
 {
-    return property(P_NBINS).value<int>();
+    return property<int>(P_NBINS);
 }
 
 // --- FixedBinAxisItem ------------------------------------------------------
@@ -89,9 +89,9 @@ std::unique_ptr<FixedBinAxisItem> FixedBinAxisItem::create(int nbins, double xmi
 std::vector<double> FixedBinAxisItem::binCenters() const
 {
     std::vector<double> result;
-    int nbins = property(P_NBINS).value<int>();
-    double start = property(P_MIN).value<double>();
-    double end = property(P_MAX).value<double>();
+    int nbins = property<int>(P_NBINS);
+    double start = property<double>(P_MIN);
+    double end = property<double>(P_MAX);
     double step = (end - start) / nbins;
 
     result.resize(static_cast<size_t>(nbins), 0.0);

--- a/source/libmvvm_model/mvvm/standarditems/data1ditem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/data1ditem.cpp
@@ -60,6 +60,8 @@ std::vector<double> Data1DItem::binCenters() const
 
 std::vector<double> Data1DItem::binValues() const
 {
-    auto variant = data();
-    return variant.isValid() ? variant.value<std::vector<double>>() : std::vector<double>();
+    return data<std::vector<double>>();
+    // FIXME cleanup
+//    auto variant = data();
+//    return variant.isValid() ? variant.value<std::vector<double>>() : std::vector<double>();
 }

--- a/source/libmvvm_model/mvvm/standarditems/data1ditem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/data1ditem.cpp
@@ -24,6 +24,7 @@ size_t total_bin_count(Data1DItem* item)
 Data1DItem::Data1DItem() : CompoundItem(Constants::Data1DItemType)
 {
     registerTag(TagInfo(T_AXIS, 0, 1, {Constants::FixedBinAxisItemType}));
+    setContent(std::vector<double>());
 }
 
 //! Sets axis. Bin content will be set to zero.
@@ -61,7 +62,4 @@ std::vector<double> Data1DItem::binCenters() const
 std::vector<double> Data1DItem::binValues() const
 {
     return data<std::vector<double>>();
-    // FIXME cleanup
-//    auto variant = data();
-//    return variant.isValid() ? variant.value<std::vector<double>>() : std::vector<double>();
 }

--- a/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
@@ -65,8 +65,10 @@ void Data2DItem::setContent(const std::vector<double>& data)
 
 std::vector<double> Data2DItem::content() const
 {
-    auto variant = data();
-    return variant.isValid() ? variant.value<std::vector<double>>() : std::vector<double>();
+    return data<std::vector<double>>();
+    // FIXME cleanup
+//    auto variant = data();
+//    return variant.isValid() ? variant.value<std::vector<double>>() : std::vector<double>();
 }
 
 //! Insert axis under given tag. Previous axis will be deleted and data points invalidated.

--- a/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
@@ -27,6 +27,7 @@ Data2DItem::Data2DItem() : CompoundItem(Constants::Data2DItemType)
 {
     registerTag(TagInfo(T_XAXIS, 0, 1, {Constants::FixedBinAxisItemType}));
     registerTag(TagInfo(T_YAXIS, 0, 1, {Constants::FixedBinAxisItemType}));
+    setContent(std::vector<double>());
 }
 
 //! Sets axes and put data points to zero.
@@ -66,9 +67,6 @@ void Data2DItem::setContent(const std::vector<double>& data)
 std::vector<double> Data2DItem::content() const
 {
     return data<std::vector<double>>();
-    // FIXME cleanup
-//    auto variant = data();
-//    return variant.isValid() ? variant.value<std::vector<double>>() : std::vector<double>();
 }
 
 //! Insert axis under given tag. Previous axis will be deleted and data points invalidated.

--- a/source/libmvvm_model/mvvm/standarditems/linkeditem.h
+++ b/source/libmvvm_model/mvvm/standarditems/linkeditem.h
@@ -38,7 +38,7 @@ public:
 
 template <typename T> T* LinkedItem::get() const
 {
-    return model() ? dynamic_cast<T*>(model()->findItem(data().value<std::string>())) : nullptr;
+    return model() ? dynamic_cast<T*>(model()->findItem(data<std::string>())) : nullptr;
 }
 
 } // namespace ModelView

--- a/source/libmvvm_model/mvvm/standarditems/vectoritem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/vectoritem.cpp
@@ -34,7 +34,7 @@ void VectorItem::activate()
 void VectorItem::update_label()
 {
     std::ostringstream ostr;
-    ostr << "(" << property(P_X).value<double>() << ", " << property(P_Y).value<double>() << ", "
-         << property(P_Z).value<double>() << ")";
+    ostr << "(" << property<double>(P_X) << ", " << property<double>(P_Y) << ", "
+         << property<double>(P_Z) << ")";
     setDataIntern(QVariant::fromValue(ostr.str()), ItemDataRole::DATA);
 }

--- a/source/libmvvm_viewmodel/mvvm/editors/defaulteditorfactory.cpp
+++ b/source/libmvvm_viewmodel/mvvm/editors/defaulteditorfactory.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<CustomEditor> DefaultEditorFactory::createEditor(const QModelInd
     if (!item)
         return {};
 
-    auto value = item->data();
+    auto value = item->data<QVariant>();
     auto builder = findBuilder(Utils::VariantName(value));
     return builder ? builder(item) : std::unique_ptr<CustomEditor>();
 }

--- a/source/libmvvm_viewmodel/mvvm/editors/editorbuilders.cpp
+++ b/source/libmvvm_viewmodel/mvvm/editors/editorbuilders.cpp
@@ -52,10 +52,8 @@ builder_t IntegerEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<IntegerEditor>();
-        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
-        // FIXME cleanup
-        if (variant.isValid()) {
-            auto limits = variant.value<RealLimits>();
+        if (item->hasData(ItemDataRole::LIMITS)) {
+            auto limits = item->data<RealLimits>();
             editor->setRange(static_cast<int>(limits.lowerLimit()),
                              static_cast<int>(limits.upperLimit()));
         }
@@ -68,10 +66,8 @@ builder_t DoubleEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<DoubleEditor>();
-        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
-        // FIXME cleanup
-        if (variant.isValid()) {
-            auto limits = variant.value<RealLimits>();
+        if (item->hasData(ItemDataRole::LIMITS)) {
+            auto limits = item->data<RealLimits>();
             editor->setRange(limits.lowerLimit(), limits.upperLimit());
             editor->setSingleStep(singleStep(default_decimals));
             editor->setDecimals(default_decimals);
@@ -85,10 +81,8 @@ builder_t ScientificDoubleEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<ScientificDoubleEditor>();
-        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
-        // FIXME cleanup
-        if (variant.isValid()) {
-            auto limits = variant.value<RealLimits>();
+        if (item->hasData(ItemDataRole::LIMITS)) {
+            auto limits = item->data<RealLimits>();
             editor->setRange(limits.lowerLimit(), limits.upperLimit());
         }
         return std::move(editor);
@@ -100,10 +94,8 @@ builder_t ScientificSpinBoxEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<ScientificSpinBoxEditor>();
-        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
-        // FIXME cleanup
-        if (variant.isValid()) {
-            auto limits = variant.value<RealLimits>();
+        if (item->hasData(ItemDataRole::LIMITS)) {
+            auto limits = item->data<RealLimits>();
             editor->setRange(limits.lowerLimit(), limits.upperLimit());
         }
         editor->setSingleStep(getStep(item->data<double>()));

--- a/source/libmvvm_viewmodel/mvvm/editors/editorbuilders.cpp
+++ b/source/libmvvm_viewmodel/mvvm/editors/editorbuilders.cpp
@@ -52,7 +52,8 @@ builder_t IntegerEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<IntegerEditor>();
-        auto variant = item->data(ItemDataRole::LIMITS);
+        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
+        // FIXME cleanup
         if (variant.isValid()) {
             auto limits = variant.value<RealLimits>();
             editor->setRange(static_cast<int>(limits.lowerLimit()),
@@ -67,7 +68,8 @@ builder_t DoubleEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<DoubleEditor>();
-        auto variant = item->data(ItemDataRole::LIMITS);
+        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
+        // FIXME cleanup
         if (variant.isValid()) {
             auto limits = variant.value<RealLimits>();
             editor->setRange(limits.lowerLimit(), limits.upperLimit());
@@ -83,7 +85,8 @@ builder_t ScientificDoubleEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<ScientificDoubleEditor>();
-        auto variant = item->data(ItemDataRole::LIMITS);
+        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
+        // FIXME cleanup
         if (variant.isValid()) {
             auto limits = variant.value<RealLimits>();
             editor->setRange(limits.lowerLimit(), limits.upperLimit());
@@ -97,12 +100,13 @@ builder_t ScientificSpinBoxEditorBuilder()
 {
     auto builder = [](const SessionItem* item) -> std::unique_ptr<CustomEditor> {
         auto editor = std::make_unique<ScientificSpinBoxEditor>();
-        auto variant = item->data(ItemDataRole::LIMITS);
+        auto variant = item->data<QVariant>(ItemDataRole::LIMITS);
+        // FIXME cleanup
         if (variant.isValid()) {
             auto limits = variant.value<RealLimits>();
             editor->setRange(limits.lowerLimit(), limits.upperLimit());
         }
-        editor->setSingleStep(getStep(item->data().value<double>()));
+        editor->setSingleStep(getStep(item->data<double>()));
         editor->setDecimals(default_decimals);
         return std::move(editor);
     };

--- a/source/libmvvm_viewmodel/mvvm/plotting/colormapplotcontroller.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/colormapplotcontroller.cpp
@@ -49,8 +49,7 @@ struct ColorMapPlotController::ColorMapPlotControllerImpl {
 
     void update_interpolation()
     {
-        auto is_interpolated =
-            colormap_item()->property(ColorMapItem::P_INTERPOLATION).value<bool>();
+        auto is_interpolated = colormap_item()->property<bool>(ColorMapItem::P_INTERPOLATION);
         color_map->setInterpolate(is_interpolated);
         custom_plot->replot();
     }

--- a/source/libmvvm_viewmodel/mvvm/plotting/graphplotcontroller.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/graphplotcontroller.cpp
@@ -47,7 +47,7 @@ struct GraphPlotController::GraphItemControllerImpl {
 
     void update_graph_pen()
     {
-        auto color = graph_item()->property(GraphItem::P_COLOR).value<QColor>();
+        auto color = graph_item()->property<QColor>(GraphItem::P_COLOR);
         graph->setPen(QPen(color));
         custom_plot->replot();
     }

--- a/source/libmvvm_viewmodel/mvvm/plotting/viewportaxisplotcontroller.cpp
+++ b/source/libmvvm_viewmodel/mvvm/plotting/viewportaxisplotcontroller.cpp
@@ -80,10 +80,10 @@ void ViewportAxisPlotController::subscribe()
             return;
 
         if (name == ViewportAxisItem::P_MIN)
-            p_impl->axis->setRangeLower(item->property(name).value<double>());
+            p_impl->axis->setRangeLower(item->property<double>(name));
 
         if (name == ViewportAxisItem::P_MAX)
-            p_impl->axis->setRangeUpper(item->property(name).value<double>());
+            p_impl->axis->setRangeUpper(item->property<double>(name));
 
         if (name == ViewportAxisItem::P_IS_LOG)
             p_impl->update_log_scale();

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/labeldatarowstrategy.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/labeldatarowstrategy.cpp
@@ -31,7 +31,7 @@ std::vector<std::unique_ptr<ViewItem>> LabelDataRowStrategy::constructRefRow(Ses
         return result;
 
     result.emplace_back(std::make_unique<ViewLabelItem>(item));
-    if (item->data().isValid())
+    if (item->data<QVariant>().isValid()) // FIXME cleanup
         result.emplace_back(std::make_unique<ViewDataItem>(item));
     else
         result.emplace_back(std::make_unique<ViewEmptyItem>());

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/labeldatarowstrategy.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/labeldatarowstrategy.cpp
@@ -31,7 +31,7 @@ std::vector<std::unique_ptr<ViewItem>> LabelDataRowStrategy::constructRefRow(Ses
         return result;
 
     result.emplace_back(std::make_unique<ViewLabelItem>(item));
-    if (item->data<QVariant>().isValid()) // FIXME cleanup
+    if (item->hasData())
         result.emplace_back(std::make_unique<ViewDataItem>(item));
     else
         result.emplace_back(std::make_unique<ViewEmptyItem>());

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/propertiesrowstrategy.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/propertiesrowstrategy.cpp
@@ -41,7 +41,7 @@ std::vector<std::unique_ptr<ViewItem>> PropertiesRowStrategy::constructRefRow(Se
         update_column_labels(items_in_row);
 
     for (auto child : items_in_row) {
-        if (child->data<QVariant>().isValid()) // FIXME cleanup
+        if (child->hasData())
             result.emplace_back(std::make_unique<ViewDataItem>(child));
         else
             result.emplace_back(std::make_unique<ViewLabelItem>(child));

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/propertiesrowstrategy.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/propertiesrowstrategy.cpp
@@ -41,7 +41,7 @@ std::vector<std::unique_ptr<ViewItem>> PropertiesRowStrategy::constructRefRow(Se
         update_column_labels(items_in_row);
 
     for (auto child : items_in_row) {
-        if (child->data().isValid())
+        if (child->data<QVariant>().isValid()) // FIXME cleanup
             result.emplace_back(std::make_unique<ViewDataItem>(child));
         else
             result.emplace_back(std::make_unique<ViewLabelItem>(child));

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/viewitem.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/viewitem.cpp
@@ -83,7 +83,7 @@ struct ViewItem::ViewItemImpl {
 
     //! Returns item data associated with this RefViewItem.
 
-    QVariant data() const { return item ? item->data(role) : QVariant(); }
+    QVariant data() const { return item ? item->data<QVariant>(role) : QVariant(); }
 
     //! Returns vector of children.
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelutils.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelutils.cpp
@@ -63,7 +63,7 @@ QVariant Utils::TextColorRole(const SessionItem& item)
 
 QVariant Utils::CheckStateRole(const SessionItem& item)
 {
-    auto value = item.data();
+    auto value = item.data<QVariant>();
     if (Utils::IsBoolVariant(value))
         return value.value<bool>() ? Qt::Checked : Qt::Unchecked;
     return QVariant();
@@ -71,7 +71,7 @@ QVariant Utils::CheckStateRole(const SessionItem& item)
 
 QVariant Utils::DecorationRole(const SessionItem& item)
 {
-    auto value = item.data();
+    auto value = item.data<QVariant>();
     if (Utils::IsColorVariant(value))
         return value;
     else if (Utils::IsExtPropertyVariant(value))

--- a/tests/libtestmachinery/toy_items.cpp
+++ b/tests/libtestmachinery/toy_items.cpp
@@ -64,7 +64,7 @@ void InterferenceFunctionItem::activate()
 void InterferenceFunctionItem::update_appearance()
 {
     auto angle_item = getItem(P_ROTATION_ANLE);
-    angle_item->setEnabled(!property(P_INTEGRATION).value<bool>());
+    angle_item->setEnabled(!property<bool>(P_INTEGRATION));
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/testmodel/TestUndoRedo.cpp
+++ b/tests/testmodel/TestUndoRedo.cpp
@@ -607,8 +607,7 @@ TEST_F(TestUndoRedo, copyLayerFromMultilayer)
     // copying layer
     auto layer_copy = dynamic_cast<ToyItems::LayerItem*>(model.copyItem(layer0, multilayer1));
     EXPECT_EQ(multilayer1->itemCount(ToyItems::MultiLayerItem::T_LAYERS), 1);
-    EXPECT_EQ(layer_copy->property(ToyItems::LayerItem::P_THICKNESS).value<double>(),
-              expected_thickness);
+    EXPECT_EQ(layer_copy->property<double>(ToyItems::LayerItem::P_THICKNESS), expected_thickness);
     EXPECT_TRUE(layer0->identifier() != layer_copy->identifier());
 
     auto id = layer_copy->identifier();

--- a/tests/testmodel/TestUndoRedo.cpp
+++ b/tests/testmodel/TestUndoRedo.cpp
@@ -182,7 +182,7 @@ TEST_F(TestUndoRedo, setDataThroughItem)
 
     // setting new data through item (and not through model)
     item->setData(value, role);
-    EXPECT_EQ(item->data(role), value);
+    EXPECT_EQ(item->data<QVariant>(role), value);
 
     EXPECT_EQ(stack->index(), 2); // insert and setData commands
     EXPECT_FALSE(model.undoStack()->canRedo());
@@ -271,7 +271,7 @@ TEST_F(TestUndoRedo, removeRow)
     EXPECT_EQ(stack->index(), 2); // insert and setData commands
     EXPECT_FALSE(model.undoStack()->canRedo());
     EXPECT_TRUE(model.undoStack()->canUndo());
-    EXPECT_EQ(item->data(role), data);
+    EXPECT_EQ(item->data<QVariant>(role), data);
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);
 
     // removing the row
@@ -329,8 +329,8 @@ TEST_F(TestUndoRedo, removeParentAndChild)
     EXPECT_EQ(parent_at->modelType(), Constants::BaseType);
     EXPECT_EQ(child_at->modelType(), Constants::PropertyType);
 
-    EXPECT_EQ(parent_at->data(role1), data1);
-    EXPECT_EQ(child_at->data(role2), data2);
+    EXPECT_EQ(parent_at->data<QVariant>(role1), data1);
+    EXPECT_EQ(child_at->data<QVariant>(role2), data2);
 }
 
 //! Insert item, remove row, undo and check item id.

--- a/tests/testmodel/axisitems.test.cpp
+++ b/tests/testmodel/axisitems.test.cpp
@@ -37,9 +37,9 @@ TEST_F(AxisItemsTest, initialState)
 TEST_F(AxisItemsTest, viewportAxisInitialState)
 {
     ViewportAxisItem axis;
-    EXPECT_EQ(axis.property(ViewportAxisItem::P_MIN), 0.0);
-    EXPECT_EQ(axis.property(ViewportAxisItem::P_MAX), 1.0);
-    EXPECT_FALSE(axis.property(ViewportAxisItem::P_IS_LOG).value<bool>());
+    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MIN), 0.0);
+    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MAX), 1.0);
+    EXPECT_FALSE(axis.property<bool>(ViewportAxisItem::P_IS_LOG));
 }
 
 //! ViewportAxisItem::setRange
@@ -54,8 +54,8 @@ TEST_F(AxisItemsTest, viewportAxisSetRange)
     EXPECT_EQ(upper, 1.0);
 
     axis.set_range(1.0, 2.0);
-    EXPECT_EQ(axis.property(ViewportAxisItem::P_MIN), 1.0);
-    EXPECT_EQ(axis.property(ViewportAxisItem::P_MAX), 2.0);
+    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MIN), 1.0);
+    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MAX), 2.0);
 }
 
 //! Factory method
@@ -64,9 +64,9 @@ TEST_F(AxisItemsTest, fixedBinAxisFactory)
 {
     auto axis = FixedBinAxisItem::create(3, 1.0, 4.0);
 
-    EXPECT_EQ(axis->property(FixedBinAxisItem::P_NBINS), 3);
-    EXPECT_EQ(axis->property(FixedBinAxisItem::P_MIN), 1.0);
-    EXPECT_EQ(axis->property(FixedBinAxisItem::P_MAX), 4.0);
+    EXPECT_EQ(axis->property<int>(FixedBinAxisItem::P_NBINS), 3);
+    EXPECT_EQ(axis->property<double>(FixedBinAxisItem::P_MIN), 1.0);
+    EXPECT_EQ(axis->property<double>(FixedBinAxisItem::P_MAX), 4.0);
 
     std::vector<double> expected{1.5, 2.5, 3.5};
     EXPECT_EQ(axis->binCenters(), expected);

--- a/tests/testmodel/colormapitem.test.cpp
+++ b/tests/testmodel/colormapitem.test.cpp
@@ -34,7 +34,7 @@ TEST_F(ColorMapItemTest, initialState)
 {
     ColorMapItem item;
     EXPECT_TRUE(item.dataItem() == nullptr);
-    EXPECT_TRUE(item.property(ColorMapItem::P_INTERPOLATION).value<bool>());
+    EXPECT_TRUE(item.property<bool>(ColorMapItem::P_INTERPOLATION));
 }
 
 //! Setting dataItem in model context.

--- a/tests/testmodel/compounditem.test.cpp
+++ b/tests/testmodel/compounditem.test.cpp
@@ -47,11 +47,11 @@ TEST_F(CompoundItemTest, addIntProperty)
     EXPECT_TRUE(item.isTag("name"));
 
     EXPECT_EQ(propertyItem->modelType(), Constants::PropertyType);
-    EXPECT_TRUE(Utils::IsIntVariant(propertyItem->data()));
+    EXPECT_TRUE(Utils::IsIntVariant(propertyItem->data<QVariant>()));
     EXPECT_EQ(propertyItem->displayName(), property_name);
-    EXPECT_EQ(propertyItem->data().value<int>(), expected);
+    EXPECT_EQ(propertyItem->data<int>(), expected);
 
-    EXPECT_FALSE(propertyItem->data(ItemDataRole::LIMITS).isValid());
+    EXPECT_FALSE(propertyItem->data<QVariant>(ItemDataRole::LIMITS).isValid());
 }
 
 TEST_F(CompoundItemTest, setIntProperty)
@@ -63,7 +63,7 @@ TEST_F(CompoundItemTest, setIntProperty)
     item.setProperty(property_name, expected);
 
     EXPECT_EQ(item.property<int>(property_name), expected);
-    EXPECT_EQ(propertyItem->data().value<int>(), expected);
+    EXPECT_EQ(propertyItem->data<int>(), expected);
 }
 
 TEST_F(CompoundItemTest, addDoubleProperty)
@@ -75,14 +75,14 @@ TEST_F(CompoundItemTest, addDoubleProperty)
     EXPECT_TRUE(item.isTag(property_name));
 
     EXPECT_EQ(propertyItem->modelType(), Constants::PropertyType);
-    EXPECT_TRUE(Utils::IsDoubleVariant(propertyItem->data()));
+    EXPECT_TRUE(Utils::IsDoubleVariant(propertyItem->data<QVariant>()));
     EXPECT_EQ(propertyItem->displayName(), property_name);
-    EXPECT_EQ(propertyItem->data().value<double>(), expected);
+    EXPECT_EQ(propertyItem->data<double>(), expected);
 
-    EXPECT_TRUE(propertyItem->data(ItemDataRole::LIMITS).isValid());
+    EXPECT_TRUE(propertyItem->data<QVariant>(ItemDataRole::LIMITS).isValid());
 
     // limits should be non negative by default
-    auto limits = propertyItem->data(ItemDataRole::LIMITS).value<RealLimits>();
+    auto limits = propertyItem->data<RealLimits>(ItemDataRole::LIMITS);
     EXPECT_TRUE(limits.hasLowerLimit());
     EXPECT_FALSE(limits.hasUpperLimit());
 }
@@ -96,7 +96,7 @@ TEST_F(CompoundItemTest, setDoubleProperty)
     item.setProperty(property_name, expected);
 
     EXPECT_EQ(item.property<double>(property_name), expected);
-    EXPECT_EQ(propertyItem->data().value<double>(), expected);
+    EXPECT_EQ(propertyItem->data<double>(), expected);
 }
 
 TEST_F(CompoundItemTest, addCharProperty)
@@ -107,10 +107,10 @@ TEST_F(CompoundItemTest, addCharProperty)
     EXPECT_TRUE(item.isTag(property_name));
 
     EXPECT_EQ(propertyItem->modelType(), Constants::PropertyType);
-    EXPECT_TRUE(Utils::IsStdStringVariant(propertyItem->data()));
-    EXPECT_EQ(propertyItem->data().value<std::string>(), std::string("abc"));
+    EXPECT_TRUE(Utils::IsStdStringVariant(propertyItem->data<QVariant>()));
+    EXPECT_EQ(propertyItem->data<std::string>(), std::string("abc"));
 
-    EXPECT_FALSE(propertyItem->data(ItemDataRole::LIMITS).isValid());
+    EXPECT_FALSE(propertyItem->data<QVariant>(ItemDataRole::LIMITS).isValid());
 }
 
 TEST_F(CompoundItemTest, setCharProperty)
@@ -122,7 +122,7 @@ TEST_F(CompoundItemTest, setCharProperty)
     item.setProperty(property_name, expected);
 
     EXPECT_EQ(item.property<std::string>(property_name), std::string(expected));
-    EXPECT_EQ(propertyItem->data().value<std::string>(), std::string(expected));
+    EXPECT_EQ(propertyItem->data<std::string>(), std::string(expected));
 }
 
 TEST_F(CompoundItemTest, addStringProperty)
@@ -133,10 +133,10 @@ TEST_F(CompoundItemTest, addStringProperty)
     EXPECT_TRUE(item.isTag(property_name));
 
     EXPECT_EQ(propertyItem->modelType(), Constants::PropertyType);
-    EXPECT_TRUE(Utils::IsStdStringVariant(propertyItem->data()));
-    EXPECT_EQ(propertyItem->data().value<std::string>(), std::string("abc"));
+    EXPECT_TRUE(Utils::IsStdStringVariant(propertyItem->data<QVariant>()));
+    EXPECT_EQ(propertyItem->data<std::string>(), std::string("abc"));
 
-    EXPECT_FALSE(propertyItem->data(ItemDataRole::LIMITS).isValid());
+    EXPECT_FALSE(propertyItem->data<QVariant>(ItemDataRole::LIMITS).isValid());
 }
 
 TEST_F(CompoundItemTest, setStringProperty)
@@ -148,7 +148,7 @@ TEST_F(CompoundItemTest, setStringProperty)
     item.setProperty(property_name, expected);
 
     EXPECT_EQ(item.property<std::string>(property_name), expected);
-    EXPECT_EQ(propertyItem->data().value<std::string>(), expected);
+    EXPECT_EQ(propertyItem->data<std::string>(), expected);
 }
 
 TEST_F(CompoundItemTest, addBoolProperty)
@@ -160,10 +160,10 @@ TEST_F(CompoundItemTest, addBoolProperty)
     EXPECT_TRUE(item.isTag(property_name));
 
     EXPECT_EQ(propertyItem->modelType(), Constants::PropertyType);
-    EXPECT_TRUE(Utils::IsBoolVariant(propertyItem->data()));
-    EXPECT_EQ(propertyItem->data().value<bool>(), expected);
+    EXPECT_TRUE(Utils::IsBoolVariant(propertyItem->data<QVariant>()));
+    EXPECT_EQ(propertyItem->data<bool>(), expected);
 
-    EXPECT_FALSE(propertyItem->data(ItemDataRole::LIMITS).isValid());
+    EXPECT_FALSE(propertyItem->data<QVariant>(ItemDataRole::LIMITS).isValid());
 }
 
 TEST_F(CompoundItemTest, setBoolProperty)
@@ -175,7 +175,7 @@ TEST_F(CompoundItemTest, setBoolProperty)
     item.setProperty(property_name, expected);
 
     EXPECT_EQ(item.property<bool>(property_name), expected);
-    EXPECT_EQ(propertyItem->data().value<bool>(), expected);
+    EXPECT_EQ(propertyItem->data<bool>(), expected);
 }
 
 TEST_F(CompoundItemTest, itemAccess)

--- a/tests/testmodel/compounditem.test.cpp
+++ b/tests/testmodel/compounditem.test.cpp
@@ -62,7 +62,7 @@ TEST_F(CompoundItemTest, setIntProperty)
     const int expected = 42;
     item.setProperty(property_name, expected);
 
-    EXPECT_EQ(item.property(property_name).value<int>(), expected);
+    EXPECT_EQ(item.property<int>(property_name), expected);
     EXPECT_EQ(propertyItem->data().value<int>(), expected);
 }
 
@@ -95,7 +95,7 @@ TEST_F(CompoundItemTest, setDoubleProperty)
     const double expected = 42.0;
     item.setProperty(property_name, expected);
 
-    EXPECT_EQ(item.property(property_name).value<double>(), expected);
+    EXPECT_EQ(item.property<double>(property_name), expected);
     EXPECT_EQ(propertyItem->data().value<double>(), expected);
 }
 
@@ -121,7 +121,7 @@ TEST_F(CompoundItemTest, setCharProperty)
     const char* expected{"bbb"};
     item.setProperty(property_name, expected);
 
-    EXPECT_EQ(item.property(property_name).value<std::string>(), std::string(expected));
+    EXPECT_EQ(item.property<std::string>(property_name), std::string(expected));
     EXPECT_EQ(propertyItem->data().value<std::string>(), std::string(expected));
 }
 
@@ -147,7 +147,7 @@ TEST_F(CompoundItemTest, setStringProperty)
     const std::string expected{"bbb"};
     item.setProperty(property_name, expected);
 
-    EXPECT_EQ(item.property(property_name).value<std::string>(), expected);
+    EXPECT_EQ(item.property<std::string>(property_name), expected);
     EXPECT_EQ(propertyItem->data().value<std::string>(), expected);
 }
 
@@ -174,7 +174,7 @@ TEST_F(CompoundItemTest, setBoolProperty)
     const bool expected = true;
     item.setProperty(property_name, expected);
 
-    EXPECT_EQ(item.property(property_name).value<bool>(), expected);
+    EXPECT_EQ(item.property<bool>(property_name), expected);
     EXPECT_EQ(propertyItem->data().value<bool>(), expected);
 }
 

--- a/tests/testmodel/copyitemcommand.test.cpp
+++ b/tests/testmodel/copyitemcommand.test.cpp
@@ -49,7 +49,7 @@ TEST_F(CopyItemCommandTest, copyChild)
     EXPECT_EQ(parent->childrenCount(), 3);
     std::vector<SessionItem*> expected = {child0, copy, child1};
     EXPECT_EQ(parent->getItems("tag1"), expected);
-    EXPECT_EQ(copy->data().value<double>(), 43.0);
+    EXPECT_EQ(copy->data<double>(), 43.0);
 
     // undoing command
     command->undo();

--- a/tests/testmodel/data1ditem.test.cpp
+++ b/tests/testmodel/data1ditem.test.cpp
@@ -35,6 +35,8 @@ TEST_F(Data1DItemTest, initialState)
     EXPECT_EQ(item.getItem(Data1DItem::T_AXIS), nullptr);
     EXPECT_EQ(item.binCenters(), std::vector<double>());
     EXPECT_EQ(item.binValues(), std::vector<double>());
+    EXPECT_TRUE(item.hasData());
+    EXPECT_TRUE(item.data<std::vector<double>>().empty());
 }
 
 //! Checking the method ::setFixedBinAxis.

--- a/tests/testmodel/data2ditem.test.cpp
+++ b/tests/testmodel/data2ditem.test.cpp
@@ -35,6 +35,8 @@ TEST_F(Data2DItemTest, initialState)
     EXPECT_EQ(item.xAxis(), nullptr);
     EXPECT_EQ(item.yAxis(), nullptr);
     EXPECT_EQ(item.content(), std::vector<double>());
+    EXPECT_TRUE(item.hasData());
+    EXPECT_TRUE(item.data<std::vector<double>>().empty());
 }
 
 //! Checking the method ::setAxis.

--- a/tests/testmodel/graphviewportitem.test.cpp
+++ b/tests/testmodel/graphviewportitem.test.cpp
@@ -61,15 +61,15 @@ TEST_F(GraphViewportItemTest, addItem)
 
     // x-axis of viewport should be set to FixedBinAxis of DataItem
     auto xaxis = viewport_item->xAxis();
-    EXPECT_DOUBLE_EQ(xaxis->property(ViewportAxisItem::P_MIN).value<double>(), expected_centers[0]);
-    EXPECT_DOUBLE_EQ(xaxis->property(ViewportAxisItem::P_MAX).value<double>(), expected_centers[2]);
+    EXPECT_DOUBLE_EQ(xaxis->property<double>(ViewportAxisItem::P_MIN), expected_centers[0]);
+    EXPECT_DOUBLE_EQ(xaxis->property<double>(ViewportAxisItem::P_MAX), expected_centers[2]);
 
     // y-axis of viewport should be set to min/max of expected_content
     auto yaxis = viewport_item->yAxis();
     auto [expected_amin, expected_amax] =
         std::minmax_element(std::begin(expected_content), std::end(expected_content));
-    EXPECT_DOUBLE_EQ(yaxis->property(ViewportAxisItem::P_MIN).value<double>(), *expected_amin);
-    EXPECT_DOUBLE_EQ(yaxis->property(ViewportAxisItem::P_MAX).value<double>(), *expected_amax);
+    EXPECT_DOUBLE_EQ(yaxis->property<double>(ViewportAxisItem::P_MIN), *expected_amin);
+    EXPECT_DOUBLE_EQ(yaxis->property<double>(ViewportAxisItem::P_MAX), *expected_amax);
 }
 
 //! Check signaling on set data item.

--- a/tests/testmodel/groupitem.test.cpp
+++ b/tests/testmodel/groupitem.test.cpp
@@ -28,8 +28,7 @@ TEST_F(GroupItemTest, initialState)
     EXPECT_EQ(item.currentIndex(), -1);
     EXPECT_EQ(item.currentItem(), nullptr);
     EXPECT_EQ(item.currentType(), "");
-    EXPECT_FALSE(item.data<QVariant>().isValid()); // FIXME cleanup
+    EXPECT_TRUE(item.hasData());
     EXPECT_TRUE(item.children().empty());
-
     EXPECT_THROW(item.setCurrentType("abc"), std::runtime_error);
 }

--- a/tests/testmodel/groupitem.test.cpp
+++ b/tests/testmodel/groupitem.test.cpp
@@ -28,7 +28,7 @@ TEST_F(GroupItemTest, initialState)
     EXPECT_EQ(item.currentIndex(), -1);
     EXPECT_EQ(item.currentItem(), nullptr);
     EXPECT_EQ(item.currentType(), "");
-    EXPECT_FALSE(item.data().isValid());
+    EXPECT_FALSE(item.data<QVariant>().isValid()); // FIXME cleanup
     EXPECT_TRUE(item.children().empty());
 
     EXPECT_THROW(item.setCurrentType("abc"), std::runtime_error);

--- a/tests/testmodel/itemmapper.test.cpp
+++ b/tests/testmodel/itemmapper.test.cpp
@@ -169,7 +169,7 @@ TEST(ItemMapperTest, onPropertyChange)
 
     // perform action
     item->setProperty("height", 43.0);
-    EXPECT_EQ(item->property("height"), 43.0);
+    EXPECT_EQ(item->property<double>("height"), 43.0);
     EXPECT_EQ(property->data().value<double>(), 43.0);
 }
 
@@ -196,7 +196,7 @@ TEST(ItemMapperTest, onChildPropertyChange)
 
     // perform action
     compound2->setProperty("height", 43.0);
-    EXPECT_EQ(compound2->property("height"), 43.0);
+    EXPECT_EQ(compound2->property<double>("height"), 43.0);
     EXPECT_EQ(property->data().value<double>(), 43.0);
 }
 

--- a/tests/testmodel/itemmapper.test.cpp
+++ b/tests/testmodel/itemmapper.test.cpp
@@ -170,7 +170,7 @@ TEST(ItemMapperTest, onPropertyChange)
     // perform action
     item->setProperty("height", 43.0);
     EXPECT_EQ(item->property<double>("height"), 43.0);
-    EXPECT_EQ(property->data().value<double>(), 43.0);
+    EXPECT_EQ(property->data<double>(), 43.0);
 }
 
 //! Changing item property.
@@ -197,7 +197,7 @@ TEST(ItemMapperTest, onChildPropertyChange)
     // perform action
     compound2->setProperty("height", 43.0);
     EXPECT_EQ(compound2->property<double>("height"), 43.0);
-    EXPECT_EQ(property->data().value<double>(), 43.0);
+    EXPECT_EQ(property->data<double>(), 43.0);
 }
 
 //! Inserting item to item.

--- a/tests/testmodel/jsondocument.test.cpp
+++ b/tests/testmodel/jsondocument.test.cpp
@@ -90,7 +90,7 @@ TEST_F(JsonDocumentTest, saveLoadSingleModel)
     EXPECT_EQ(reco_parent->childrenCount(), 1);
     EXPECT_EQ(reco_parent->identifier(), parent_identifier);
     EXPECT_EQ(reco_parent->defaultTag(), "defaultTag");
-    EXPECT_EQ(reco_parent->data(), 42);
+    EXPECT_EQ(reco_parent->data<int>(), 42);
 
     // checking child reconstruction
     EXPECT_EQ(reco_child->model(), &model);

--- a/tests/testmodel/jsonitembackupstrategy.test.cpp
+++ b/tests/testmodel/jsonitembackupstrategy.test.cpp
@@ -49,7 +49,7 @@ TEST_F(JsonItemBackupStrategyTest, propertyItem)
 
     EXPECT_EQ(item.modelType(), restored->modelType());
     EXPECT_EQ(item.identifier(), restored->identifier());
-    EXPECT_EQ(item.data(), restored->data());
+    EXPECT_EQ(item.data<QVariant>(), restored->data<QVariant>());
 }
 
 //! Saving/restoring CompoundItem.
@@ -66,7 +66,7 @@ TEST_F(JsonItemBackupStrategyTest, compoundItem)
 
     EXPECT_EQ(item.modelType(), restored->modelType());
     EXPECT_EQ(item.identifier(), restored->identifier());
-    EXPECT_EQ(restored->getItem("thickness")->data(), property->data());
+    EXPECT_EQ(restored->getItem("thickness")->data<double>(), property->data<double>());
     EXPECT_EQ(restored->getItem("thickness")->identifier(), property->identifier());
 }
 

--- a/tests/testmodel/jsonitemcopystrategy.test.cpp
+++ b/tests/testmodel/jsonitemcopystrategy.test.cpp
@@ -47,7 +47,7 @@ TEST_F(JsonItemCopyStrategyTest, propertyItem)
     auto copy = strategy->createCopy(&item);
 
     EXPECT_EQ(item.modelType(), copy->modelType());
-    EXPECT_EQ(item.data(), copy->data());
+    EXPECT_EQ(item.data<QVariant>(), copy->data<QVariant>());
     EXPECT_FALSE(item.identifier() == copy->identifier());
 }
 
@@ -63,7 +63,7 @@ TEST_F(JsonItemCopyStrategyTest, compoundItem)
     auto copy = strategy->createCopy(&item);
 
     EXPECT_EQ(item.modelType(), copy->modelType());
-    EXPECT_EQ(copy->getItem("thickness")->data(), property->data());
+    EXPECT_EQ(copy->getItem("thickness")->data<double>(), property->data<double>());
     EXPECT_FALSE(copy->getItem("thickness")->identifier() == property->identifier());
     EXPECT_FALSE(item.identifier() == copy->identifier());
 }

--- a/tests/testmodel/jsonmodelconverter.test.cpp
+++ b/tests/testmodel/jsonmodelconverter.test.cpp
@@ -151,7 +151,7 @@ TEST_F(JsonModelConverterTest, parentAndChildToJsonAndBack)
     EXPECT_EQ(reco_parent->childrenCount(), 1);
     EXPECT_EQ(reco_parent->identifier(), parent->identifier());
     EXPECT_EQ(reco_parent->defaultTag(), "defaultTag");
-    EXPECT_EQ(reco_parent->data(), 42);
+    EXPECT_EQ(reco_parent->data<int>(), 42);
 
     // checking child reconstruction
     EXPECT_EQ(reco_child->model(), &target);
@@ -241,7 +241,7 @@ TEST_F(JsonModelConverterTest, parentAndChildToFileAndBack)
     EXPECT_EQ(reco_parent->childrenCount(), 1);
     EXPECT_EQ(reco_parent->identifier(), parent->identifier());
     EXPECT_EQ(reco_parent->defaultTag(), "defaultTag");
-    EXPECT_EQ(reco_parent->data(), 42);
+    EXPECT_EQ(reco_parent->data<int>(), 42);
 
     // checking child reconstruction
     EXPECT_EQ(reco_child->model(), &target);

--- a/tests/testmodel/linkeditem.test.cpp
+++ b/tests/testmodel/linkeditem.test.cpp
@@ -51,7 +51,7 @@ TEST_F(LinkedItemTest, sameModelContext)
 
     // now linked
     EXPECT_EQ(link->get(), item);
-    EXPECT_EQ(link->data().value<std::string>(), item->identifier());
+    EXPECT_EQ(link->data<std::string>(), item->identifier());
 }
 
 //! Link in different model context.
@@ -118,5 +118,5 @@ TEST_F(LinkedItemTest, setNullAsLink)
     // still null link
     link->setLink(nullptr);
     EXPECT_EQ(link->get(), nullptr);
-    EXPECT_FALSE(link->data().isValid());
+    EXPECT_FALSE(link->data<QVariant>().isValid());
 }

--- a/tests/testmodel/removeitemcommand.test.cpp
+++ b/tests/testmodel/removeitemcommand.test.cpp
@@ -77,7 +77,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandChild)
     EXPECT_EQ(restored->identifier(), child1_identifier);
 
     // checking the data of restored item
-    EXPECT_EQ(restored->data().value<double>(), 42.0);
+    EXPECT_EQ(restored->data<double>(), 42.0);
 }
 
 TEST_F(RemoveItemCommandTest, removeAtCommandParentWithChild)
@@ -112,7 +112,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandParentWithChild)
     EXPECT_EQ(restored_child->identifier(), child1_identifier);
 
     // checking the data of restored item
-    EXPECT_EQ(restored_child->data().value<double>(), 42.0);
+    EXPECT_EQ(restored_child->data<double>(), 42.0);
 }
 
 //! RemoveAtCommand in multitag context
@@ -158,7 +158,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandMultitag)
     EXPECT_EQ(restored_child2->identifier(), child2_identifier);
 
     // checking the data of restored item
-    EXPECT_EQ(restored_child2->data().value<double>(), 42.0);
+    EXPECT_EQ(restored_child2->data<double>(), 42.0);
 }
 
 //! Attempt to remove property item.

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -78,6 +78,21 @@ TEST_F(SessionItemTest, setData)
     EXPECT_EQ(item.data<QVariant>(role), QVariant::fromValue(43.0));
 }
 
+TEST_F(SessionItemTest, hasData)
+{
+    SessionItem item;
+
+    EXPECT_FALSE(item.hasData());
+    EXPECT_TRUE(item.hasData(ItemDataRole::IDENTIFIER));
+    EXPECT_FALSE(item.hasData(ItemDataRole::DATA));
+    EXPECT_TRUE(item.hasData(ItemDataRole::DISPLAY));
+    EXPECT_FALSE(item.hasData(ItemDataRole::APPEARANCE));
+    EXPECT_FALSE(item.hasData(ItemDataRole::LIMITS));
+
+    item.setData(42.0);
+    EXPECT_TRUE(item.hasData());
+}
+
 //! Display role.
 
 TEST_F(SessionItemTest, displayName)

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -33,7 +33,7 @@ TEST_F(SessionItemTest, initialState)
     EXPECT_EQ(item.model(), nullptr);
     EXPECT_EQ(item.parent(), nullptr);
     EXPECT_EQ(item.childrenCount(), 0);
-    EXPECT_FALSE(item.data(role).isValid());
+    EXPECT_FALSE(item.data<QVariant>(role).isValid());
     EXPECT_TRUE(item.children().empty());
     EXPECT_EQ(item.modelType(), Constants::BaseType);
     EXPECT_EQ(item.displayName(), Constants::BaseType);
@@ -57,7 +57,7 @@ TEST_F(SessionItemTest, setData)
     SessionItem item;
     const int role = ItemDataRole::DATA;
 
-    EXPECT_FALSE(item.data(role).isValid());
+    EXPECT_FALSE(item.data<QVariant>(role).isValid());
 
     QVariant expected(42.0);
     EXPECT_TRUE(item.setData(expected, role));
@@ -65,17 +65,17 @@ TEST_F(SessionItemTest, setData)
     std::vector<int> expected_roles = {ItemDataRole::IDENTIFIER, ItemDataRole::DISPLAY,
                                        ItemDataRole::DATA};
     EXPECT_EQ(item.roles(), expected_roles);
-    EXPECT_EQ(item.data(role), expected);
+    EXPECT_EQ(item.data<QVariant>(role), expected);
 
     // setting another value
     EXPECT_TRUE(item.setData(QVariant::fromValue(43.0), role));
     EXPECT_EQ(item.roles(), expected_roles);
-    EXPECT_EQ(item.data(role), QVariant::fromValue(43.0));
+    EXPECT_EQ(item.data<QVariant>(role), QVariant::fromValue(43.0));
 
     // setting same value
     EXPECT_FALSE(item.setData(QVariant::fromValue(43.0), role));
     EXPECT_EQ(item.roles(), expected_roles);
-    EXPECT_EQ(item.data(role), QVariant::fromValue(43.0));
+    EXPECT_EQ(item.data<QVariant>(role), QVariant::fromValue(43.0));
 }
 
 //! Display role.
@@ -92,7 +92,7 @@ TEST_F(SessionItemTest, displayName)
     // checking setter
     item.setDisplayName("width");
     EXPECT_EQ(item.displayName(), "width");
-    EXPECT_EQ(item.data().value<double>(), 42.0);
+    EXPECT_EQ(item.data<double>(), 42.0);
 }
 
 //! Attempt to set the different Variant to already existing role.
@@ -109,7 +109,7 @@ TEST_F(SessionItemTest, variantMismatch)
     std::vector<int> expected_roles = {ItemDataRole::IDENTIFIER, ItemDataRole::DISPLAY,
                                        ItemDataRole::DATA};
     EXPECT_EQ(item.roles(), expected_roles);
-    EXPECT_EQ(item.data(role), expected);
+    EXPECT_EQ(item.data<QVariant>(role), expected);
 
     // attempt to rewrite variant with another type
     EXPECT_THROW(item.setData(QVariant::fromValue(std::string("abc")), role), std::runtime_error);
@@ -530,7 +530,7 @@ TEST_F(SessionItemTest, appearance)
     SessionItem item("Model");
 
     // there shouldn't be any data
-    auto variant = item.data(ItemDataRole::APPEARANCE);
+    auto variant = item.data<QVariant>(ItemDataRole::APPEARANCE);
     EXPECT_FALSE(variant.isValid());
 
     // default status
@@ -543,7 +543,7 @@ TEST_F(SessionItemTest, appearance)
     EXPECT_TRUE(item.isEditable());
 
     // data should be there now
-    variant = item.data(ItemDataRole::APPEARANCE);
+    variant = item.data<QVariant>(ItemDataRole::APPEARANCE);
     EXPECT_TRUE(variant.isValid());
 
     // making it readonly

--- a/tests/testmodel/sessionitemdata.test.cpp
+++ b/tests/testmodel/sessionitemdata.test.cpp
@@ -153,14 +153,14 @@ TEST_F(SessionItemDataTest, rangeLoop)
 TEST_F(SessionItemDataTest, hasRole)
 {
     SessionItemData data;
-    EXPECT_FALSE(data.hasRole(0));
-    EXPECT_FALSE(data.hasRole(1));
+    EXPECT_FALSE(data.hasData(0));
+    EXPECT_FALSE(data.hasData(1));
 
     const int role = 99;
     data.setData(QVariant::fromValue(42), role);
-    EXPECT_TRUE(data.hasRole(role));
-    EXPECT_FALSE(data.hasRole(1));
+    EXPECT_TRUE(data.hasData(role));
+    EXPECT_FALSE(data.hasData(1));
 
     data.setData(QVariant(), role);
-    EXPECT_FALSE(data.hasRole(role));
+    EXPECT_FALSE(data.hasData(role));
 }

--- a/tests/testmodel/sessionitemdata.test.cpp
+++ b/tests/testmodel/sessionitemdata.test.cpp
@@ -149,3 +149,18 @@ TEST_F(SessionItemDataTest, rangeLoop)
     EXPECT_EQ(values, expected_values);
     EXPECT_EQ(roles, expected_roles);
 }
+
+TEST_F(SessionItemDataTest, hasRole)
+{
+    SessionItemData data;
+    EXPECT_FALSE(data.hasRole(0));
+    EXPECT_FALSE(data.hasRole(1));
+
+    const int role = 99;
+    data.setData(QVariant::fromValue(42), role);
+    EXPECT_TRUE(data.hasRole(role));
+    EXPECT_FALSE(data.hasRole(1));
+
+    data.setData(QVariant(), role);
+    EXPECT_FALSE(data.hasRole(role));
+}

--- a/tests/testmodel/sessionmodel.test.cpp
+++ b/tests/testmodel/sessionmodel.test.cpp
@@ -272,7 +272,7 @@ TEST_F(SessionModelTest, copyModelItemRootContext)
     ASSERT_TRUE(copy != item);
     EXPECT_FALSE(copy->identifier().empty());
     EXPECT_TRUE(copy->identifier() != item->identifier());
-    EXPECT_EQ(copy->data().value<double>(), 42.0);
+    EXPECT_EQ(copy->data<double>(), 42.0);
     EXPECT_EQ(model.rootItem()->children().size(), 2);
     EXPECT_TRUE(item != copy);
     std::vector<SessionItem*> expected = {item, copy};
@@ -299,7 +299,7 @@ TEST_F(SessionModelTest, copyParentWithProperty)
     ASSERT_TRUE(copy_child != nullptr);
     EXPECT_FALSE(copy->identifier().empty());
     EXPECT_TRUE(copy->identifier() != parent0->identifier());
-    EXPECT_EQ(copy_child->data().value<double>(), 42.0);
+    EXPECT_EQ(copy_child->data<double>(), 42.0);
 }
 
 //! Tests item copy for property item.
@@ -318,7 +318,7 @@ TEST_F(SessionModelTest, copyFreeItem)
 
     // copying to parent
     auto copy = model.copyItem(item.get(), parent0);
-    EXPECT_EQ(copy->data().value<double>(), 42.0);
+    EXPECT_EQ(copy->data<double>(), 42.0);
 }
 
 //! Attempt to copy property item into the same tag.

--- a/tests/testmodel/vectoritem.test.cpp
+++ b/tests/testmodel/vectoritem.test.cpp
@@ -40,7 +40,7 @@ TEST_F(VectorItemTest, initialState)
     EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
     // default label
-    EXPECT_EQ(item.data().value<std::string>(), "(0, 0, 0)");
+    EXPECT_EQ(item.data<std::string>(), "(0, 0, 0)");
 }
 
 //! Initial state of item in model context
@@ -55,9 +55,9 @@ TEST_F(VectorItemTest, initialStateFromModel)
     EXPECT_EQ(item->property<double>(VectorItem::P_Z), 0.0);
 
     // default label
-    EXPECT_EQ(item->data().value<std::string>(), "(0, 0, 0)");
+    EXPECT_EQ(item->data<std::string>(), "(0, 0, 0)");
 
     // changing vector component
     item->setProperty(VectorItem::P_X, 1.0);
-    EXPECT_EQ(item->data().value<std::string>(), "(1, 0, 0)");
+    EXPECT_EQ(item->data<std::string>(), "(1, 0, 0)");
 }

--- a/tests/testmodel/vectoritem.test.cpp
+++ b/tests/testmodel/vectoritem.test.cpp
@@ -35,9 +35,9 @@ TEST_F(VectorItemTest, initialState)
 
     EXPECT_FALSE(item.isEditable());
 
-    EXPECT_EQ(item.property(VectorItem::P_X).value<double>(), 0.0);
-    EXPECT_EQ(item.property(VectorItem::P_Y).value<double>(), 0.0);
-    EXPECT_EQ(item.property(VectorItem::P_Z).value<double>(), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_X), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
     // default label
     EXPECT_EQ(item.data().value<std::string>(), "(0, 0, 0)");
@@ -50,9 +50,9 @@ TEST_F(VectorItemTest, initialStateFromModel)
     SessionModel model;
     auto item = model.insertItem<VectorItem>();
 
-    EXPECT_EQ(item->property(VectorItem::P_X).value<double>(), 0.0);
-    EXPECT_EQ(item->property(VectorItem::P_Y).value<double>(), 0.0);
-    EXPECT_EQ(item->property(VectorItem::P_Z).value<double>(), 0.0);
+    EXPECT_EQ(item->property<double>(VectorItem::P_X), 0.0);
+    EXPECT_EQ(item->property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_EQ(item->property<double>(VectorItem::P_Z), 0.0);
 
     // default label
     EXPECT_EQ(item->data().value<std::string>(), "(0, 0, 0)");

--- a/tests/testviewmodel/TestToyInterferenceFunctionItem.cpp
+++ b/tests/testviewmodel/TestToyInterferenceFunctionItem.cpp
@@ -30,8 +30,7 @@ TEST_F(ToyInterferenceFunctionItemTest, rotationAngleEnabled)
     auto interference = model.insertItem<ToyItems::InterferenceFunctionItem>();
 
     // by default integration flag is ON, rotation angle is disabled
-    EXPECT_TRUE(
-        interference->property(ToyItems::InterferenceFunctionItem::P_INTEGRATION).value<bool>());
+    EXPECT_TRUE(interference->property<bool>(ToyItems::InterferenceFunctionItem::P_INTEGRATION));
     EXPECT_FALSE(
         interference->getItem(ToyItems::InterferenceFunctionItem::P_ROTATION_ANLE)->isEnabled());
 

--- a/tests/testviewmodel/TestToyLayerItem.cpp
+++ b/tests/testviewmodel/TestToyLayerItem.cpp
@@ -45,7 +45,7 @@ TEST_F(ToyLayerItemTest, inModel)
     ToyItems::SampleModel model;
     auto layer = model.insertItem<ToyItems::LayerItem>();
 
-    EXPECT_FALSE(layer->data().isValid());
+    EXPECT_FALSE(layer->data<QVariant>().isValid());
     EXPECT_EQ(layer->displayName(), ToyItems::Constants::LayerItemType);
 }
 

--- a/tests/testviewmodel/TestToyMultiLayerItem.cpp
+++ b/tests/testviewmodel/TestToyMultiLayerItem.cpp
@@ -41,7 +41,7 @@ TEST_F(ToyMultilayerItemTest, multiLayer)
     ToyItems::SampleModel model;
     auto multiLayer = model.insertItem<ToyItems::MultiLayerItem>();
 
-    EXPECT_FALSE(multiLayer->data().isValid());
+    EXPECT_FALSE(multiLayer->data<QVariant>().isValid());
     EXPECT_EQ(multiLayer->displayName(), ToyItems::Constants::MultiLayerItemType);
 }
 

--- a/tests/testviewmodel/TestToyShapeGroupItem.cpp
+++ b/tests/testviewmodel/TestToyShapeGroupItem.cpp
@@ -35,7 +35,7 @@ TEST_F(ToyShapeGroupItemTest, initialState)
 
     EXPECT_EQ(item.currentIndex(), 1);
     ASSERT_TRUE(item.currentItem() != nullptr);
-    EXPECT_TRUE(item.data().isValid());
+    EXPECT_TRUE(item.data<QVariant>().isValid());
     EXPECT_EQ(item.currentType(), item.currentItem()->modelType());
     EXPECT_EQ(item.currentType(), ToyItems::Constants::SphereItemType);
     ASSERT_EQ(item.children().size(), 3);
@@ -46,7 +46,7 @@ TEST_F(ToyShapeGroupItemTest, initialState)
     EXPECT_EQ(item.children().at(2)->parent(), &item);
 
     // expected value in combo
-    ComboProperty combo = item.data().value<ComboProperty>();
+    ComboProperty combo = item.data<ComboProperty>();
     EXPECT_EQ(combo.currentIndex(), 1);
     EXPECT_EQ(combo.values(),
               std::vector<std::string>({"Cylinder", "Full sphere", "Anysotropical pyramid"}));
@@ -61,11 +61,11 @@ TEST_F(ToyShapeGroupItemTest, setCurrentType)
     ASSERT_TRUE(item.currentItem() != nullptr);
     EXPECT_EQ(item.currentType(), item.currentItem()->modelType());
     EXPECT_EQ(item.currentItem()->modelType(), ToyItems::Constants::CylinderItemType);
-    EXPECT_TRUE(item.data().isValid());
+    EXPECT_TRUE(item.data<QVariant>().isValid());
     EXPECT_EQ(item.children().size(), 3);
 
     // expected value in combo
-    ComboProperty combo = item.data().value<ComboProperty>();
+    ComboProperty combo = item.data<ComboProperty>();
     EXPECT_EQ(combo.currentIndex(), 0);
     EXPECT_EQ(combo.values(),
               std::vector<std::string>({"Cylinder", "Full sphere", "Anysotropical pyramid"}));
@@ -79,7 +79,7 @@ TEST_F(ToyShapeGroupItemTest, inModelContext)
 
     EXPECT_EQ(item->currentIndex(), 1);
     ASSERT_TRUE(item->currentItem() != nullptr);
-    EXPECT_TRUE(item->data().isValid());
+    EXPECT_TRUE(item->data<QVariant>().isValid());
     EXPECT_EQ(item->currentType(), item->currentItem()->modelType());
     EXPECT_EQ(item->children().size(), 3);
 

--- a/tests/testviewmodel/propertiesrowstrategy.test.cpp
+++ b/tests/testviewmodel/propertiesrowstrategy.test.cpp
@@ -64,9 +64,9 @@ TEST_F(PropertiesRowStrategyTest, vectorItemCustomLabels)
 {
     VectorItem item;
 
-    EXPECT_EQ(item.property(VectorItem::P_X).value<double>(), 0.0);
-    EXPECT_EQ(item.property(VectorItem::P_Y).value<double>(), 0.0);
-    EXPECT_EQ(item.property(VectorItem::P_Z).value<double>(), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_X), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
     PropertiesRowStrategy strategy({"a", "b", "c"});
     auto items = strategy.constructRefRow(&item);
@@ -93,11 +93,13 @@ TEST_F(PropertiesRowStrategyTest, vectorItemAutoLabels)
 {
     VectorItem item;
 
-    EXPECT_EQ(item.property(VectorItem::P_X).value<double>(), 0.0);
-    EXPECT_EQ(item.property(VectorItem::P_Y).value<double>(), 0.0);
-    EXPECT_EQ(item.property(VectorItem::P_Z).value<double>(), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_X), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
-    QStringList expected = QStringList() << "X" << "Y" << "Z";
+    QStringList expected = QStringList() << "X"
+                                         << "Y"
+                                         << "Z";
 
     PropertiesRowStrategy strategy;
     auto items = strategy.constructRefRow(&item);

--- a/tests/testviewmodel/standardviewitems.test.cpp
+++ b/tests/testviewmodel/standardviewitems.test.cpp
@@ -69,7 +69,7 @@ TEST_F(StandardViewItemsTest, ViewLabelItem_setData)
     EXPECT_EQ(viewItem.data(Qt::EditRole), new_data);    // new data
 
     // SessionItem itself should have new data
-    EXPECT_EQ(item.data(ItemDataRole::DISPLAY), Utils::toCustomVariant(new_data)); // new data
+    EXPECT_EQ(item.data<QVariant>(ItemDataRole::DISPLAY), Utils::toCustomVariant(new_data)); // new data
 
     // it is not allowed to set another type of data to ViewLabelItem
     QVariant not_allowed_value(42);
@@ -134,7 +134,7 @@ TEST_F(StandardViewItemsTest, ViewDataItem_setDataForDouble)
     EXPECT_EQ(viewItem.data(Qt::EditRole), new_data);    // new data
 
     // SessionItem itself should have new data
-    EXPECT_EQ(item.data(), new_data); // new data
+    EXPECT_EQ(item.data<QVariant>(), new_data); // new data
 
     // it is not allowed to set another type of data to ViewDataItem
     QVariant not_allowed_value("Layer");
@@ -193,7 +193,7 @@ TEST_F(StandardViewItemsTest, ViewDataItem_setDataForColor)
     EXPECT_EQ(viewItem.data(Qt::DecorationRole), new_data); // new data
 
     // SessionItem itself should have new data
-    EXPECT_EQ(item.data(), new_data); // new data
+    EXPECT_EQ(item.data<QVariant>(), new_data); // new data
 
     // it is not allowed to set another type of data to ViewDataItem
     QVariant not_allowed_value("Layer");

--- a/tests/testviewmodel/viewmodeldelegate.test.cpp
+++ b/tests/testviewmodel/viewmodeldelegate.test.cpp
@@ -85,5 +85,5 @@ TEST_F(ViewModelDelegateTest, widgetMapper)
 
     editor->setData(43.0);
     editor->dataChanged(editor->data());
-    EXPECT_EQ(x_item->data().value<double>(), 43.0);
+    EXPECT_EQ(x_item->data<double>(), 43.0);
 }

--- a/tests/testviewmodel/viewportaxisplotcontroller.test.cpp
+++ b/tests/testviewmodel/viewportaxisplotcontroller.test.cpp
@@ -129,8 +129,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeQCPAxis)
     EXPECT_EQ(yChanged->count(), 0);
 
     // Check changed properties in ViewportAxisItem
-    EXPECT_EQ(axisItem->property(ViewportAxisItem::P_MIN).value<double>(), expected_min);
-    EXPECT_EQ(axisItem->property(ViewportAxisItem::P_MAX).value<double>(), expected_max);
+    EXPECT_EQ(axisItem->property<double>(ViewportAxisItem::P_MIN), expected_min);
+    EXPECT_EQ(axisItem->property<double>(ViewportAxisItem::P_MAX), expected_max);
 }
 
 //! Controller subscribed to ViewportAxisItem.


### PR DESCRIPTION
Make SessionItem::property methods templated to decrease verbosity and QVariant visibility.