### PR TITLE
Fix application crash when GraphViewportItem is removed

### DIFF
--- a/source/libmvvm_model/mvvm/model/itemutils.cpp
+++ b/source/libmvvm_model/mvvm/model/itemutils.cpp
@@ -119,3 +119,15 @@ SessionItem* Utils::FindNextItemToSelect(SessionItem* item)
     auto closest = next ? next : FindPreviousSibling(item);
     return closest ? closest : item->parent();
 }
+
+bool Utils::IsItemAncestor(const SessionItem* item, const SessionItem* candidate)
+{
+    const SessionItem* parent = item->parent();
+    while (parent) {
+        if (parent == candidate)
+            return true;
+        else
+            parent = parent->parent();
+    }
+    return false;
+}

--- a/source/libmvvm_model/mvvm/model/itemutils.h
+++ b/source/libmvvm_model/mvvm/model/itemutils.h
@@ -63,6 +63,9 @@ CORE_EXPORT SessionItem* FindPreviousSibling(SessionItem* item);
 
 CORE_EXPORT SessionItem* FindNextItemToSelect(SessionItem* item);
 
+//! Returns true if 'candidate' is one of ancestor of given item.
+CORE_EXPORT bool IsItemAncestor(const SessionItem* item, const SessionItem* candidate);
+
 } // namespace Utils
 
 } // namespace ModelView

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelbase.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelbase.cpp
@@ -12,10 +12,10 @@
 
 using namespace ModelView;
 
-struct ViewModelBase::RefViewModelImpl {
+struct ViewModelBase::ViewModelBaseImpl {
     ViewModelBase* model{nullptr};
     std::unique_ptr<ViewItem> root;
-    RefViewModelImpl(ViewModelBase* model) : model(model) {}
+    ViewModelBaseImpl(ViewModelBase* model) : model(model) {}
 
     bool item_belongs_to_model(ViewItem* item)
     {
@@ -24,7 +24,7 @@ struct ViewModelBase::RefViewModelImpl {
 };
 
 ViewModelBase::ViewModelBase(QObject* parent)
-    : QAbstractItemModel(parent), p_impl(std::make_unique<RefViewModelImpl>(this))
+    : QAbstractItemModel(parent), p_impl(std::make_unique<ViewModelBaseImpl>(this))
 {
     beginResetModel();
     setRootViewItem(std::make_unique<RootViewItem>(nullptr));
@@ -118,7 +118,7 @@ QModelIndex ViewModelBase::indexFromItem(const ViewItem* item) const
 void ViewModelBase::removeRow(ViewItem* parent, int row)
 {
     if (!p_impl->item_belongs_to_model(parent))
-        throw std::runtime_error("Error in RefViewModel: attempt to use parent from another model");
+        throw std::runtime_error("Error in ViewModelBase: attempt to use parent from another model");
 
     beginRemoveRows(indexFromItem(parent), row, row);
     parent->removeRow(row);
@@ -128,7 +128,7 @@ void ViewModelBase::removeRow(ViewItem* parent, int row)
 void ViewModelBase::clearRows(ViewItem* parent)
 {
     if (!p_impl->item_belongs_to_model(parent))
-        throw std::runtime_error("Error in RefViewModel: attempt to use parent from another model");
+        throw std::runtime_error("Error in ViewModelBase: attempt to use parent from another model");
 
     if (!parent->rowCount())
         return;
@@ -144,7 +144,7 @@ void ViewModelBase::insertRow(ViewItem* parent, int row,
                               std::vector<std::unique_ptr<ViewItem>> items)
 {
     if (!p_impl->item_belongs_to_model(parent))
-        throw std::runtime_error("Error in RefViewModel: attempt to use parent from another model");
+        throw std::runtime_error("Error in ViewModelBase: attempt to use parent from another model");
 
     beginInsertRows(indexFromItem(parent), row, row);
     parent->insertRow(row, std::move(items));

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelbase.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelbase.h
@@ -67,8 +67,8 @@ public:
 private:    
     void setRootViewItem(std::unique_ptr<ViewItem> root_item);
     friend class ViewModelController;
-    struct RefViewModelImpl;
-    std::unique_ptr<RefViewModelImpl> p_impl;
+    struct ViewModelBaseImpl;
+    std::unique_ptr<ViewModelBaseImpl> p_impl;
 };
 
 }; // namespace ModelView

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelcontroller.cpp
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelcontroller.cpp
@@ -38,7 +38,7 @@ bool isValidItemRole(const ViewItem* view, int item_role)
 
 } // namespace
 
-struct ViewModelController::RefViewModelControllerImpl {
+struct ViewModelController::ViewModelControllerImpl {
     ViewModelController* controller;
     SessionModel* session_model{nullptr};
     ViewModelBase* view_model{nullptr};
@@ -47,7 +47,7 @@ struct ViewModelController::RefViewModelControllerImpl {
     std::map<SessionItem*, ViewItem*> item_to_view; //! correspondence of item and its view
     Path root_item_path;
 
-    RefViewModelControllerImpl(ViewModelController* controller, SessionModel* session_model,
+    ViewModelControllerImpl(ViewModelController* controller, SessionModel* session_model,
                                ViewModelBase* view_model)
         : controller(controller), view_model(view_model)
     {
@@ -56,7 +56,7 @@ struct ViewModelController::RefViewModelControllerImpl {
 
     void check_initialization()
     {
-        const std::string msg("Error in RefViewModelController: ");
+        const std::string msg("Error in ViewModelController: ");
         if (!view_model)
             throw std::runtime_error(msg + "ViewModel is not defined");
 
@@ -196,7 +196,7 @@ struct ViewModelController::RefViewModelControllerImpl {
 };
 
 ViewModelController::ViewModelController(SessionModel* session_model, ViewModelBase* view_model)
-    : p_impl(std::make_unique<RefViewModelControllerImpl>(this, session_model, view_model))
+    : p_impl(std::make_unique<ViewModelControllerImpl>(this, session_model, view_model))
 {
 }
 

--- a/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelcontroller.h
+++ b/source/libmvvm_viewmodel/mvvm/viewmodel/viewmodelcontroller.h
@@ -62,8 +62,8 @@ protected:
     void update_branch(const SessionItem* item);
 
 private:
-    struct RefViewModelControllerImpl;
-    std::unique_ptr<RefViewModelControllerImpl> p_impl;
+    struct ViewModelControllerImpl;
+    std::unique_ptr<ViewModelControllerImpl> p_impl;
 };
 
 } // namespace ModelView

--- a/tests/testmodel/itemutils.test.cpp
+++ b/tests/testmodel/itemutils.test.cpp
@@ -15,6 +15,7 @@
 #include <mvvm/model/sessionitem.h>
 #include <mvvm/model/sessionmodel.h>
 #include <mvvm/model/taginfo.h>
+#include <mvvm/standarditems/vectoritem.h>
 
 using namespace ModelView;
 
@@ -229,4 +230,27 @@ TEST_F(ItemUtilsTest, FindNextItemToSelect)
     EXPECT_EQ(Utils::FindNextItemToSelect(child2), child1);
     EXPECT_EQ(Utils::FindNextItemToSelect(property), parent);
     EXPECT_EQ(Utils::FindNextItemToSelect(parent), model.rootItem());
+}
+
+//! Looking for previous item.
+
+TEST_F(ItemUtilsTest, IsItemAncestor)
+{
+    SessionModel model;
+    EXPECT_FALSE(Utils::IsItemAncestor(model.rootItem(), model.rootItem()));
+
+    // rootItem in ancestor of vectorItem, but not vice versa
+    auto vector_item = model.insertItem<VectorItem>();
+    EXPECT_TRUE(Utils::IsItemAncestor(vector_item, model.rootItem()));
+    EXPECT_FALSE(Utils::IsItemAncestor(model.rootItem(), vector_item));
+
+    auto x_item = vector_item->getItem(VectorItem::P_X);
+
+    EXPECT_TRUE(Utils::IsItemAncestor(x_item, model.rootItem()));
+    EXPECT_TRUE(Utils::IsItemAncestor(x_item, vector_item));
+    EXPECT_FALSE(Utils::IsItemAncestor(model.rootItem(), x_item));
+    EXPECT_FALSE(Utils::IsItemAncestor(vector_item, x_item));
+
+    auto y_item = vector_item->getItem(VectorItem::P_Y);
+    EXPECT_FALSE(Utils::IsItemAncestor(x_item, y_item));
 }

--- a/tests/testviewmodel/TestToyLayerItem.cpp
+++ b/tests/testviewmodel/TestToyLayerItem.cpp
@@ -148,21 +148,3 @@ TEST_F(ToyLayerItemTest, setRootItemContext)
     EXPECT_EQ(viewModel.sessionItemFromIndex(thicknessIndex),
               layer->getItem(ToyItems::LayerItem::P_THICKNESS));
 }
-
-//! LayerItem as rootItem.
-
-TEST_F(ToyLayerItemTest, inTopItemsViewModelContext)
-{
-    ToyItems::SampleModel model;
-    auto layer = model.insertItem<ToyItems::LayerItem>();
-
-    TopItemsViewModel viewModel(&model);
-    viewModel.setRootSessionItem(layer);
-
-    EXPECT_EQ(viewModel.rowCount(QModelIndex()), 0);
-    EXPECT_EQ(viewModel.columnCount(QModelIndex()), 0);
-
-    model.insertItem<ToyItems::ParticleItem>(layer);
-    EXPECT_EQ(viewModel.rowCount(QModelIndex()), 1);
-    EXPECT_EQ(viewModel.columnCount(QModelIndex()), 2);
-}

--- a/tests/testviewmodel/propertyviewmodel.test.cpp
+++ b/tests/testviewmodel/propertyviewmodel.test.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include "google_test.h"
+#include "toy_includes.h"
 #include <mvvm/model/propertyitem.h>
 #include <mvvm/model/sessionitem.h>
 #include <mvvm/model/sessionmodel.h>
@@ -85,4 +86,26 @@ TEST_F(PropertyViewModelTest, vectorItem)
     viewModel.setRootSessionItem(parent);
     EXPECT_EQ(viewModel.rowCount(), 3);
     EXPECT_EQ(viewModel.columnCount(), 2);
+}
+
+//! LayerItem in a MultiLayer.
+
+TEST_F(PropertyViewModelTest, layerInMultiLayerAsRootItem)
+{
+    SessionModel model;
+    auto multilayer = model.insertItem<ToyItems::MultiLayerItem>();
+    auto layer = model.insertItem<ToyItems::LayerItem>(multilayer);
+
+    PropertyViewModel viewmodel(&model);
+    viewmodel.setRootSessionItem(layer);
+
+    // check layer thickness and color
+    EXPECT_EQ(viewmodel.rowCount(), 2);
+    EXPECT_EQ(viewmodel.columnCount(), 2);
+
+    // remove multilayer
+    model.removeItem(model.rootItem(), {"", 0});
+
+    EXPECT_EQ(viewmodel.rowCount(), 0);
+    EXPECT_EQ(viewmodel.columnCount(), 0);
 }

--- a/tests/testviewmodel/topitemsviewmodel.test.cpp
+++ b/tests/testviewmodel/topitemsviewmodel.test.cpp
@@ -1,0 +1,139 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+#include "toy_includes.h"
+#include <QSignalSpy>
+#include <mvvm/model/propertyitem.h>
+#include <mvvm/model/sessionitem.h>
+#include <mvvm/model/sessionmodel.h>
+#include <mvvm/model/taginfo.h>
+#include <mvvm/standarditems/vectoritem.h>
+#include <mvvm/viewmodel/topitemsviewmodel.h>
+
+using namespace ModelView;
+
+//! Tests for TopItemsViewModel class.
+
+class TopItemsViewModelTest : public ::testing::Test
+{
+public:
+    ~TopItemsViewModelTest();
+};
+
+TopItemsViewModelTest::~TopItemsViewModelTest() = default;
+
+TEST_F(TopItemsViewModelTest, initialState)
+{
+    SessionModel model;
+    TopItemsViewModel viewModel(&model);
+    EXPECT_EQ(viewModel.rowCount(), 0);
+    EXPECT_EQ(viewModel.columnCount(), 0);
+    EXPECT_EQ(viewModel.sessionItemFromIndex(QModelIndex()), model.rootItem());
+}
+
+//! Insert LayerItem in empty model.
+
+TEST_F(TopItemsViewModelTest, insertLayerThenRemove)
+{
+    ToyItems::SampleModel model;
+    TopItemsViewModel viewmodel(&model);
+
+    QSignalSpy spyInsert(&viewmodel, &ViewModelBase::rowsInserted);
+    QSignalSpy spyRemove(&viewmodel, &ViewModelBase::rowsRemoved);
+
+    model.insertItem<ToyItems::LayerItem>();
+
+    EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 1);
+    EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 2);
+
+    EXPECT_EQ(spyRemove.count(), 0);
+    EXPECT_EQ(spyInsert.count(), 1);
+
+    model.removeItem(model.rootItem(), {"", 0});
+    EXPECT_EQ(spyRemove.count(), 1);
+    EXPECT_EQ(spyInsert.count(), 1);
+
+    EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 0);
+    EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 0);
+}
+
+//! Insert LayerItem in MultiLayer.
+
+TEST_F(TopItemsViewModelTest, insertLayerInMultiLayerThenRemove)
+{
+    ToyItems::SampleModel model;
+    TopItemsViewModel viewmodel(&model);
+
+    QSignalSpy spyInsert(&viewmodel, &ViewModelBase::rowsInserted);
+    QSignalSpy spyRemove(&viewmodel, &ViewModelBase::rowsRemoved);
+
+    // inserting multilayer
+    auto multilayer = model.insertItem<ToyItems::MultiLayerItem>();
+
+    EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 1);
+    EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 2);
+    EXPECT_EQ(spyRemove.count(), 0);
+    EXPECT_EQ(spyInsert.count(), 1);
+
+    // insert layer
+    auto layer = model.insertItem<ToyItems::LayerItem>(multilayer);
+    EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 1);
+    EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 2);
+    EXPECT_EQ(spyRemove.count(), 0);
+    EXPECT_EQ(spyInsert.count(), 2);
+
+    // checking their indices
+    auto multilayer_index = viewmodel.index(0, 0, QModelIndex());
+    auto layer_index = viewmodel.index(0, 0, multilayer_index);
+    EXPECT_EQ(viewmodel.sessionItemFromIndex(multilayer_index), multilayer);
+    EXPECT_EQ(viewmodel.sessionItemFromIndex(layer_index), layer);
+
+    // checking row and columns
+    EXPECT_EQ(viewmodel.rowCount(multilayer_index), 1);
+    EXPECT_EQ(viewmodel.columnCount(multilayer_index), 2);
+    EXPECT_EQ(viewmodel.rowCount(layer_index), 0);
+    EXPECT_EQ(viewmodel.columnCount(layer_index), 0);
+
+    // removing layer
+    model.removeItem(multilayer, {"", 0});
+    EXPECT_EQ(spyRemove.count(), 1);
+    EXPECT_EQ(spyInsert.count(), 2);
+    EXPECT_EQ(viewmodel.rowCount(multilayer_index), 0);
+    EXPECT_EQ(viewmodel.columnCount(multilayer_index), 0);
+}
+
+//! Insert LayerItem in MultiLayer while multilayer is root item. Then deleting multilayer.
+
+TEST_F(TopItemsViewModelTest, multuLayerAsRooItem)
+{
+    ToyItems::SampleModel model;
+    TopItemsViewModel viewmodel(&model);
+
+    // setting up single multilayer playing the role
+    auto multilayer = model.insertItem<ToyItems::MultiLayerItem>();
+    viewmodel.setRootSessionItem(multilayer);
+    QSignalSpy spyInsert(&viewmodel, &ViewModelBase::rowsInserted);
+    QSignalSpy spyRemove(&viewmodel, &ViewModelBase::rowsRemoved);
+
+    // initial conditions
+    EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 0);
+    EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 0);
+    EXPECT_EQ(viewmodel.sessionItemFromIndex(QModelIndex()), multilayer); // our new root
+
+    // adding layer
+    model.insertItem<ToyItems::LayerItem>(multilayer);
+    EXPECT_EQ(viewmodel.rowCount(QModelIndex()), 1);
+    EXPECT_EQ(viewmodel.columnCount(QModelIndex()), 2);
+    EXPECT_EQ(spyRemove.count(), 0);
+    EXPECT_EQ(spyInsert.count(), 1);
+
+    // removing multilayer
+//    model.removeItem(model.rootItem(), {"", 0});
+}

--- a/tests/testviewmodel/topitemsviewmodel.test.cpp
+++ b/tests/testviewmodel/topitemsviewmodel.test.cpp
@@ -135,5 +135,5 @@ TEST_F(TopItemsViewModelTest, multuLayerAsRooItem)
     EXPECT_EQ(spyInsert.count(), 1);
 
     // removing multilayer
-//    model.removeItem(model.rootItem(), {"", 0});
+    model.removeItem(model.rootItem(), {"", 0});
 }

--- a/tests/testviewmodel/viewmodelbase.test.cpp
+++ b/tests/testviewmodel/viewmodelbase.test.cpp
@@ -80,7 +80,7 @@ TEST_F(ViewModelBaseTest, standardItemModel)
     // item are the same
 }
 
-//! Initial state of empty RefViewModel.
+//! Initial state of empty ViewModelBase.
 
 TEST_F(ViewModelBaseTest, initialState)
 {


### PR DESCRIPTION
The problem was in ViewModelController which tries to regenerate presentation when one of top level ancestors is removed.