### PR TITLE
Command macro

### DIFF
--- a/source/libmvvm_model/mvvm/commands/CMakeLists.txt
+++ b/source/libmvvm_model/mvvm/commands/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${library_name} PRIVATE
     commandservice.h
     copyitemcommand.cpp
     copyitemcommand.h
+    commandresult.h
     insertnewitemcommand.cpp
     insertnewitemcommand.h
     moveitemcommand.cpp

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.cpp
@@ -117,7 +117,7 @@ SessionModel* AbstractItemCommand::model() const
     return p_impl->model;
 }
 
-void AbstractItemCommand::setCommandResult(const CommandResult& command_result)
+void AbstractItemCommand::setResult(const CommandResult& command_result)
 {
     p_impl->m_result = command_result;
 }

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.cpp
@@ -22,6 +22,7 @@ struct AbstractItemCommand::AbstractItemCommandImpl {
     EStatus status{INITIAL};
     SessionModel* model{nullptr};
     AbstractItemCommand* parent_impl{nullptr};
+    CommandResult m_result;
     AbstractItemCommandImpl(AbstractItemCommand* parent) : parent_impl(parent) {}
 
     void set_after_execute() { status = AFTER_EXECUTE; }
@@ -82,6 +83,11 @@ std::string AbstractItemCommand::description() const
     return p_impl->text;
 }
 
+CommandResult AbstractItemCommand::commandResult() const
+{
+    return p_impl->m_result;
+}
+
 //! Sets command obsolete flag.
 
 void AbstractItemCommand::setObsolete(bool flag)
@@ -109,4 +115,9 @@ SessionItem* AbstractItemCommand::itemFromPath(const Path& path) const
 SessionModel* AbstractItemCommand::model() const
 {
     return p_impl->model;
+}
+
+void AbstractItemCommand::setCommandResult(const CommandResult& command_result)
+{
+    p_impl->m_result = command_result;
 }

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.cpp
@@ -83,7 +83,7 @@ std::string AbstractItemCommand::description() const
     return p_impl->text;
 }
 
-CommandResult AbstractItemCommand::commandResult() const
+CommandResult AbstractItemCommand::result() const
 {
     return p_impl->m_result;
 }

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <mvvm/model_export.h>
+#include <mvvm/commands/commandresult.h>
 #include <string>
 
 namespace ModelView
@@ -37,12 +38,15 @@ public:
 
     std::string description() const;
 
+    CommandResult commandResult() const;
+
 protected:
     void setObsolete(bool flag);
     void setDescription(const std::string& text);
     Path pathFromItem(SessionItem* item) const;
     SessionItem* itemFromPath(const Path& path) const;
     SessionModel* model() const;
+    void setCommandResult(const CommandResult& command_result);
 
 private:
     virtual void execute_command() = 0;

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
@@ -38,7 +38,7 @@ public:
 
     std::string description() const;
 
-    CommandResult commandResult() const;
+    CommandResult result() const;
 
 protected:
     void setObsolete(bool flag);

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
@@ -46,7 +46,7 @@ protected:
     Path pathFromItem(SessionItem* item) const;
     SessionItem* itemFromPath(const Path& path) const;
     SessionModel* model() const;
-    void setCommandResult(const CommandResult& command_result);
+    void setResult(const CommandResult& command_result);
 
 private:
     virtual void execute_command() = 0;

--- a/source/libmvvm_model/mvvm/commands/commandresult.h
+++ b/source/libmvvm_model/mvvm/commands/commandresult.h
@@ -1,0 +1,25 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#ifndef MVVM_COMMANDS_COMMANDRESULT_H
+#define MVVM_COMMANDS_COMMANDRESULT_H
+
+#include <variant>
+
+namespace ModelView
+{
+
+class SessionItem;
+
+//! Results of command execution.
+using CommandResult = std::variant<bool, ModelView::SessionItem*>;
+
+} // namespace ModelView
+
+#endif // MVVM_COMMANDS_COMMANDRESULT_H

--- a/source/libmvvm_model/mvvm/commands/commandservice.cpp
+++ b/source/libmvvm_model/mvvm/commands/commandservice.cpp
@@ -37,7 +37,8 @@ SessionItem* CommandService::insertNewItem(const item_factory_func_t& func, Sess
 
     int actual_row = tagrow.row < 0 ? parent->itemCount(tagrow.tag) : tagrow.row;
 
-    return process_command<InsertNewItemCommand>(func, parent, TagRow{tagrow.tag, actual_row});
+    return std::get<SessionItem*>(
+        process_command<InsertNewItemCommand>(func, parent, TagRow{tagrow.tag, actual_row}));
 }
 
 SessionItem* CommandService::copyItem(const SessionItem* item, SessionItem* parent,
@@ -52,7 +53,8 @@ SessionItem* CommandService::copyItem(const SessionItem* item, SessionItem* pare
 
     int actual_row = tagrow.row < 0 ? parent->itemCount(tagrow.tag) : tagrow.row;
 
-    return process_command<CopyItemCommand>(item, parent, TagRow{tagrow.tag, actual_row});
+    return std::get<SessionItem*>(
+        process_command<CopyItemCommand>(item, parent, TagRow{tagrow.tag, actual_row}));
 }
 
 bool CommandService::setData(SessionItem* item, const Variant& value, int role)
@@ -60,7 +62,7 @@ bool CommandService::setData(SessionItem* item, const Variant& value, int role)
     if (!item)
         return false;
 
-    return process_command<SetValueCommand>(item, value, role);
+    return std::get<bool>(process_command<SetValueCommand>(item, value, role));
 }
 
 void CommandService::removeItem(SessionItem* parent, const TagRow& tagrow)

--- a/source/libmvvm_model/mvvm/commands/commandservice.h
+++ b/source/libmvvm_model/mvvm/commands/commandservice.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <mvvm/commands/undostack.h>
+#include <mvvm/commands/commandresult.h>
 #include <mvvm/core/variant.h>
 #include <mvvm/model/function_types.h>
 #include <mvvm/model_export.h>
@@ -50,7 +51,7 @@ public:
     void setCommandRecordPause(bool value);
 
 private:
-    template <typename C, typename... Args> typename C::result_t process_command(Args&&... args);
+    template <typename C, typename... Args> CommandResult process_command(Args&&... args);
 
     bool provideUndo() const;
 
@@ -62,22 +63,18 @@ private:
 //! Creates and processes command of given type using given argument list.
 
 template <typename C, typename... Args>
-typename C::result_t CommandService::process_command(Args&&... args)
+CommandResult CommandService::process_command(Args&&... args)
 {
-    typename C::result_t result;
-
     if (provideUndo()) {
         // making shared because underlying QUndoStack requires ownership
         auto command = std::make_shared<C>(std::forward<Args>(args)...);
         m_commands->execute(command);
-        result = command->result();
+        return command->commandResult();
     } else {
         auto command = std::make_unique<C>(std::forward<Args>(args)...);
         command->execute();
-        result = command->result();
+        return command->commandResult();
     }
-
-    return result;
 }
 
 } // namespace ModelView

--- a/source/libmvvm_model/mvvm/commands/commandservice.h
+++ b/source/libmvvm_model/mvvm/commands/commandservice.h
@@ -11,8 +11,8 @@
 #define MVVM_COMMANDS_COMMANDSERVICE_H
 
 #include <memory>
-#include <mvvm/commands/undostack.h>
 #include <mvvm/commands/commandresult.h>
+#include <mvvm/commands/undostack.h>
 #include <mvvm/core/variant.h>
 #include <mvvm/model/function_types.h>
 #include <mvvm/model_export.h>
@@ -71,9 +71,9 @@ CommandResult CommandService::process_command(Args&&... args)
         m_commands->execute(command);
         return command->commandResult();
     } else {
-        auto command = std::make_unique<C>(std::forward<Args>(args)...);
-        command->execute();
-        return command->commandResult();
+        C command(std::forward<Args>(args)...);
+        command.execute();
+        return command.commandResult();
     }
 }
 

--- a/source/libmvvm_model/mvvm/commands/commandservice.h
+++ b/source/libmvvm_model/mvvm/commands/commandservice.h
@@ -11,7 +11,6 @@
 #define MVVM_COMMANDS_COMMANDSERVICE_H
 
 #include <memory>
-#include <mvvm/commands/commandadapter.h>
 #include <mvvm/commands/undostack.h>
 #include <mvvm/core/variant.h>
 #include <mvvm/model/function_types.h>
@@ -69,8 +68,7 @@ typename C::result_t CommandService::process_command(Args&&... args)
 
     if (provideUndo()) {
         auto command = std::make_shared<C>(std::forward<Args>(args)...);
-        auto adapter = new CommandAdapter(command);
-        m_commands->push(adapter);
+        m_commands->execute(command);
         result = command->result();
     } else {
         auto command = std::make_unique<C>(std::forward<Args>(args)...);

--- a/source/libmvvm_model/mvvm/commands/commandservice.h
+++ b/source/libmvvm_model/mvvm/commands/commandservice.h
@@ -69,11 +69,11 @@ CommandResult CommandService::process_command(Args&&... args)
         // making shared because underlying QUndoStack requires ownership
         auto command = std::make_shared<C>(std::forward<Args>(args)...);
         m_commands->execute(command);
-        return command->commandResult();
+        return command->result();
     } else {
         C command(std::forward<Args>(args)...);
         command.execute();
-        return command.commandResult();
+        return command.result();
     }
 }
 

--- a/source/libmvvm_model/mvvm/commands/commandservice.h
+++ b/source/libmvvm_model/mvvm/commands/commandservice.h
@@ -67,6 +67,7 @@ typename C::result_t CommandService::process_command(Args&&... args)
     typename C::result_t result;
 
     if (provideUndo()) {
+        // making shared because underlying QUndoStack requires ownership
         auto command = std::make_shared<C>(std::forward<Args>(args)...);
         m_commands->execute(command);
         result = command->result();

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -33,6 +33,8 @@ struct CopyItemCommand::CopyItemCommandImpl {
 CopyItemCommand::CopyItemCommand(const SessionItem* item, SessionItem* parent, TagRow tagrow)
     : AbstractItemCommand(parent), p_impl(std::make_unique<CopyItemCommandImpl>(std::move(tagrow)))
 {
+    setCommandResult(nullptr);
+
     setDescription(generate_description(item->modelType(), p_impl->tagrow));
     p_impl->backup_strategy = parent->model()->itemBackupStrategy();
     p_impl->item_path = pathFromItem(parent);
@@ -49,6 +51,7 @@ void CopyItemCommand::undo_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
     delete parent->takeItem(p_impl->tagrow);
+    setCommandResult(nullptr);
     p_impl->result = nullptr;
 }
 
@@ -58,7 +61,9 @@ void CopyItemCommand::execute_command()
     auto item = p_impl->backup_strategy->restoreItem();
     if (parent->insertItem(item.get(), p_impl->tagrow)) {
         p_impl->result = item.release();
+        setCommandResult(item.release());
     } else {
+        setCommandResult(nullptr);
         p_impl->result = nullptr;
         setObsolete(true);
     }

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -60,8 +60,9 @@ void CopyItemCommand::execute_command()
     auto parent = itemFromPath(p_impl->item_path);
     auto item = p_impl->backup_strategy->restoreItem();
     if (parent->insertItem(item.get(), p_impl->tagrow)) {
-        p_impl->result = item.release();
-        setCommandResult(item.release());
+        auto result = item.release();
+        p_impl->result = result;
+        setCommandResult(result);
     } else {
         setCommandResult(nullptr);
         p_impl->result = nullptr;

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -32,7 +32,7 @@ struct CopyItemCommand::CopyItemCommandImpl {
 CopyItemCommand::CopyItemCommand(const SessionItem* item, SessionItem* parent, TagRow tagrow)
     : AbstractItemCommand(parent), p_impl(std::make_unique<CopyItemCommandImpl>(std::move(tagrow)))
 {
-    setCommandResult(nullptr);
+    setResult(nullptr);
 
     setDescription(generate_description(item->modelType(), p_impl->tagrow));
     p_impl->backup_strategy = parent->model()->itemBackupStrategy();
@@ -50,7 +50,7 @@ void CopyItemCommand::undo_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
     delete parent->takeItem(p_impl->tagrow);
-    setCommandResult(nullptr);
+    setResult(nullptr);
 }
 
 void CopyItemCommand::execute_command()
@@ -59,9 +59,9 @@ void CopyItemCommand::execute_command()
     auto item = p_impl->backup_strategy->restoreItem();
     if (parent->insertItem(item.get(), p_impl->tagrow)) {
         auto result = item.release();
-        setCommandResult(result);
+        setResult(result);
     } else {
-        setCommandResult(nullptr);
+        setResult(nullptr);
         setObsolete(true);
     }
 }

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -24,10 +24,9 @@ std::string generate_description(const std::string& modelType, const TagRow& tag
 
 struct CopyItemCommand::CopyItemCommandImpl {
     TagRow tagrow;
-    result_t result;
     std::unique_ptr<ItemBackupStrategy> backup_strategy;
     Path item_path;
-    CopyItemCommandImpl(TagRow tagrow) : tagrow(std::move(tagrow)), result(nullptr) {}
+    CopyItemCommandImpl(TagRow tagrow) : tagrow(std::move(tagrow)) {}
 };
 
 CopyItemCommand::CopyItemCommand(const SessionItem* item, SessionItem* parent, TagRow tagrow)
@@ -52,7 +51,6 @@ void CopyItemCommand::undo_command()
     auto parent = itemFromPath(p_impl->item_path);
     delete parent->takeItem(p_impl->tagrow);
     setCommandResult(nullptr);
-    p_impl->result = nullptr;
 }
 
 void CopyItemCommand::execute_command()
@@ -61,18 +59,11 @@ void CopyItemCommand::execute_command()
     auto item = p_impl->backup_strategy->restoreItem();
     if (parent->insertItem(item.get(), p_impl->tagrow)) {
         auto result = item.release();
-        p_impl->result = result;
         setCommandResult(result);
     } else {
         setCommandResult(nullptr);
-        p_impl->result = nullptr;
         setObsolete(true);
     }
-}
-
-CopyItemCommand::result_t CopyItemCommand::result() const
-{
-    return p_impl->result;
 }
 
 namespace

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.h
@@ -23,12 +23,8 @@ class TagRow;
 class MVVM_MODEL_EXPORT CopyItemCommand : public AbstractItemCommand
 {
 public:
-    using result_t = SessionItem*;
-
     CopyItemCommand(const SessionItem* item, SessionItem* parent, TagRow tagrow);
     ~CopyItemCommand() override;
-
-    result_t result() const;
 
 private:
     void undo_command() override;

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -34,6 +34,7 @@ InsertNewItemCommand::InsertNewItemCommand(item_factory_func_t func, SessionItem
                                            const TagRow& tagrow)
     : AbstractItemCommand(parent), p_impl(std::make_unique<InsertNewItemCommandImpl>(func, tagrow))
 {
+    setCommandResult(nullptr);
     p_impl->item_path = pathFromItem(parent);
 }
 
@@ -44,6 +45,7 @@ void InsertNewItemCommand::undo_command()
     auto parent = itemFromPath(p_impl->item_path);
     delete parent->takeItem(p_impl->tagrow);
     p_impl->result = nullptr;
+    setCommandResult(nullptr);
 }
 
 void InsertNewItemCommand::execute_command()
@@ -53,6 +55,7 @@ void InsertNewItemCommand::execute_command()
     setDescription(generate_description(child->modelType(), p_impl->tagrow));
     if (parent->insertItem(child, p_impl->tagrow)) {
         p_impl->result = child;
+        setCommandResult(child);
     } else {
         delete child;
         setObsolete(true);

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -22,10 +22,9 @@ std::string generate_description(const std::string& modelType, const TagRow& tag
 struct InsertNewItemCommand::InsertNewItemCommandImpl {
     item_factory_func_t factory_func;
     TagRow tagrow;
-    result_t result;
     Path item_path;
     InsertNewItemCommandImpl(item_factory_func_t func, TagRow tagrow)
-        : factory_func(std::move(func)), tagrow(std::move(tagrow)), result(nullptr)
+        : factory_func(std::move(func)), tagrow(std::move(tagrow))
     {
     }
 };
@@ -44,7 +43,6 @@ void InsertNewItemCommand::undo_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
     delete parent->takeItem(p_impl->tagrow);
-    p_impl->result = nullptr;
     setCommandResult(nullptr);
 }
 
@@ -54,17 +52,11 @@ void InsertNewItemCommand::execute_command()
     auto child = p_impl->factory_func().release();
     setDescription(generate_description(child->modelType(), p_impl->tagrow));
     if (parent->insertItem(child, p_impl->tagrow)) {
-        p_impl->result = child;
         setCommandResult(child);
     } else {
         delete child;
         setObsolete(true);
     }
-}
-
-InsertNewItemCommand::result_t InsertNewItemCommand::result() const
-{
-    return p_impl->result;
 }
 
 namespace
@@ -76,3 +68,4 @@ std::string generate_description(const std::string& modelType, const TagRow& tag
     return ostr.str();
 }
 } // namespace
+

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -33,7 +33,7 @@ InsertNewItemCommand::InsertNewItemCommand(item_factory_func_t func, SessionItem
                                            const TagRow& tagrow)
     : AbstractItemCommand(parent), p_impl(std::make_unique<InsertNewItemCommandImpl>(func, tagrow))
 {
-    setCommandResult(nullptr);
+    setResult(nullptr);
     p_impl->item_path = pathFromItem(parent);
 }
 
@@ -43,7 +43,7 @@ void InsertNewItemCommand::undo_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
     delete parent->takeItem(p_impl->tagrow);
-    setCommandResult(nullptr);
+    setResult(nullptr);
 }
 
 void InsertNewItemCommand::execute_command()
@@ -52,7 +52,7 @@ void InsertNewItemCommand::execute_command()
     auto child = p_impl->factory_func().release();
     setDescription(generate_description(child->modelType(), p_impl->tagrow));
     if (parent->insertItem(child, p_impl->tagrow)) {
-        setCommandResult(child);
+        setResult(child);
     } else {
         delete child;
         setObsolete(true);

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.h
@@ -24,12 +24,8 @@ class TagRow;
 class MVVM_MODEL_EXPORT InsertNewItemCommand : public AbstractItemCommand
 {
 public:
-    using result_t = SessionItem*;
-
     InsertNewItemCommand(item_factory_func_t func, SessionItem* parent, const TagRow& tagrow);
     ~InsertNewItemCommand() override;
-
-    result_t result() const;
 
 private:
     void undo_command() override;

--- a/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
@@ -26,8 +26,7 @@ struct MoveItemCommand::MoveItemCommandImpl {
     Path target_parent_path;
     Path original_parent_path;
     TagRow original_tagrow;
-    result_t result;
-    MoveItemCommandImpl(TagRow tagrow) : target_tagrow(std::move(tagrow)), result(true)
+    MoveItemCommandImpl(TagRow tagrow) : target_tagrow(std::move(tagrow))
     {
         if (target_tagrow.row < 0)
             throw std::runtime_error("MoveItemCommand() -> Error. Uninitialized target row");
@@ -95,11 +94,6 @@ void MoveItemCommand::execute_command()
     // adjusting new addresses
     p_impl->target_parent_path = pathFromItem(target_parent);
     p_impl->original_parent_path = pathFromItem(original_parent);
-}
-
-MoveItemCommand::result_t MoveItemCommand::result() const
-{
-    return p_impl->result;
 }
 
 namespace

--- a/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
@@ -37,6 +37,8 @@ struct MoveItemCommand::MoveItemCommandImpl {
 MoveItemCommand::MoveItemCommand(SessionItem* item, SessionItem* new_parent, TagRow tagrow)
     : AbstractItemCommand(new_parent), p_impl(std::make_unique<MoveItemCommandImpl>(tagrow))
 {
+    setCommandResult(true);
+
     check_input_data(item, new_parent);
     setDescription(generate_description(p_impl->target_tagrow));
 

--- a/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
@@ -36,7 +36,7 @@ struct MoveItemCommand::MoveItemCommandImpl {
 MoveItemCommand::MoveItemCommand(SessionItem* item, SessionItem* new_parent, TagRow tagrow)
     : AbstractItemCommand(new_parent), p_impl(std::make_unique<MoveItemCommandImpl>(tagrow))
 {
-    setCommandResult(true);
+    setResult(true);
 
     check_input_data(item, new_parent);
     setDescription(generate_description(p_impl->target_tagrow));

--- a/source/libmvvm_model/mvvm/commands/moveitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/moveitemcommand.h
@@ -24,12 +24,8 @@ class TagRow;
 class MVVM_MODEL_EXPORT MoveItemCommand : public AbstractItemCommand
 {
 public:
-    using result_t = bool;
-
     MoveItemCommand(SessionItem* item, SessionItem* new_parent, TagRow tagrow);
     ~MoveItemCommand() override;
-
-    result_t result() const;
 
 private:
     void undo_command() override;

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
@@ -31,7 +31,7 @@ RemoveItemCommand::RemoveItemCommand(SessionItem* parent, TagRow tagrow)
     : AbstractItemCommand(parent)
     , p_impl(std::make_unique<RemoveItemCommandImpl>(std::move(tagrow)))
 {
-    setCommandResult(false);
+    setResult(false);
 
     setDescription(generate_description(p_impl->tagrow));
     p_impl->backup_strategy = parent->model()->itemBackupStrategy();
@@ -53,9 +53,9 @@ void RemoveItemCommand::execute_command()
     if (auto child = parent->takeItem(p_impl->tagrow); child) {
         p_impl->backup_strategy->saveItem(child);
         delete child;
-        setCommandResult(true);
+        setResult(true);
     } else {
-        setCommandResult(false);
+        setResult(false);
         setObsolete(true);
     }
 }

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
@@ -32,6 +32,8 @@ RemoveItemCommand::RemoveItemCommand(SessionItem* parent, TagRow tagrow)
     : AbstractItemCommand(parent)
     , p_impl(std::make_unique<RemoveItemCommandImpl>(std::move(tagrow)))
 {
+    setCommandResult(false);
+
     setDescription(generate_description(p_impl->tagrow));
     p_impl->backup_strategy = parent->model()->itemBackupStrategy();
     p_impl->item_path = pathFromItem(parent);
@@ -53,8 +55,10 @@ void RemoveItemCommand::execute_command()
         p_impl->backup_strategy->saveItem(child);
         delete child;
         p_impl->result = true;
+        setCommandResult(true);
     } else {
         p_impl->result = false;
+        setCommandResult(false);
         setObsolete(true);
     }
 }

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
@@ -22,10 +22,9 @@ std::string generate_description(const TagRow& tagrow);
 
 struct RemoveItemCommand::RemoveItemCommandImpl {
     TagRow tagrow;
-    result_t result;
     std::unique_ptr<ItemBackupStrategy> backup_strategy;
     Path item_path;
-    RemoveItemCommandImpl(TagRow tagrow) : tagrow(std::move(tagrow)), result(false) {}
+    RemoveItemCommandImpl(TagRow tagrow) : tagrow(std::move(tagrow)) {}
 };
 
 RemoveItemCommand::RemoveItemCommand(SessionItem* parent, TagRow tagrow)
@@ -54,18 +53,11 @@ void RemoveItemCommand::execute_command()
     if (auto child = parent->takeItem(p_impl->tagrow); child) {
         p_impl->backup_strategy->saveItem(child);
         delete child;
-        p_impl->result = true;
         setCommandResult(true);
     } else {
-        p_impl->result = false;
         setCommandResult(false);
         setObsolete(true);
     }
-}
-
-RemoveItemCommand::result_t RemoveItemCommand::result() const
-{
-    return p_impl->result;
 }
 
 namespace

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.h
@@ -23,12 +23,8 @@ class TagRow;
 class MVVM_MODEL_EXPORT RemoveItemCommand : public AbstractItemCommand
 {
 public:
-    using result_t = bool;
-
     RemoveItemCommand(SessionItem* parent, TagRow tagrow);
     ~RemoveItemCommand() override;
-
-    result_t result() const;
 
 private:
     void undo_command() override;

--- a/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
@@ -23,12 +23,8 @@ using namespace ModelView;
 struct SetValueCommand::SetValueCommandImpl {
     Variant m_value; //! Value to set as a result of command execution.
     int m_role;
-    result_t m_result;
     Path m_item_path;
-    SetValueCommandImpl(Variant value, int role)
-        : m_value(std::move(value)), m_role(role), m_result(false)
-    {
-    }
+    SetValueCommandImpl(Variant value, int role) : m_value(std::move(value)), m_role(role) {}
 };
 
 // ----------------------------------------------------------------------------
@@ -60,18 +56,9 @@ void SetValueCommand::swap_values()
     auto item = itemFromPath(p_impl->m_item_path);
     auto old = item->data<Variant>(p_impl->m_role);
     auto result = item->setDataIntern(p_impl->m_value, p_impl->m_role);
-    p_impl->m_result = result;
     setCommandResult(result);
     setObsolete(!result);
     p_impl->m_value = old;
-}
-
-//! Returns result of the command, which is bool value denoting that the value was set succesfully.
-//! The value 'false' means that the data is the same and no change was required.
-
-SetValueCommand::result_t SetValueCommand::result() const
-{
-    return p_impl->m_result;
 }
 
 namespace

--- a/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
@@ -37,6 +37,8 @@ SetValueCommand::SetValueCommand(SessionItem* item, Variant value, int role)
     : AbstractItemCommand(item)
     , p_impl(std::make_unique<SetValueCommandImpl>(std::move(value), role))
 {
+    setCommandResult(false);
+
     setDescription(generate_description(p_impl->m_value.toString().toStdString()));
     p_impl->m_item_path = pathFromItem(item);
 }
@@ -57,8 +59,10 @@ void SetValueCommand::swap_values()
 {
     auto item = itemFromPath(p_impl->m_item_path);
     auto old = item->data<Variant>(p_impl->m_role);
-    p_impl->m_result = item->setDataIntern(p_impl->m_value, p_impl->m_role);
-    setObsolete(!p_impl->m_result);
+    auto result = item->setDataIntern(p_impl->m_value, p_impl->m_role);
+    p_impl->m_result = result;
+    setCommandResult(result);
+    setObsolete(!result);
     p_impl->m_value = old;
 }
 

--- a/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/setvaluecommand.cpp
@@ -33,7 +33,7 @@ SetValueCommand::SetValueCommand(SessionItem* item, Variant value, int role)
     : AbstractItemCommand(item)
     , p_impl(std::make_unique<SetValueCommandImpl>(std::move(value), role))
 {
-    setCommandResult(false);
+    setResult(false);
 
     setDescription(generate_description(p_impl->m_value.toString().toStdString()));
     p_impl->m_item_path = pathFromItem(item);
@@ -56,7 +56,7 @@ void SetValueCommand::swap_values()
     auto item = itemFromPath(p_impl->m_item_path);
     auto old = item->data<Variant>(p_impl->m_role);
     auto result = item->setDataIntern(p_impl->m_value, p_impl->m_role);
-    setCommandResult(result);
+    setResult(result);
     setObsolete(!result);
     p_impl->m_value = old;
 }

--- a/source/libmvvm_model/mvvm/commands/setvaluecommand.h
+++ b/source/libmvvm_model/mvvm/commands/setvaluecommand.h
@@ -23,11 +23,8 @@ class SessionItem;
 class MVVM_MODEL_EXPORT SetValueCommand : public AbstractItemCommand
 {
 public:
-    using result_t = bool;
     SetValueCommand(SessionItem* item, Variant value, int role);
     ~SetValueCommand() override;
-
-    result_t result() const;
 
 private:
     void undo_command() override;

--- a/source/libmvvm_model/mvvm/commands/undostack.cpp
+++ b/source/libmvvm_model/mvvm/commands/undostack.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include <QUndoStack>
+#include <mvvm/commands/commandadapter.h>
 #include <mvvm/commands/undostack.h>
 
 using namespace ModelView;
@@ -15,68 +16,76 @@ using namespace ModelView;
 struct UndoStack::UndoStackImpl {
     std::unique_ptr<QUndoStack> m_undoStack;
     UndoStackImpl() : m_undoStack(std::make_unique<QUndoStack>()) {}
-    QUndoStack* stack() { return m_undoStack.get(); }
+    QUndoStack* undoStack() { return m_undoStack.get(); }
 };
 
 UndoStack::UndoStack() : p_impl(std::make_unique<UndoStackImpl>()) {}
+
+void UndoStack::execute(std::shared_ptr<AbstractItemCommand> command)
+{
+    // Wrapping command for Qt. It will be executed by Qt after push.
+    p_impl->undoStack()->push(new CommandAdapter(command));
+}
 
 UndoStack::~UndoStack() = default;
 
 void UndoStack::push(QUndoCommand* cmd)
 {
-    p_impl->stack()->push(cmd);
+    p_impl->undoStack()->push(cmd);
 }
 
 bool UndoStack::isActive() const
 {
-    return p_impl->stack()->isActive();
+    return p_impl->undoStack()->isActive();
 }
 
 bool UndoStack::canUndo() const
 {
-    return p_impl->stack()->canUndo();
+    return p_impl->undoStack()->canUndo();
 }
 
 bool UndoStack::canRedo() const
 {
-    return p_impl->stack()->canRedo();
+    return p_impl->undoStack()->canRedo();
 }
 
 int UndoStack::index() const
 {
-    return p_impl->stack()->index();
+    return p_impl->undoStack()->index();
 }
 
 int UndoStack::count() const
 {
-    return p_impl->stack()->count();
+    return p_impl->undoStack()->count();
 }
 
 void UndoStack::undo()
 {
-    return p_impl->stack()->undo();
+    return p_impl->undoStack()->undo();
 }
 
 void UndoStack::redo()
 {
-    return p_impl->stack()->redo();
+    return p_impl->undoStack()->redo();
 }
 
 void UndoStack::clear()
 {
-    return p_impl->stack()->clear();
+    return p_impl->undoStack()->clear();
 }
 
 void UndoStack::setUndoLimit(int limit)
 {
-    return p_impl->stack()->setUndoLimit(limit);
+    return p_impl->undoStack()->setUndoLimit(limit);
 }
 
 //! Returns underlying QUndoStack if given object can be casted to UndoStack instance.
+//! This method is used to "convert" current instance to Qt implementation, and use it with other
+//! Qt widgets, if necessary.
 
 QUndoStack* UndoStack::qtUndoStack(UndoStackInterface* stack_interface)
 {
     if (auto stack = dynamic_cast<UndoStack*>(stack_interface); stack)
-        return stack->p_impl->stack();
+        return stack->p_impl->undoStack();
     return nullptr;
 }

--- a/source/libmvvm_model/mvvm/commands/undostack.cpp
+++ b/source/libmvvm_model/mvvm/commands/undostack.cpp
@@ -29,11 +29,6 @@ void UndoStack::execute(std::shared_ptr<AbstractItemCommand> command)
 
 UndoStack::~UndoStack() = default;
 
-void UndoStack::push(QUndoCommand* cmd)
-{
-    p_impl->undoStack()->push(cmd);
-}
-
 bool UndoStack::isActive() const
 {
     return p_impl->undoStack()->isActive();

--- a/source/libmvvm_model/mvvm/commands/undostack.cpp
+++ b/source/libmvvm_model/mvvm/commands/undostack.cpp
@@ -84,3 +84,13 @@ QUndoStack* UndoStack::qtUndoStack(UndoStackInterface* stack_interface)
         return stack->p_impl->undoStack();
     return nullptr;
 }
+
+void UndoStack::beginMacro(const std::string& name)
+{
+    p_impl->undoStack()->beginMacro(QString::fromStdString(name));
+}
+
+void UndoStack::endMacro()
+{
+    p_impl->undoStack()->endMacro();
+}

--- a/source/libmvvm_model/mvvm/commands/undostack.h
+++ b/source/libmvvm_model/mvvm/commands/undostack.h
@@ -44,6 +44,9 @@ public:
 
     static QUndoStack* qtUndoStack(UndoStackInterface* stack_interface);
 
+    void beginMacro(const std::string& name);
+    void endMacro();
+
 private:
     struct UndoStackImpl;
     std::unique_ptr<UndoStackImpl> p_impl;

--- a/source/libmvvm_model/mvvm/commands/undostack.h
+++ b/source/libmvvm_model/mvvm/commands/undostack.h
@@ -14,6 +14,8 @@
 #include <mvvm/interfaces/undostackinterface.h>
 #include <mvvm/model_export.h>
 
+class QUndoStack;
+
 namespace ModelView
 {
 
@@ -26,6 +28,9 @@ class MVVM_MODEL_EXPORT UndoStack : public UndoStackInterface
 public:
     UndoStack();
     ~UndoStack() override;
+
+    //! Executes the command, then pushes it in the stack for possible undo.
+    void execute(std::shared_ptr<AbstractItemCommand> command) override;
 
     void push(QUndoCommand* cmd) override;
     bool isActive() const override;

--- a/source/libmvvm_model/mvvm/commands/undostack.h
+++ b/source/libmvvm_model/mvvm/commands/undostack.h
@@ -32,7 +32,6 @@ public:
     //! Executes the command, then pushes it in the stack for possible undo.
     void execute(std::shared_ptr<AbstractItemCommand> command) override;
 
-    void push(QUndoCommand* cmd) override;
     bool isActive() const override;
     bool canUndo() const override;
     bool canRedo() const override;

--- a/source/libmvvm_model/mvvm/interfaces/undostackinterface.h
+++ b/source/libmvvm_model/mvvm/interfaces/undostackinterface.h
@@ -33,8 +33,6 @@ public:
     //! c) to bypass QUndoStack behavior which wants to have an ownership
     virtual void execute(std::shared_ptr<AbstractItemCommand> command) = 0;
 
-    virtual void push(QUndoCommand* cmd) = 0;
-
     virtual bool isActive() const = 0;
     virtual bool canUndo() const = 0;
     virtual bool canRedo() const = 0;

--- a/source/libmvvm_model/mvvm/interfaces/undostackinterface.h
+++ b/source/libmvvm_model/mvvm/interfaces/undostackinterface.h
@@ -10,10 +10,14 @@
 #ifndef MVVM_INTERFACES_UNDDOSTACKINTERFACE_H
 #define MVVM_INTERFACES_UNDDOSTACKINTERFACE_H
 
+#include <memory>
+
 class QUndoCommand;
 
 namespace ModelView
 {
+
+class AbstractItemCommand;
 
 //! Interface class for undo/redo stack.
 
@@ -21,7 +25,16 @@ class UndoStackInterface
 {
 public:
     virtual ~UndoStackInterface() = default;
+
+    //! Executes the command, then pushes it in the stack for possible undo.
+    //! Current design relies on shared pointer. This is done
+    //! a) to retrieve result of the command from another place
+    //! b) to adapt the command for QUndoStack
+    //! c) to bypass QUndoStack behavior which wants to have an ownership
+    virtual void execute(std::shared_ptr<AbstractItemCommand> command) = 0;
+
     virtual void push(QUndoCommand* cmd) = 0;
+
     virtual bool isActive() const = 0;
     virtual bool canUndo() const = 0;
     virtual bool canRedo() const = 0;

--- a/source/libmvvm_model/mvvm/interfaces/undostackinterface.h
+++ b/source/libmvvm_model/mvvm/interfaces/undostackinterface.h
@@ -11,6 +11,7 @@
 #define MVVM_INTERFACES_UNDDOSTACKINTERFACE_H
 
 #include <memory>
+#include <string>
 
 class QUndoCommand;
 
@@ -42,6 +43,9 @@ public:
     virtual void redo() = 0;
     virtual void clear() = 0;
     virtual void setUndoLimit(int limit) = 0;
+
+    virtual void beginMacro(const std::string& name) = 0;
+    virtual void endMacro() = 0;
 };
 
 } // namespace ModelView

--- a/tests/testmodel/copyitemcommand.test.cpp
+++ b/tests/testmodel/copyitemcommand.test.cpp
@@ -44,7 +44,7 @@ TEST_F(CopyItemCommandTest, copyChild)
     command->execute();
 
     // checking that parent has now three children
-    auto copy = std::get<SessionItem*>(command->commandResult());
+    auto copy = std::get<SessionItem*>(command->result());
     EXPECT_FALSE(command->isObsolete());
     EXPECT_TRUE(copy != nullptr);
     EXPECT_EQ(parent->childrenCount(), 3);
@@ -79,7 +79,7 @@ TEST_F(CopyItemCommandTest, invalidCopyAttempt)
 
     // checking that parent has now three children
     EXPECT_TRUE(command->isObsolete());
-    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), nullptr);
+    EXPECT_EQ(std::get<SessionItem*>(command->result()), nullptr);
 
     // undoing of obsolete command is not possible
     EXPECT_THROW(command->undo(), std::runtime_error);

--- a/tests/testmodel/copyitemcommand.test.cpp
+++ b/tests/testmodel/copyitemcommand.test.cpp
@@ -44,7 +44,7 @@ TEST_F(CopyItemCommandTest, copyChild)
     command->execute();
 
     // checking that parent has now three children
-    auto copy = command->result();
+    auto copy = std::get<SessionItem*>(command->commandResult());
     EXPECT_FALSE(command->isObsolete());
     EXPECT_TRUE(copy != nullptr);
     EXPECT_EQ(parent->childrenCount(), 3);
@@ -79,7 +79,7 @@ TEST_F(CopyItemCommandTest, invalidCopyAttempt)
 
     // checking that parent has now three children
     EXPECT_TRUE(command->isObsolete());
-    EXPECT_EQ(command->result(), nullptr);
+    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), nullptr);
 
     // undoing of obsolete command is not possible
     EXPECT_THROW(command->undo(), std::runtime_error);

--- a/tests/testmodel/insertnewitemcommand.test.cpp
+++ b/tests/testmodel/insertnewitemcommand.test.cpp
@@ -47,19 +47,19 @@ TEST_F(InsertNewItemCommandTest, insertNewItemCommand)
     // executing command
     command->execute();
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);
-    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), model.rootItem()->getItem("", 0));
+    EXPECT_EQ(std::get<SessionItem*>(command->result()), model.rootItem()->getItem("", 0));
     EXPECT_EQ(command->isObsolete(), false);
 
     // undoing command
     command->undo();
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);
-    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), nullptr);
+    EXPECT_EQ(std::get<SessionItem*>(command->result()), nullptr);
     EXPECT_EQ(command->isObsolete(), false);
 
     // executing again
     command->execute();
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);
-    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), model.rootItem()->getItem("", 0));
+    EXPECT_EQ(std::get<SessionItem*>(command->result()), model.rootItem()->getItem("", 0));
     EXPECT_EQ(command->isObsolete(), false);
 }
 
@@ -74,7 +74,7 @@ TEST_F(InsertNewItemCommandTest, insertNewItemWithTagCommand)
     command1->execute(); // insertion
     EXPECT_EQ(command1->isObsolete(), false);
 
-    auto parent = std::get<SessionItem*>(command1->commandResult());
+    auto parent = std::get<SessionItem*>(command1->result());
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
     EXPECT_EQ(parent->childrenCount(), 0);
 
@@ -84,12 +84,12 @@ TEST_F(InsertNewItemCommandTest, insertNewItemWithTagCommand)
     EXPECT_EQ(command2->isObsolete(), false);
 
     EXPECT_EQ(parent->childrenCount(), 1);
-    EXPECT_EQ(Utils::ChildAt(parent, 0), std::get<SessionItem*>(command2->commandResult()));
+    EXPECT_EQ(Utils::ChildAt(parent, 0), std::get<SessionItem*>(command2->result()));
 
     // undoing command
     command2->undo();
     EXPECT_EQ(parent->childrenCount(), 0);
-    EXPECT_EQ(nullptr, std::get<SessionItem*>(command2->commandResult()));
+    EXPECT_EQ(nullptr, std::get<SessionItem*>(command2->result()));
     EXPECT_EQ(command2->isObsolete(), false);
 }
 
@@ -138,13 +138,13 @@ TEST_F(InsertNewItemCommandTest, attemptInsertSecondProperty)
     InsertNewItemCommand command1(factory_func, parent, TagRow{"radius", -1});
     EXPECT_NO_THROW(command1.execute());
     EXPECT_FALSE(command1.isObsolete());
-    EXPECT_EQ(std::get<SessionItem*>(command1.commandResult()), parent->getItem("radius"));
+    EXPECT_EQ(std::get<SessionItem*>(command1.result()), parent->getItem("radius"));
 
     // adding second property to the same tag is not possible. Command should be in obsolete state
     InsertNewItemCommand command2(factory_func, parent, TagRow{"radius", -1});
     EXPECT_NO_THROW(command2.execute());
     EXPECT_TRUE(command2.isObsolete());
-    EXPECT_EQ(std::get<SessionItem*>(command2.commandResult()), nullptr);
+    EXPECT_EQ(std::get<SessionItem*>(command2.result()), nullptr);
 
     // undoing failed command shouldn't be possible
     EXPECT_THROW(command2.undo(), std::runtime_error);

--- a/tests/testmodel/insertnewitemcommand.test.cpp
+++ b/tests/testmodel/insertnewitemcommand.test.cpp
@@ -47,19 +47,19 @@ TEST_F(InsertNewItemCommandTest, insertNewItemCommand)
     // executing command
     command->execute();
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);
-    EXPECT_EQ(command->result(), model.rootItem()->getItem("", 0));
+    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), model.rootItem()->getItem("", 0));
     EXPECT_EQ(command->isObsolete(), false);
 
     // undoing command
     command->undo();
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);
-    EXPECT_EQ(command->result(), nullptr);
+    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), nullptr);
     EXPECT_EQ(command->isObsolete(), false);
 
     // executing again
     command->execute();
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);
-    EXPECT_EQ(command->result(), model.rootItem()->getItem("", 0));
+    EXPECT_EQ(std::get<SessionItem*>(command->commandResult()), model.rootItem()->getItem("", 0));
     EXPECT_EQ(command->isObsolete(), false);
 }
 
@@ -74,7 +74,7 @@ TEST_F(InsertNewItemCommandTest, insertNewItemWithTagCommand)
     command1->execute(); // insertion
     EXPECT_EQ(command1->isObsolete(), false);
 
-    auto parent = command1->result();
+    auto parent = std::get<SessionItem*>(command1->commandResult());
     parent->registerTag(TagInfo::universalTag("tag1"), /*set_as_default*/ true);
     EXPECT_EQ(parent->childrenCount(), 0);
 
@@ -84,12 +84,12 @@ TEST_F(InsertNewItemCommandTest, insertNewItemWithTagCommand)
     EXPECT_EQ(command2->isObsolete(), false);
 
     EXPECT_EQ(parent->childrenCount(), 1);
-    EXPECT_EQ(Utils::ChildAt(parent, 0), command2->result());
+    EXPECT_EQ(Utils::ChildAt(parent, 0), std::get<SessionItem*>(command2->commandResult()));
 
     // undoing command
     command2->undo();
     EXPECT_EQ(parent->childrenCount(), 0);
-    EXPECT_EQ(nullptr, command2->result());
+    EXPECT_EQ(nullptr, std::get<SessionItem*>(command2->commandResult()));
     EXPECT_EQ(command2->isObsolete(), false);
 }
 
@@ -138,13 +138,13 @@ TEST_F(InsertNewItemCommandTest, attemptInsertSecondProperty)
     InsertNewItemCommand command1(factory_func, parent, TagRow{"radius", -1});
     EXPECT_NO_THROW(command1.execute());
     EXPECT_FALSE(command1.isObsolete());
-    EXPECT_EQ(command1.result(), parent->getItem("radius"));
+    EXPECT_EQ(std::get<SessionItem*>(command1.commandResult()), parent->getItem("radius"));
 
     // adding second property to the same tag is not possible. Command should be in obsolete state
     InsertNewItemCommand command2(factory_func, parent, TagRow{"radius", -1});
     EXPECT_NO_THROW(command2.execute());
     EXPECT_TRUE(command2.isObsolete());
-    EXPECT_EQ(command2.result(), nullptr);
+    EXPECT_EQ(std::get<SessionItem*>(command2.commandResult()), nullptr);
 
     // undoing failed command shouldn't be possible
     EXPECT_THROW(command2.undo(), std::runtime_error);

--- a/tests/testmodel/moveitemcommand.test.cpp
+++ b/tests/testmodel/moveitemcommand.test.cpp
@@ -39,7 +39,7 @@ TEST_F(MoveItemCommandTest, rootContextNext)
     // moving item1 to the next position
     MoveItemCommand command(item1, model.rootItem(), {"", 2});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
 
     // expecting new order of items
     expected = {item0, item2, item1, item3};
@@ -47,13 +47,13 @@ TEST_F(MoveItemCommandTest, rootContextNext)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     expected = {item0, item1, item2, item3};
     EXPECT_EQ(model.rootItem()->children(), expected);
 
     // redoing
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item2, item1, item3};
@@ -75,7 +75,7 @@ TEST_F(MoveItemCommandTest, rootContextSamePos)
     // moving item1 to the same position
     MoveItemCommand command(item1, model.rootItem(), {"", 1});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -84,7 +84,7 @@ TEST_F(MoveItemCommandTest, rootContextSamePos)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -106,7 +106,7 @@ TEST_F(MoveItemCommandTest, rootContextPrev)
     // moving item2 to item1's place
     MoveItemCommand command(item2, model.rootItem(), {"", 1});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -115,7 +115,7 @@ TEST_F(MoveItemCommandTest, rootContextPrev)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -137,7 +137,7 @@ TEST_F(MoveItemCommandTest, rootContextLast)
     // moving item0 in the back of the list
     MoveItemCommand command(item0, model.rootItem(), {"", model.rootItem()->childrenCount() - 1});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -146,7 +146,7 @@ TEST_F(MoveItemCommandTest, rootContextLast)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -168,7 +168,7 @@ TEST_F(MoveItemCommandTest, rootContextLast2)
     // moving item0 in the back of the list
     MoveItemCommand command(item0, model.rootItem(), {"", 3});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -177,7 +177,7 @@ TEST_F(MoveItemCommandTest, rootContextLast2)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -205,7 +205,7 @@ TEST_F(MoveItemCommandTest, fromRootToParent)
     // moving item0 from root to parent
     MoveItemCommand command(item0, parent, {"", 1});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -218,7 +218,7 @@ TEST_F(MoveItemCommandTest, fromRootToParent)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -251,7 +251,7 @@ TEST_F(MoveItemCommandTest, fromParentToRoot)
     // moving child0 from parent to root
     MoveItemCommand command(child0, model.rootItem(), {"", 0});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -264,7 +264,7 @@ TEST_F(MoveItemCommandTest, fromParentToRoot)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -299,7 +299,7 @@ TEST_F(MoveItemCommandTest, betweenParentTags)
     // moving child2 to another tag
     MoveItemCommand command(child2, parent, {"tag1", 0});
     command.execute();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -316,7 +316,7 @@ TEST_F(MoveItemCommandTest, betweenParentTags)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command.result()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item

--- a/tests/testmodel/moveitemcommand.test.cpp
+++ b/tests/testmodel/moveitemcommand.test.cpp
@@ -39,7 +39,7 @@ TEST_F(MoveItemCommandTest, rootContextNext)
     // moving item1 to the next position
     MoveItemCommand command(item1, model.rootItem(), {"", 2});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
 
     // expecting new order of items
     expected = {item0, item2, item1, item3};
@@ -47,13 +47,13 @@ TEST_F(MoveItemCommandTest, rootContextNext)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     expected = {item0, item1, item2, item3};
     EXPECT_EQ(model.rootItem()->children(), expected);
 
     // redoing
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item2, item1, item3};
@@ -75,7 +75,7 @@ TEST_F(MoveItemCommandTest, rootContextSamePos)
     // moving item1 to the same position
     MoveItemCommand command(item1, model.rootItem(), {"", 1});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -84,7 +84,7 @@ TEST_F(MoveItemCommandTest, rootContextSamePos)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -106,7 +106,7 @@ TEST_F(MoveItemCommandTest, rootContextPrev)
     // moving item2 to item1's place
     MoveItemCommand command(item2, model.rootItem(), {"", 1});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -115,7 +115,7 @@ TEST_F(MoveItemCommandTest, rootContextPrev)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -137,7 +137,7 @@ TEST_F(MoveItemCommandTest, rootContextLast)
     // moving item0 in the back of the list
     MoveItemCommand command(item0, model.rootItem(), {"", model.rootItem()->childrenCount() - 1});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -146,7 +146,7 @@ TEST_F(MoveItemCommandTest, rootContextLast)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -168,7 +168,7 @@ TEST_F(MoveItemCommandTest, rootContextLast2)
     // moving item0 in the back of the list
     MoveItemCommand command(item0, model.rootItem(), {"", 3});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expecting new order of items
@@ -177,7 +177,7 @@ TEST_F(MoveItemCommandTest, rootContextLast2)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     expected = {item0, item1, item2, item3};
@@ -205,7 +205,7 @@ TEST_F(MoveItemCommandTest, fromRootToParent)
     // moving item0 from root to parent
     MoveItemCommand command(item0, parent, {"", 1});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -218,7 +218,7 @@ TEST_F(MoveItemCommandTest, fromRootToParent)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -251,7 +251,7 @@ TEST_F(MoveItemCommandTest, fromParentToRoot)
     // moving child0 from parent to root
     MoveItemCommand command(child0, model.rootItem(), {"", 0});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -264,7 +264,7 @@ TEST_F(MoveItemCommandTest, fromParentToRoot)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -299,7 +299,7 @@ TEST_F(MoveItemCommandTest, betweenParentTags)
     // moving child2 to another tag
     MoveItemCommand command(child2, parent, {"tag1", 0});
     command.execute();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item
@@ -316,7 +316,7 @@ TEST_F(MoveItemCommandTest, betweenParentTags)
 
     // undoing command
     command.undo();
-    EXPECT_EQ(command.result(), true);
+    EXPECT_EQ(std::get<bool>(command.commandResult()), true);
     EXPECT_EQ(command.isObsolete(), false);
 
     // expected items for root item

--- a/tests/testmodel/removeitemcommand.test.cpp
+++ b/tests/testmodel/removeitemcommand.test.cpp
@@ -36,7 +36,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommand)
     auto command = std::make_unique<RemoveItemCommand>(model.rootItem(), TagRow{"", 0});
     command->execute(); // removal
 
-    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command->result()), true);
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);
     EXPECT_FALSE(command->isObsolete());
 
@@ -66,7 +66,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandChild)
 
     // check that one child was removed
     EXPECT_FALSE(command->isObsolete());
-    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command->result()), true);
     EXPECT_EQ(parent->childrenCount(), 1);
 
     // undo command
@@ -98,7 +98,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandParentWithChild)
     EXPECT_FALSE(command->isObsolete());
 
     // check that one child was removed
-    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command->result()), true);
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);
 
     // undo command
@@ -144,7 +144,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandMultitag)
 
     // check that one child was removed
     EXPECT_FALSE(command->isObsolete());
-    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
+    EXPECT_EQ(std::get<bool>(command->result()), true);
     EXPECT_EQ(parent->childrenCount(), 2);
 
     // undo command
@@ -173,5 +173,5 @@ TEST_F(RemoveItemCommandTest, attemptToRemoveItem)
     command->execute();
 
     EXPECT_TRUE(command->isObsolete());
-    EXPECT_EQ(std::get<bool>(command->commandResult()), false);
+    EXPECT_EQ(std::get<bool>(command->result()), false);
 }

--- a/tests/testmodel/removeitemcommand.test.cpp
+++ b/tests/testmodel/removeitemcommand.test.cpp
@@ -36,7 +36,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommand)
     auto command = std::make_unique<RemoveItemCommand>(model.rootItem(), TagRow{"", 0});
     command->execute(); // removal
 
-    EXPECT_EQ(command->result(), true);
+    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);
     EXPECT_FALSE(command->isObsolete());
 
@@ -66,7 +66,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandChild)
 
     // check that one child was removed
     EXPECT_FALSE(command->isObsolete());
-    EXPECT_EQ(command->result(), true);
+    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
     EXPECT_EQ(parent->childrenCount(), 1);
 
     // undo command
@@ -98,7 +98,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandParentWithChild)
     EXPECT_FALSE(command->isObsolete());
 
     // check that one child was removed
-    EXPECT_EQ(command->result(), true);
+    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
     EXPECT_EQ(model.rootItem()->childrenCount(), 0);
 
     // undo command
@@ -144,7 +144,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandMultitag)
 
     // check that one child was removed
     EXPECT_FALSE(command->isObsolete());
-    EXPECT_EQ(command->result(), true);
+    EXPECT_EQ(std::get<bool>(command->commandResult()), true);
     EXPECT_EQ(parent->childrenCount(), 2);
 
     // undo command
@@ -173,5 +173,5 @@ TEST_F(RemoveItemCommandTest, attemptToRemoveItem)
     command->execute();
 
     EXPECT_TRUE(command->isObsolete());
-    EXPECT_EQ(command->result(), false);
+    EXPECT_EQ(std::get<bool>(command->commandResult()), false);
 }

--- a/tests/testmodel/setvaluecommand.test.cpp
+++ b/tests/testmodel/setvaluecommand.test.cpp
@@ -39,13 +39,13 @@ TEST_F(SetValueCommandTest, setValueCommand)
 
     // executing command
     command->execute();
-    EXPECT_TRUE(std::get<bool>(command->commandResult())); // value was changed
+    EXPECT_TRUE(std::get<bool>(command->result())); // value was changed
     EXPECT_EQ(command->isObsolete(), false);
     EXPECT_EQ(model.data(item, role), expected);
 
     // undoing command
     command->undo();
-    EXPECT_TRUE(std::get<bool>(command->commandResult())); // value was changed
+    EXPECT_TRUE(std::get<bool>(command->result())); // value was changed
     EXPECT_FALSE(model.data(item, role).isValid());
     EXPECT_EQ(command->isObsolete(), false);
 }
@@ -67,7 +67,7 @@ TEST_F(SetValueCommandTest, setSameValueCommand)
 
     // executing command
     command->execute();
-    EXPECT_FALSE(std::get<bool>(command->commandResult())); // value wasn't changed
+    EXPECT_FALSE(std::get<bool>(command->result())); // value wasn't changed
     EXPECT_EQ(model.data(item, role), expected);
     EXPECT_EQ(command->isObsolete(), true);
 

--- a/tests/testmodel/setvaluecommand.test.cpp
+++ b/tests/testmodel/setvaluecommand.test.cpp
@@ -39,13 +39,13 @@ TEST_F(SetValueCommandTest, setValueCommand)
 
     // executing command
     command->execute();
-    EXPECT_TRUE(command->result()); // value was changed
+    EXPECT_TRUE(std::get<bool>(command->commandResult())); // value was changed
     EXPECT_EQ(command->isObsolete(), false);
     EXPECT_EQ(model.data(item, role), expected);
 
     // undoing command
     command->undo();
-    EXPECT_TRUE(command->result()); // value was changed
+    EXPECT_TRUE(std::get<bool>(command->commandResult())); // value was changed
     EXPECT_FALSE(model.data(item, role).isValid());
     EXPECT_EQ(command->isObsolete(), false);
 }
@@ -67,7 +67,7 @@ TEST_F(SetValueCommandTest, setSameValueCommand)
 
     // executing command
     command->execute();
-    EXPECT_FALSE(command->result()); // value wasn't changed
+    EXPECT_FALSE(std::get<bool>(command->commandResult())); // value wasn't changed
     EXPECT_EQ(model.data(item, role), expected);
     EXPECT_EQ(command->isObsolete(), true);
 


### PR DESCRIPTION
- Allow packing commands into macros
- Switch from templated method to std::variant in all machinery related to the value returned from the command
