### PR TITLE
ViewportItem refactoring; bug in redo while updating viewport

### DIFF
--- a/examples/graphicsproxy/graphicsproxycore/graphicsscene.cpp
+++ b/examples/graphicsproxy/graphicsproxycore/graphicsscene.cpp
@@ -51,7 +51,7 @@ void GraphicsScene::update_size(const QSize& newSize)
 void GraphicsScene::create_colormap_proxy(ModelView::ColorMapCanvas* colormap)
 {
     scene_adapter = colormap->createSceneAdapter();
-    colormap_proxy = new CustomPlotProxyWidget(colormap);
+    colormap_proxy = new ModelView::CustomPlotProxyWidget(colormap);
     addItem(colormap_proxy);
 }
 

--- a/examples/graphicsproxy/graphicsproxycore/graphicsscene.h
+++ b/examples/graphicsproxy/graphicsproxycore/graphicsscene.h
@@ -17,9 +17,9 @@ namespace ModelView
 {
 class ColorMapCanvas;
 class SceneAdapterInterface;
+class CustomPlotProxyWidget;
 } // namespace ModelView
 
-class CustomPlotProxyWidget;
 class RegionOfInterestItem;
 
 //! Custom graphics scene to show QCustomPlot with additional elements on top.
@@ -40,7 +40,7 @@ private:
     void create_colormap_proxy(ModelView::ColorMapCanvas* colormap);
     void create_roi_view(RegionOfInterestItem* roi_item);
 
-    CustomPlotProxyWidget* colormap_proxy{nullptr};
+    ModelView::CustomPlotProxyWidget* colormap_proxy{nullptr};
     std::unique_ptr<ModelView::SceneAdapterInterface> scene_adapter;
 };
 

--- a/examples/graphicsproxy/graphicsproxycore/scenewidget.cpp
+++ b/examples/graphicsproxy/graphicsproxycore/scenewidget.cpp
@@ -61,7 +61,7 @@ void SceneWidget::init_actions()
     m_resetViewportAction = new QAction("Reset view", this);
     auto on_reset = [this]() {
         auto viewport = m_model->topItem<ColorMapViewportItem>();
-        viewport->update_viewport();
+        viewport->setViewportToContent();
     };
     connect(m_resetViewportAction, &QAction::triggered, on_reset);
     m_toolBar->addAction(m_resetViewportAction);

--- a/examples/plotcolormap/plotcolormapcore/colormapwidget.cpp
+++ b/examples/plotcolormap/plotcolormapcore/colormapwidget.cpp
@@ -67,7 +67,7 @@ void ColorMapWidget::init_actions()
     m_resetViewportAction = new QAction("Reset view", this);
     auto on_reset = [this]() {
         auto viewport = m_model->topItem<ColorMapViewportItem>();
-        viewport->update_viewport();
+        viewport->setViewportToContent();
     };
     connect(m_resetViewportAction, &QAction::triggered, on_reset);
 

--- a/examples/plotgraphs/plotgraphscore/graphwidget.cpp
+++ b/examples/plotgraphs/plotgraphscore/graphwidget.cpp
@@ -69,7 +69,7 @@ void GraphWidget::init_actions()
     m_resetViewportAction = new QAction("Reset view", this);
     auto on_reset = [this]() {
         auto viewport = m_model->topItem<GraphViewportItem>();
-        viewport->setViewportToContent();
+        viewport->setViewportToContent(0.0, 0.1, 0.0, 0.1);
     };
     connect(m_resetViewportAction, &QAction::triggered, on_reset);
 

--- a/examples/plotgraphs/plotgraphscore/graphwidget.cpp
+++ b/examples/plotgraphs/plotgraphscore/graphwidget.cpp
@@ -69,7 +69,7 @@ void GraphWidget::init_actions()
     m_resetViewportAction = new QAction("Reset view", this);
     auto on_reset = [this]() {
         auto viewport = m_model->topItem<GraphViewportItem>();
-        viewport->update_viewport();
+        viewport->setViewportToContent();
     };
     connect(m_resetViewportAction, &QAction::triggered, on_reset);
 

--- a/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
+++ b/source/libmvvm_model/mvvm/commands/abstractitemcommand.h
@@ -30,6 +30,9 @@ public:
     explicit AbstractItemCommand(SessionItem* receiver);
     virtual ~AbstractItemCommand();
 
+    AbstractItemCommand(const AbstractItemCommand& other) = delete;
+    AbstractItemCommand& operator=(const AbstractItemCommand& other) = delete;
+
     void execute();
 
     void undo();

--- a/source/libmvvm_model/mvvm/commands/undostack.cpp
+++ b/source/libmvvm_model/mvvm/commands/undostack.cpp
@@ -24,7 +24,8 @@ UndoStack::UndoStack() : p_impl(std::make_unique<UndoStackImpl>()) {}
 void UndoStack::execute(std::shared_ptr<AbstractItemCommand> command)
 {
     // Wrapping command for Qt. It will be executed by Qt after push.
-    p_impl->undoStack()->push(new CommandAdapter(command));
+    auto adapter = new CommandAdapter(std::move(command));
+    p_impl->undoStack()->push(adapter);
 }
 
 UndoStack::~UndoStack() = default;

--- a/source/libmvvm_model/mvvm/commands/undostack.h
+++ b/source/libmvvm_model/mvvm/commands/undostack.h
@@ -44,8 +44,8 @@ public:
 
     static QUndoStack* qtUndoStack(UndoStackInterface* stack_interface);
 
-    void beginMacro(const std::string& name);
-    void endMacro();
+    void beginMacro(const std::string& name) override;
+    void endMacro() override;
 
 private:
     struct UndoStackImpl;

--- a/source/libmvvm_model/mvvm/model/modelutils.cpp
+++ b/source/libmvvm_model/mvvm/model/modelutils.cpp
@@ -7,6 +7,7 @@
 //
 // ************************************************************************** //
 
+#include <mvvm/interfaces/undostackinterface.h>
 #include <mvvm/model/modelutils.h>
 
 using namespace ModelView;
@@ -40,4 +41,22 @@ void Utils::MoveDown(SessionItem* item)
     if (tagrow.row == item->parent()->itemCount(tagrow.tag) - 1)
         return; // item already at the buttom
     item->model()->moveItem(item, item->parent(), tagrow.next());
+}
+
+void Utils::BeginMacros(const SessionItem* item, const std::string& macro_name)
+{
+    if (!item->model())
+        return;
+
+    if (auto stack = item->model()->undoStack(); stack)
+        stack->beginMacro(macro_name);
+}
+
+void Utils::EndMacros(const SessionItem* item)
+{
+    if (!item->model())
+        return;
+
+    if (auto stack = item->model()->undoStack(); stack)
+        stack->endMacro();
 }

--- a/source/libmvvm_model/mvvm/model/modelutils.h
+++ b/source/libmvvm_model/mvvm/model/modelutils.h
@@ -63,6 +63,14 @@ void MVVM_MODEL_EXPORT DeleteItemFromModel(SessionItem* item);
 void MVVM_MODEL_EXPORT MoveUp(SessionItem* item);
 void MVVM_MODEL_EXPORT MoveDown(SessionItem* item);
 
+//! Begin undo/redo macros with given name. Works only if item belongs to the model, and model has
+//! undo/redo enabled. Otherwise, do nothing.
+void MVVM_MODEL_EXPORT BeginMacros(const SessionItem* item, const std::string& macro_name);
+
+//! Finishes undo/redo macros. Works only if item belongs to the model, and model has undo/redo
+//! enabled. Otherwise, do nothing.
+void MVVM_MODEL_EXPORT EndMacros(const SessionItem* item);
+
 } // namespace Utils
 } // namespace ModelView
 

--- a/source/libmvvm_model/mvvm/serialization/jsonitemconverter.cpp
+++ b/source/libmvvm_model/mvvm/serialization/jsonitemconverter.cpp
@@ -51,19 +51,19 @@ std::unique_ptr<JsonItemDataConverterInterface> createDataConverter(const Conver
 } // namespace
 
 struct JsonItemConverter::JsonItemConverterImpl {
-    JsonItemConverter* m_parent{nullptr};
+    JsonItemConverter* m_self{nullptr};
     std::unique_ptr<JsonItemDataConverterInterface> m_itemdata_converter;
     std::unique_ptr<JsonItemTagsConverter> m_itemtags_converter;
     ConverterContext m_context;
 
     JsonItemConverterImpl(JsonItemConverter* parent, const ConverterContext& context)
-        : m_parent(parent), m_context(context)
+        : m_self(parent), m_context(context)
     {
         //! Callback to convert SessionItem to JSON object.
-        auto create_json = [this](const SessionItem& item) { return m_parent->to_json(&item); };
+        auto create_json = [this](const SessionItem& item) { return m_self->to_json(&item); };
 
         //! Callback to create SessionItem from JSON object.
-        auto create_item = [this](const QJsonObject& json) { return m_parent->from_json(json); };
+        auto create_item = [this](const QJsonObject& json) { return m_self->from_json(json); };
 
         //! Callback to update SessionItem from JSON object.
         auto update_item = [this](const QJsonObject& json, SessionItem* item) {

--- a/source/libmvvm_model/mvvm/standarditems/colormapviewportitem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/colormapviewportitem.cpp
@@ -34,9 +34,9 @@ ViewportAxisItem* ColorMapViewportItem::zAxis() const
     return item<ViewportAxisItem>(P_ZAXIS);
 }
 
-void ColorMapViewportItem::update_viewport()
+void ColorMapViewportItem::setViewportToContent()
 {
-    ViewportItem::update_viewport();
+    ViewportItem::setViewportToContent();
     update_data_range();
 }
 

--- a/source/libmvvm_model/mvvm/standarditems/colormapviewportitem.h
+++ b/source/libmvvm_model/mvvm/standarditems/colormapviewportitem.h
@@ -28,7 +28,7 @@ public:
 
     ViewportAxisItem* zAxis() const;
 
-    void update_viewport() override;
+    void setViewportToContent() override;
 
 protected:
     virtual std::pair<double, double> data_xaxis_range() const override;

--- a/source/libmvvm_model/mvvm/standarditems/graphitem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/graphitem.cpp
@@ -70,7 +70,7 @@ std::vector<double> GraphItem::binErrors() const
 
 std::string GraphItem::colorName() const
 {
-    return item<PenItem>(P_PEN)->colorName();
+    return penItem()->colorName();
 }
 
 //! Sets named color following schema from https://www.w3.org/TR/css-color-3/#svg-color.
@@ -78,5 +78,10 @@ std::string GraphItem::colorName() const
 
 void GraphItem::setNamedColor(const std::string& named_color)
 {
-    item<PenItem>(P_PEN)->setNamedColor(named_color);
+    penItem()->setNamedColor(named_color);
+}
+
+PenItem* GraphItem::penItem() const
+{
+    return item<PenItem>(P_PEN);
 }

--- a/source/libmvvm_model/mvvm/standarditems/graphitem.h
+++ b/source/libmvvm_model/mvvm/standarditems/graphitem.h
@@ -16,6 +16,7 @@ namespace ModelView
 {
 
 class Data1DItem;
+class PenItem;
 
 //! One-dimensional graph representation of Data1DItem.
 //! Contains plot properties (i.e. color, line type etc) and link to Data1DItem, which will provide
@@ -45,6 +46,8 @@ public:
 
     std::string colorName() const;
     void setNamedColor(const std::string& named_color);
+
+    PenItem* penItem() const;
 };
 
 } // namespace ModelView

--- a/source/libmvvm_model/mvvm/standarditems/viewportitem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/viewportitem.cpp
@@ -24,9 +24,9 @@ ViewportAxisItem* ViewportItem::yAxis() const
     return item<ViewportAxisItem>(P_YAXIS);
 }
 
-//! Updates range of x,y window to show all data.
+//! Sets range of x,y window to show all data.
 
-void ViewportItem::update_viewport()
+void ViewportItem::setViewportToContent()
 {
     auto [xmin, xmax] = data_xaxis_range();
     xAxis()->set_range(xmin, xmax);

--- a/source/libmvvm_model/mvvm/standarditems/viewportitem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/viewportitem.cpp
@@ -7,6 +7,7 @@
 //
 // ************************************************************************** //
 
+#include <mvvm/model/modelutils.h>
 #include <mvvm/standarditems/axisitems.h>
 #include <mvvm/standarditems/viewportitem.h>
 
@@ -32,22 +33,26 @@ ViewportAxisItem* ViewportItem::yAxis() const
 
 void ViewportItem::setViewportToContent(double left, double top, double right, double bottom)
 {
+    Utils::BeginMacros(this, "setViewportToContent");
     auto [xmin, xmax] = data_xaxis_range();
     xAxis()->set_range(xmin - (xmax - xmin) * left, xmax + (xmax - xmin) * right);
 
     auto [ymin, ymax] = data_yaxis_range();
     yAxis()->set_range(ymin - (ymax - ymin) * bottom, ymax + (ymax - ymin) * top);
+    Utils::EndMacros(this);
 }
 
 //! Sets range of x,y window to show all data.
 
 void ViewportItem::setViewportToContent()
 {
+    Utils::BeginMacros(this, "setViewportToContent");
     auto [xmin, xmax] = data_xaxis_range();
     xAxis()->set_range(xmin, xmax);
 
     auto [ymin, ymax] = data_yaxis_range();
     yAxis()->set_range(ymin, ymax);
+    Utils::EndMacros(this);
 }
 
 void ViewportItem::register_xy_axes()

--- a/source/libmvvm_model/mvvm/standarditems/viewportitem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/viewportitem.cpp
@@ -25,6 +25,21 @@ ViewportAxisItem* ViewportItem::yAxis() const
 }
 
 //! Sets range of x,y window to show all data.
+//! Allows adding an additional margin to automatically calculated axis range. Margins are
+//! given in relative units wrt calculated axis range.
+//! Example: setViewportToContent(0.0, 0.1, 0.0, 0.1) will set axes to show all graphs with 10% gap
+//! above and below graph's max and min.
+
+void ViewportItem::setViewportToContent(double left, double top, double right, double bottom)
+{
+    auto [xmin, xmax] = data_xaxis_range();
+    xAxis()->set_range(xmin - (xmax - xmin) * left, xmax + (xmax - xmin) * right);
+
+    auto [ymin, ymax] = data_yaxis_range();
+    yAxis()->set_range(ymin - (ymax - ymin) * bottom, ymax + (ymax - ymin) * top);
+}
+
+//! Sets range of x,y window to show all data.
 
 void ViewportItem::setViewportToContent()
 {

--- a/source/libmvvm_model/mvvm/standarditems/viewportitem.h
+++ b/source/libmvvm_model/mvvm/standarditems/viewportitem.h
@@ -33,6 +33,8 @@ public:
 
     ViewportAxisItem* yAxis() const;
 
+    virtual void setViewportToContent(double left, double top, double right, double bottom);
+
     virtual void setViewportToContent();
 
 protected:

--- a/source/libmvvm_model/mvvm/standarditems/viewportitem.h
+++ b/source/libmvvm_model/mvvm/standarditems/viewportitem.h
@@ -18,7 +18,7 @@ namespace ModelView
 class ViewportAxisItem;
 
 //! Base class to represent 2D viewport.
-//! Used to define x,y axis for graphs and 2d colormaps, intended for use in QCustomPlot context.
+//! Contains x,y axis, indended to display graphs or 2d colormaps.
 
 class MVVM_MODEL_EXPORT ViewportItem : public CompoundItem
 {
@@ -33,7 +33,7 @@ public:
 
     ViewportAxisItem* yAxis() const;
 
-    virtual void update_viewport();
+    virtual void setViewportToContent();
 
 protected:
     void register_xy_axes();

--- a/source/libmvvm_view/mvvm/plotting/colormapviewportplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/colormapviewportplotcontroller.cpp
@@ -49,7 +49,7 @@ struct ColorMapViewportPlotController::ColorMapViewportPlotControllerImpl {
         colorScaleController->setItem(viewport->zAxis());
         auto colormap_item = viewport_item()->item<ColorMapItem>(ColorMapViewportItem::T_ITEMS);
         colorMapController->setItem(colormap_item);
-        viewport_item()->update_viewport();
+        viewport_item()->setViewportToContent();
     }
 
     void unsubscribe_components()

--- a/source/libmvvm_view/mvvm/plotting/customplotproxywidget.cpp
+++ b/source/libmvvm_view/mvvm/plotting/customplotproxywidget.cpp
@@ -14,6 +14,8 @@
 #include <QWidget>
 #include <mvvm/plotting/customplotproxywidget.h>
 
+using namespace ModelView;
+
 CustomPlotProxyWidget::CustomPlotProxyWidget(QWidget* colormap)
 {
     setWidget(colormap);

--- a/source/libmvvm_view/mvvm/plotting/customplotproxywidget.h
+++ b/source/libmvvm_view/mvvm/plotting/customplotproxywidget.h
@@ -15,11 +15,15 @@
 
 class QWidget;
 
+namespace ModelView
+{
+
 //! Custom proxy widget to embed color map in graphics scene.
 
 class MVVM_VIEW_EXPORT CustomPlotProxyWidget : public QGraphicsProxyWidget
 {
     Q_OBJECT
+
 public:
     CustomPlotProxyWidget(QWidget* colormap);
 
@@ -36,5 +40,7 @@ protected:
 private:
     bool block_signals_to_proxy{false};
 };
+
+} // namespace ModelView
 
 #endif //  MVVM_PLOTTING_CUSTOMPLOTPROXYWIDGET_H

--- a/source/libmvvm_view/mvvm/plotting/graphcanvas.cpp
+++ b/source/libmvvm_view/mvvm/plotting/graphcanvas.cpp
@@ -62,7 +62,7 @@ struct GraphCanvas::GraphCanvasImpl {
     {
         if (!viewport_controller->currentItem())
             return;
-        viewport_controller->currentItem()->update_viewport();
+        viewport_controller->currentItem()->setViewportToContent();
     }
 
     QCustomPlot* customPlot() { return custom_plot; }

--- a/source/libmvvm_view/mvvm/plotting/graphplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/graphplotcontroller.cpp
@@ -19,14 +19,14 @@
 using namespace ModelView;
 
 struct GraphPlotController::GraphItemControllerImpl {
-    GraphPlotController* m_master{nullptr};
+    GraphPlotController* m_self{nullptr};
     QCustomPlot* m_customPlot{nullptr};
     QCPGraph* m_graph{nullptr};
     std::unique_ptr<Data1DPlotController> m_dataController;
     std::unique_ptr<PenController> m_penController;
 
     GraphItemControllerImpl(GraphPlotController* master, QCustomPlot* plot)
-        : m_master(master), m_customPlot(plot)
+        : m_self(master), m_customPlot(plot)
     {
     }
 
@@ -49,7 +49,7 @@ struct GraphPlotController::GraphItemControllerImpl {
             m_customPlot->removePlottable(m_graph);
     }
 
-    GraphItem* graph_item() { return m_master->currentItem(); }
+    GraphItem* graph_item() { return m_self->currentItem(); }
 
     void update_data_controller() { m_dataController->setItem(graph_item()->dataItem()); }
 

--- a/source/libmvvm_view/mvvm/plotting/graphplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/graphplotcontroller.cpp
@@ -57,7 +57,7 @@ struct GraphPlotController::GraphItemControllerImpl {
 
     void update_graph_pen()
     {
-        m_penController->setItem(graph_item()->item<PenItem>(GraphItem::P_PEN));
+        m_penController->setItem(graph_item()->penItem());
     }
 
     //! Update visible

--- a/source/libmvvm_view/mvvm/plotting/graphviewportplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/graphviewportplotcontroller.cpp
@@ -64,7 +64,7 @@ struct GraphViewportPlotController::GraphViewportPlotControllerImpl {
             controller->setItem(graph_item);
             graph_controllers.push_back(std::move(controller));
         }
-        viewport->update_viewport();
+        viewport->setViewportToContent();
     }
 
     //! Adds controller for item.

--- a/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
@@ -20,14 +20,14 @@ using namespace ModelView;
 
 struct ViewportAxisPlotController::AxesPlotControllerImpl {
 
-    ViewportAxisPlotController* m_master{nullptr};
+    ViewportAxisPlotController* m_self{nullptr};
     QCPAxis* m_axis{nullptr};
     bool m_blockUpdate{false};
     std::unique_ptr<QMetaObject::Connection> m_axisConn;
     std::unique_ptr<AxisTitleController> m_titleController;
 
     AxesPlotControllerImpl(ViewportAxisPlotController* controller, QCPAxis* axis)
-        : m_master(controller), m_axis(axis)
+        : m_self(controller), m_axis(axis)
     {
         if (!axis)
             throw std::runtime_error("AxisPlotController: axis is not initialized.");
@@ -39,7 +39,7 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
     {
         auto on_axis_range = [this](const QCPRange& newRange) {
             m_blockUpdate = true;
-            auto item = m_master->currentItem();
+            auto item = m_self->currentItem();
             item->set_range(newRange.lower, newRange.upper);
             m_blockUpdate = false;
         };
@@ -56,7 +56,7 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
     //! Sets axesRange from SessionItem.
     void setAxisRangeFromItem()
     {
-        auto [lower, upper] = m_master->currentItem()->range();
+        auto [lower, upper] = m_self->currentItem()->range();
         m_axis->setRange(QCPRange(lower, upper));
     }
 
@@ -64,7 +64,7 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
 
     void setAxisLogScaleFromItem()
     {
-        Utils::SetLogarithmicScale(m_axis, m_master->currentItem()->is_in_log());
+        Utils::SetLogarithmicScale(m_axis, m_self->currentItem()->is_in_log());
     }
 
     //! Init axis from item and setup connections.
@@ -72,7 +72,7 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
     void init_axis()
     {
         m_titleController = std::make_unique<AxisTitleController>(m_axis);
-        auto text_item = m_master->currentItem()->item<TextItem>(ViewportAxisItem::P_TITLE);
+        auto text_item = m_self->currentItem()->item<TextItem>(ViewportAxisItem::P_TITLE);
         m_titleController->setItem(text_item);
         setAxisRangeFromItem();
         setAxisLogScaleFromItem();

--- a/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
@@ -54,28 +54,32 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
     void setDisconnected() { QObject::disconnect(*m_axisConn); }
 
     //! Sets axesRange from SessionItem.
-    void setAxisRangeFromItem()
+    void setAxisRangeFromItem(const ViewportAxisItem* item)
     {
-        auto [lower, upper] = m_self->currentItem()->range();
+        setDisconnected();
+        auto [lower, upper] = item->range();
         m_axis->setRange(QCPRange(lower, upper));
+        setConnected();
     }
 
     //! Sets log scale from item.
 
-    void setAxisLogScaleFromItem()
+    void setAxisLogScaleFromItem(const ViewportAxisItem* item)
     {
-        Utils::SetLogarithmicScale(m_axis, m_self->currentItem()->is_in_log());
+        setDisconnected();
+        Utils::SetLogarithmicScale(m_axis, item->is_in_log());
+        setConnected();
     }
 
     //! Init axis from item and setup connections.
 
-    void init_axis()
+    void init_axis(const ViewportAxisItem* item)
     {
         m_titleController = std::make_unique<AxisTitleController>(m_axis);
-        auto text_item = m_self->currentItem()->item<TextItem>(ViewportAxisItem::P_TITLE);
+        auto text_item = item->item<TextItem>(ViewportAxisItem::P_TITLE);
         m_titleController->setItem(text_item);
-        setAxisRangeFromItem();
-        setAxisLogScaleFromItem();
+        setAxisRangeFromItem(item);
+        setAxisLogScaleFromItem(item);
         setConnected();
     }
 
@@ -117,13 +121,13 @@ void ViewportAxisPlotController::subscribe()
             p_impl->updateUpperRange(currentItem());
 
         if (name == ViewportAxisItem::P_IS_LOG)
-            p_impl->setAxisLogScaleFromItem();
+            p_impl->setAxisLogScaleFromItem(currentItem());
 
         p_impl->m_axis->parentPlot()->replot();
     };
     setOnPropertyChange(on_property_change);
 
-    p_impl->init_axis();
+    p_impl->init_axis(currentItem());
 }
 
 void ViewportAxisPlotController::unsubscribe()

--- a/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
@@ -54,32 +54,28 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
     void setDisconnected() { QObject::disconnect(*m_axisConn); }
 
     //! Sets axesRange from SessionItem.
-    void setAxisRangeFromItem(const ViewportAxisItem* item)
+    void setAxisRangeFromItem()
     {
-        setDisconnected();
-        auto [lower, upper] = item->range();
+        auto [lower, upper] = m_self->currentItem()->range();
         m_axis->setRange(QCPRange(lower, upper));
-        setConnected();
     }
 
     //! Sets log scale from item.
 
-    void setAxisLogScaleFromItem(const ViewportAxisItem* item)
+    void setAxisLogScaleFromItem()
     {
-        setDisconnected();
-        Utils::SetLogarithmicScale(m_axis, item->is_in_log());
-        setConnected();
+        Utils::SetLogarithmicScale(m_axis, m_self->currentItem()->is_in_log());
     }
 
     //! Init axis from item and setup connections.
 
-    void init_axis(const ViewportAxisItem* item)
+    void init_axis()
     {
         m_titleController = std::make_unique<AxisTitleController>(m_axis);
-        auto text_item = item->item<TextItem>(ViewportAxisItem::P_TITLE);
+        auto text_item = m_self->currentItem()->item<TextItem>(ViewportAxisItem::P_TITLE);
         m_titleController->setItem(text_item);
-        setAxisRangeFromItem(item);
-        setAxisLogScaleFromItem(item);
+        setAxisRangeFromItem();
+        setAxisLogScaleFromItem();
         setConnected();
     }
 
@@ -121,13 +117,13 @@ void ViewportAxisPlotController::subscribe()
             p_impl->updateUpperRange(currentItem());
 
         if (name == ViewportAxisItem::P_IS_LOG)
-            p_impl->setAxisLogScaleFromItem(currentItem());
+            p_impl->setAxisLogScaleFromItem();
 
         p_impl->m_axis->parentPlot()->replot();
     };
     setOnPropertyChange(on_property_change);
 
-    p_impl->init_axis(currentItem());
+    p_impl->init_axis();
 }
 
 void ViewportAxisPlotController::unsubscribe()

--- a/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
+++ b/source/libmvvm_view/mvvm/plotting/viewportaxisplotcontroller.cpp
@@ -79,6 +79,20 @@ struct ViewportAxisPlotController::AxesPlotControllerImpl {
         setConnected();
     }
 
+    void updateLowerRange(const ViewportAxisItem* item)
+    {
+        setDisconnected();
+        m_axis->setRangeLower(item->property<double>(ViewportAxisItem::P_MIN));
+        setConnected();
+    }
+
+    void updateUpperRange(const ViewportAxisItem* item)
+    {
+        setDisconnected();
+        m_axis->setRangeUpper(item->property<double>(ViewportAxisItem::P_MAX));
+        setConnected();
+    }
+
     ~AxesPlotControllerImpl() { setDisconnected(); }
 };
 
@@ -92,15 +106,15 @@ ViewportAxisPlotController::~ViewportAxisPlotController() = default;
 
 void ViewportAxisPlotController::subscribe()
 {
-    auto on_property_change = [this](SessionItem* item, std::string name) {
+    auto on_property_change = [this](SessionItem*, std::string name) {
         if (p_impl->m_blockUpdate)
             return;
 
         if (name == ViewportAxisItem::P_MIN)
-            p_impl->m_axis->setRangeLower(item->property<double>(name));
+            p_impl->updateLowerRange(currentItem());
 
         if (name == ViewportAxisItem::P_MAX)
-            p_impl->m_axis->setRangeUpper(item->property<double>(name));
+            p_impl->updateUpperRange(currentItem());
 
         if (name == ViewportAxisItem::P_IS_LOG)
             p_impl->setAxisLogScaleFromItem();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 include(GoogleTest)
 
 add_subdirectory(libtestmachinery)
+add_subdirectory(testintegration)
 add_subdirectory(testmodel)
-add_subdirectory(testviewmodel)
 add_subdirectory(testview)
+add_subdirectory(testviewmodel)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(GoogleTest)
 
+if(WIN32)
+    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY)
+endif()
+
 add_subdirectory(libtestmachinery)
 add_subdirectory(testintegration)
 add_subdirectory(testmodel)

--- a/tests/testintegration/CMakeLists.txt
+++ b/tests/testintegration/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(test testintegration)
+
+include(GoogleTest)
+
+file(GLOB source_files "*.cpp")
+file(GLOB include_files "*.h")
+
+find_package(Qt5Core REQUIRED)
+find_package(Qt5Test REQUIRED)
+
+# necessary for Qt creator and clang code model
+include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+
+set(CMAKE_AUTOMOC ON)
+add_executable(${test} ${source_files} ${include_files})
+target_link_libraries(${test} gtest gmock Qt5::Core Qt5::Test mvvm_view testmachinery qcustomplot)
+
+if (MVVM_DISCOVER_TESTS)
+    gtest_discover_tests(${test})
+else()
+    add_custom_target(${test}_run ALL DEPENDS ${test} COMMAND ${test})
+endif()

--- a/tests/testintegration/CMakeLists.txt
+++ b/tests/testintegration/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(test testintegration)
 
-include(GoogleTest)
-
 file(GLOB source_files "*.cpp")
 file(GLOB include_files "*.h")
 

--- a/tests/testintegration/TestAll.cpp
+++ b/tests/testintegration/TestAll.cpp
@@ -1,0 +1,25 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+#include "qcustomplot.h"
+#include <QApplication>
+#include <QStandardItem>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    ModelView::Comparators::registerComparators();
+
+    QApplication app(argc, argv);
+    Q_UNUSED(app)
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/testintegration/undoscenario.test.cpp
+++ b/tests/testintegration/undoscenario.test.cpp
@@ -8,6 +8,13 @@
 // ************************************************************************** //
 
 #include "google_test.h"
+#include "qcustomplot.h"
+#include <mvvm/interfaces/undostackinterface.h>
+#include <mvvm/model/sessionmodel.h>
+#include <mvvm/plotting/viewportaxisplotcontroller.h>
+#include <mvvm/standarditems/axisitems.h>
+
+using namespace ModelView;
 
 //! Testing various undo/redo scenario.
 
@@ -19,7 +26,57 @@ public:
 
 UndoScenarioTest::~UndoScenarioTest() = default;
 
-TEST_F(UndoScenarioTest, initialState)
+//! Check undo/redo of ViewportAxisItem range, when it is listened by controller.
+//! Real-life bug.
+
+TEST_F(UndoScenarioTest, undoViewportSetRange)
 {
-    EXPECT_EQ(1, 1);
+    // initialzing model, custom plot and controller
+    SessionModel model;
+    auto axisItem = model.insertItem<ViewportAxisItem>();
+    axisItem->setProperty(ViewportAxisItem::P_MIN, 1.0);
+    axisItem->setProperty(ViewportAxisItem::P_MAX, 2.0);
+    QCustomPlot custom_plot;
+    ViewportAxisPlotController controller(custom_plot.xAxis);
+    controller.setItem(axisItem);
+
+    // initial axis state
+    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot.xAxis->range().upper, 2.0);
+
+    // enabling undo/redo, and  its initial state
+    model.setUndoRedoEnabled(true);
+    auto stack = model.undoStack();
+    EXPECT_FALSE(stack->canRedo());
+    EXPECT_FALSE(stack->canUndo());
+    EXPECT_EQ(stack->index(), 0);
+    EXPECT_EQ(stack->count(), 0);
+
+    // changing axis
+    axisItem->setProperty(ViewportAxisItem::P_MAX, 20.0);
+    EXPECT_FALSE(stack->canRedo());
+    EXPECT_TRUE(stack->canUndo());
+    EXPECT_EQ(stack->index(), 1);
+    EXPECT_EQ(stack->count(), 1);
+    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot.xAxis->range().upper, 20.0);
+
+    // undoing
+    stack->undo();
+    EXPECT_TRUE(stack->canRedo());
+    EXPECT_FALSE(stack->canUndo());
+    EXPECT_EQ(stack->index(), 0);
+    EXPECT_EQ(stack->count(), 1);
+    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot.xAxis->range().upper, 2.0);
+
+    // redoing
+    // FIXME uncomment tests below, there is segfault
+    //    stack->redo();
+    //    EXPECT_FALSE(stack->canRedo());
+    //    EXPECT_TRUE(stack->canUndo());
+    //    EXPECT_EQ(stack->index(), 1);
+    //    EXPECT_EQ(stack->count(), 1);
+    //    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
+    //    EXPECT_EQ(custom_plot.xAxis->range().upper, 20.0);
 }

--- a/tests/testintegration/undoscenario.test.cpp
+++ b/tests/testintegration/undoscenario.test.cpp
@@ -1,0 +1,25 @@
+// ************************************************************************** //
+//
+//  Model-view-view-model framework for large GUI applications
+//
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @authors   see AUTHORS
+//
+// ************************************************************************** //
+
+#include "google_test.h"
+
+//! Testing various undo/redo scenario.
+
+class UndoScenarioTest : public ::testing::Test
+{
+public:
+    ~UndoScenarioTest();
+};
+
+UndoScenarioTest::~UndoScenarioTest() = default;
+
+TEST_F(UndoScenarioTest, initialState)
+{
+    EXPECT_EQ(1, 1);
+}

--- a/tests/testintegration/undoscenario.test.cpp
+++ b/tests/testintegration/undoscenario.test.cpp
@@ -71,12 +71,11 @@ TEST_F(UndoScenarioTest, undoViewportSetRange)
     EXPECT_EQ(custom_plot.xAxis->range().upper, 2.0);
 
     // redoing
-    // FIXME uncomment tests below, there is segfault
-    //    stack->redo();
-    //    EXPECT_FALSE(stack->canRedo());
-    //    EXPECT_TRUE(stack->canUndo());
-    //    EXPECT_EQ(stack->index(), 1);
-    //    EXPECT_EQ(stack->count(), 1);
-    //    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
-    //    EXPECT_EQ(custom_plot.xAxis->range().upper, 20.0);
+    stack->redo();
+    EXPECT_FALSE(stack->canRedo());
+    EXPECT_TRUE(stack->canUndo());
+    EXPECT_EQ(stack->index(), 1);
+    EXPECT_EQ(stack->count(), 1);
+    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot.xAxis->range().upper, 20.0);
 }

--- a/tests/testmodel/CMakeLists.txt
+++ b/tests/testmodel/CMakeLists.txt
@@ -6,19 +6,12 @@ file(GLOB include_files "*.h")
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Test REQUIRED)
 
-if(WIN32)
-    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY)
-endif()
-
 # necessary for Qt creator and clang code model
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
 set(CMAKE_AUTOMOC ON)
 add_executable(${test} ${source_files} ${include_files})
 target_link_libraries(${test} gtest gmock Qt5::Core Qt5::Test mvvm_model testmachinery)
-
-# to make clang code model in Qt creator happy
-target_compile_features(${test} PUBLIC cxx_std_17)
 
 if (MVVM_DISCOVER_TESTS)
     gtest_discover_tests(${test})

--- a/tests/testmodel/colormapviewportitem.test.cpp
+++ b/tests/testmodel/colormapviewportitem.test.cpp
@@ -47,7 +47,7 @@ TEST_F(ColorMapViewportItemTest, uninitializedViewportUpdate)
 
     auto viewport_item = model.insertItem<ColorMapViewportItem>();
 
-    viewport_item->update_viewport();
+    viewport_item->setViewportToContent();
 
     // x-axis of viewport should be set Data2DItem
     auto [xmin, xmax] = viewport_item->xAxis()->range();
@@ -84,7 +84,7 @@ TEST_F(ColorMapViewportItemTest, addItem)
     EXPECT_EQ(viewport_item->items<ColorMapItem>(ColorMapViewportItem::T_ITEMS).size(), 1);
 
     // updating viewport to graph
-    viewport_item->update_viewport();
+    viewport_item->setViewportToContent();
 
     // x-axis of viewport should be set Data2DItem
     auto [xmin, xmax] = viewport_item->xAxis()->range();

--- a/tests/testmodel/graphitem.test.cpp
+++ b/tests/testmodel/graphitem.test.cpp
@@ -156,14 +156,13 @@ TEST_F(GraphItemTest, setFromGraphItem)
     data_item->setValues(expected_values);
 
     graph_item->setDataItem(data_item);
-    graph_item->item<PenItem>(GraphItem::P_PEN)->setProperty(PenItem::P_COLOR, QColor(Qt::red));
+    graph_item->penItem()->setProperty(PenItem::P_COLOR, QColor(Qt::red));
 
     graph_item2->setFromGraphItem(graph_item);
 
     EXPECT_EQ(graph_item2->binValues(), expected_values);
     EXPECT_EQ(graph_item2->binCenters(), expected_centers);
-    EXPECT_EQ(graph_item2->item<PenItem>(GraphItem::P_PEN)->property<QColor>(PenItem::P_COLOR),
-              QColor(Qt::red));
+    EXPECT_EQ(graph_item2->penItem()->property<QColor>(PenItem::P_COLOR), QColor(Qt::red));
 }
 
 TEST_F(GraphItemTest, penItem_setNamedColor)

--- a/tests/testmodel/graphviewportitem.test.cpp
+++ b/tests/testmodel/graphviewportitem.test.cpp
@@ -120,3 +120,41 @@ TEST_F(GraphViewportItemTest, onSetDataItem)
     // triggering action
     graph_item->setDataItem(data_item);
 }
+
+//! Add graph to viewport.
+
+TEST_F(GraphViewportItemTest, setViewportToContentWithMargins)
+{
+    SessionModel model;
+
+    auto viewport_item = model.insertItem<GraphViewportItem>();
+    auto graph_item = model.insertItem<GraphItem>(viewport_item);
+    auto data_item = model.insertItem<Data1DItem>();
+
+    const std::vector<double> expected_values = {1.0, 2.0, 3.0};
+    const std::vector<double> expected_centers = {0.5, 1.5, 2.5};
+    data_item->setAxis<FixedBinAxisItem>(3, 0.0, 3.0);
+    data_item->setValues(expected_values);
+
+    graph_item->setDataItem(data_item);
+    EXPECT_EQ(viewport_item->graphItems().size(), 1);
+
+    // updating viewport to graph
+    const double bottom{0.1}, top{0.1};
+    viewport_item->setViewportToContent(0.0, top, 0.0, bottom);
+
+    // x-axis of viewport should be set to FixedBinAxis of DataItem
+    auto xaxis = viewport_item->xAxis();
+    EXPECT_DOUBLE_EQ(xaxis->property<double>(ViewportAxisItem::P_MIN), expected_centers[0]);
+    EXPECT_DOUBLE_EQ(xaxis->property<double>(ViewportAxisItem::P_MAX), expected_centers[2]);
+
+    // y-axis of viewport should be set to min/max of expected_content
+    auto yaxis = viewport_item->yAxis();
+    auto [expected_amin, expected_amax] =
+        std::minmax_element(std::begin(expected_values), std::end(expected_values));
+
+    double expected_ymin = *expected_amin - (*expected_amax - *expected_amin) * bottom;
+    double expected_ymax = *expected_amax + (*expected_amax - *expected_amin) * top;
+    EXPECT_DOUBLE_EQ(yaxis->property<double>(ViewportAxisItem::P_MIN), expected_ymin);
+    EXPECT_DOUBLE_EQ(yaxis->property<double>(ViewportAxisItem::P_MAX), expected_ymax);
+}

--- a/tests/testmodel/graphviewportitem.test.cpp
+++ b/tests/testmodel/graphviewportitem.test.cpp
@@ -57,7 +57,7 @@ TEST_F(GraphViewportItemTest, addItem)
     EXPECT_EQ(viewport_item->graphItems().size(), 1);
 
     // updating viewport to graph
-    viewport_item->update_viewport();
+    viewport_item->setViewportToContent();
 
     // x-axis of viewport should be set to FixedBinAxis of DataItem
     auto xaxis = viewport_item->xAxis();

--- a/tests/testmodel/undostack.test.cpp
+++ b/tests/testmodel/undostack.test.cpp
@@ -10,8 +10,12 @@
 #include "google_test.h"
 #include "toy_includes.h"
 #include "toy_items.h"
+#include <mvvm/commands/commandadapter.h>
+#include <mvvm/commands/setvaluecommand.h>
+#include <mvvm/commands/undostack.h>
 #include <mvvm/interfaces/undostackinterface.h>
 #include <mvvm/model/itemutils.h>
+#include <mvvm/model/propertyitem.h>
 #include <mvvm/model/sessionitem.h>
 #include <mvvm/model/sessionmodel.h>
 #include <mvvm/model/taginfo.h>
@@ -28,6 +32,77 @@ public:
 };
 
 UndoStackTest::~UndoStackTest() = default;
+
+//! Checking time of life of the command during undo/redo.
+//! This is connected with the fact, that Qt takes ownership of the command and we have to use
+//! our own wrapper.
+
+TEST_F(UndoStackTest, commandTimeOfLife)
+{
+    SessionModel model;
+    auto item = model.insertItem<PropertyItem>();
+    item->setData(42);
+
+    std::weak_ptr<SetValueCommand> pw_command; // to trace command time of life
+
+    UndoStack stack;
+
+    {
+        // creating command
+        auto command =
+            std::make_shared<SetValueCommand>(item, QVariant::fromValue(43), ItemDataRole::DATA);
+        pw_command = command;
+        EXPECT_EQ(pw_command.use_count(), 1);
+
+        // checking state of item, stack and command
+        EXPECT_EQ(item->data<int>(), 42);
+        EXPECT_FALSE(stack.canRedo());
+        EXPECT_FALSE(stack.canUndo());
+        EXPECT_EQ(stack.index(), 0);
+        EXPECT_EQ(stack.count(), 0);
+        EXPECT_EQ(command->isObsolete(), false);
+        EXPECT_FALSE(std::get<bool>(command->result()));
+
+        // adding command to the stack, it will lead to command execution
+        stack.execute(command);
+        EXPECT_EQ(pw_command.use_count(), 2);
+
+        // checking state of item, stack and command
+        EXPECT_EQ(item->data<int>(), 43);
+        EXPECT_FALSE(stack.canRedo());
+        EXPECT_TRUE(stack.canUndo());
+        EXPECT_EQ(stack.index(), 1);
+        EXPECT_EQ(stack.count(), 1);
+        EXPECT_EQ(command->isObsolete(), false);
+        EXPECT_TRUE(std::get<bool>(command->result()));
+
+        // undoing
+        stack.undo();
+        EXPECT_EQ(item->data<int>(), 42);
+        EXPECT_TRUE(stack.canRedo());
+        EXPECT_FALSE(stack.canUndo());
+        EXPECT_EQ(stack.index(), 0);
+        EXPECT_EQ(stack.count(), 1);
+        EXPECT_EQ(command->isObsolete(), false);
+        EXPECT_TRUE(std::get<bool>(command->result()));
+
+        // redoing
+        stack.redo();
+        EXPECT_EQ(item->data<int>(), 43);
+        EXPECT_FALSE(stack.canRedo());
+        EXPECT_TRUE(stack.canUndo());
+        EXPECT_EQ(stack.index(), 1);
+        EXPECT_EQ(stack.count(), 1);
+        EXPECT_EQ(command->isObsolete(), false);
+        EXPECT_TRUE(std::get<bool>(command->result()));
+    }
+
+    EXPECT_EQ(pw_command.use_count(), 1);
+    if (auto command = pw_command.lock()) {
+        EXPECT_EQ(command->isObsolete(), false);
+        EXPECT_TRUE(std::get<bool>(command->result()));
+    }
+}
 
 TEST_F(UndoStackTest, initialState)
 {

--- a/tests/testview/CMakeLists.txt
+++ b/tests/testview/CMakeLists.txt
@@ -1,16 +1,10 @@
 set(test testview)
 
-include(GoogleTest)
-
 file(GLOB source_files "*.cpp")
 file(GLOB include_files "*.h")
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Test REQUIRED)
-
-if(WIN32)
-    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY)
-endif()
 
 # necessary for Qt creator and clang code model
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/tests/testview/CMakeLists.txt
+++ b/tests/testview/CMakeLists.txt
@@ -8,6 +8,10 @@ file(GLOB include_files "*.h")
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Test REQUIRED)
 
+if(WIN32)
+    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY)
+endif()
+
 # necessary for Qt creator and clang code model
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 

--- a/tests/testview/TestAll.cpp
+++ b/tests/testview/TestAll.cpp
@@ -8,6 +8,7 @@
 // ************************************************************************** //
 
 #include "google_test.h"
+#include <gmock/gmock.h>
 #include "qcustomplot.h"
 #include "customplot_test_utils.h"
 #include <QApplication>
@@ -16,6 +17,7 @@
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
+    ::testing::InitGoogleMock(&argc, argv);
 
     ModelView::Comparators::registerComparators();
     qRegisterMetaType<QStandardItem*>("QStandardItem*");

--- a/tests/testview/TestAll.cpp
+++ b/tests/testview/TestAll.cpp
@@ -9,6 +9,7 @@
 
 #include "google_test.h"
 #include "qcustomplot.h"
+#include "customplot_test_utils.h"
 #include <QApplication>
 #include <QStandardItem>
 

--- a/tests/testview/customplot_test_utils.h
+++ b/tests/testview/customplot_test_utils.h
@@ -50,4 +50,6 @@ template <typename T> T* GetPlottable(QCustomPlot* custom_plot)
 }
 } // namespace TestUtils
 
+Q_DECLARE_METATYPE(QCPRange)
+
 #endif

--- a/tests/testview/graphplotcontroller.test.cpp
+++ b/tests/testview/graphplotcontroller.test.cpp
@@ -94,7 +94,7 @@ TEST_F(GraphPlotControllerTest, changeGraphAppearance)
     controller.setItem(graph_item);
 
     // changing appearance properties
-    auto pen_item = graph_item->item<PenItem>(GraphItem::P_PEN);
+    auto pen_item = graph_item->penItem();
     pen_item->setProperty(PenItem::P_COLOR, QColor(Qt::red));
 
     auto styleCombo = pen_item->property<ComboProperty>(PenItem::P_STYLE);
@@ -127,7 +127,7 @@ TEST_F(GraphPlotControllerTest, setPointwiseItem)
 
     // setup graph item
     auto graph_item = model.insertItem<GraphItem>();
-    auto pen_item = graph_item->item<PenItem>(GraphItem::P_PEN);
+    auto pen_item = graph_item->penItem();
     pen_item->setProperty(PenItem::P_COLOR, QColor(Qt::red));
     graph_item->setDataItem(data_item);
 
@@ -192,7 +192,7 @@ TEST_F(GraphPlotControllerTest, unlinkFromItem)
 
     // setup graph item
     auto graph_item = model.insertItem<GraphItem>();
-    auto pen_item = graph_item->item<PenItem>(GraphItem::P_PEN);
+    auto pen_item = graph_item->penItem();
     pen_item->setProperty(PenItem::P_COLOR, QColor(Qt::red));
     graph_item->setDataItem(data_item);
 

--- a/tests/testview/graphviewportplotcontroller.test.cpp
+++ b/tests/testview/graphviewportplotcontroller.test.cpp
@@ -138,7 +138,7 @@ TEST_F(GraphViewportPlotControllerTest, addAndRemoveGraphs)
     EXPECT_EQ(custom_plot->graphCount(), 2);
 
     // Checking that viewport min, max adjusted to both graphs when manually call update_viewport()
-    viewport_item->update_viewport();
+    viewport_item->setViewportToContent();
     EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().lower, expected_centers[0]);
     EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().upper, expected_centers[2]);
     EXPECT_DOUBLE_EQ(custom_plot->yAxis->range().lower, expected_values1[0]);

--- a/tests/testview/viewportaxisplotcontroller.test.cpp
+++ b/tests/testview/viewportaxisplotcontroller.test.cpp
@@ -230,34 +230,34 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemSignaling)
 //! Change ViewportAxisItem and check that QCPAxis got new values.
 //! Check correctness that there is not extra looping and item doesn't start changing many times
 
-TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemMapping)
-{
-    auto custom_plot = std::make_unique<QCustomPlot>();
+//TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemMapping)
+//{
+//    auto custom_plot = std::make_unique<QCustomPlot>();
 
-    // creating the model with single ViewportAxisItem
-    SessionModel model;
-    auto axisItem = model.insertItem<ViewportAxisItem>();
-    axisItem->setProperty(ViewportAxisItem::P_MIN, 1.0);
-    axisItem->setProperty(ViewportAxisItem::P_MAX, 2.0);
+//    // creating the model with single ViewportAxisItem
+//    SessionModel model;
+//    auto axisItem = model.insertItem<ViewportAxisItem>();
+//    axisItem->setProperty(ViewportAxisItem::P_MIN, 1.0);
+//    axisItem->setProperty(ViewportAxisItem::P_MAX, 2.0);
 
-    // setting up QCustomPlot and item controller.
-    ViewportAxisPlotController controller(custom_plot->xAxis);
-    controller.setItem(axisItem);
+//    // setting up QCustomPlot and item controller.
+//    ViewportAxisPlotController controller(custom_plot->xAxis);
+//    controller.setItem(axisItem);
 
-    MockWidgetForItem widget(axisItem);
-    EXPECT_CALL(widget, onDataChange(_, _)).Times(0);
-    EXPECT_CALL(widget, onPropertyChange(axisItem, ViewportAxisItem::P_MAX)).Times(1);
-    EXPECT_CALL(widget, onChildPropertyChange(_, _)).Times(0);
-    EXPECT_CALL(widget, onItemInserted(_, _)).Times(0);
-    EXPECT_CALL(widget, onAboutToRemoveItem(_, _)).Times(0);
+//    MockWidgetForItem widget(axisItem);
+//    EXPECT_CALL(widget, onDataChange(_, _)).Times(0);
+//    EXPECT_CALL(widget, onPropertyChange(axisItem, ViewportAxisItem::P_MAX)).Times(1);
+//    EXPECT_CALL(widget, onChildPropertyChange(_, _)).Times(0);
+//    EXPECT_CALL(widget, onItemInserted(_, _)).Times(0);
+//    EXPECT_CALL(widget, onAboutToRemoveItem(_, _)).Times(0);
 
-    // making a change
-    const double expected_max = 20.0;
-    axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
+//    // making a change
+//    const double expected_max = 20.0;
+//    axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
 
-    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
-}
+//    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
+//    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+//}
 
 //! Set ViewportAxisItem logz, subscribe controller and check that QCPAxis has it.
 

--- a/tests/testview/viewportaxisplotcontroller.test.cpp
+++ b/tests/testview/viewportaxisplotcontroller.test.cpp
@@ -230,34 +230,34 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemSignaling)
 //! Change ViewportAxisItem and check that QCPAxis got new values.
 //! Check correctness that there is not extra looping and item doesn't start changing many times
 
-//TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemMapping)
-//{
-//    auto custom_plot = std::make_unique<QCustomPlot>();
+TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemMapping)
+{
+    auto custom_plot = std::make_unique<QCustomPlot>();
 
-//    // creating the model with single ViewportAxisItem
-//    SessionModel model;
-//    auto axisItem = model.insertItem<ViewportAxisItem>();
-//    axisItem->setProperty(ViewportAxisItem::P_MIN, 1.0);
-//    axisItem->setProperty(ViewportAxisItem::P_MAX, 2.0);
+    // creating the model with single ViewportAxisItem
+    SessionModel model;
+    auto axisItem = model.insertItem<ViewportAxisItem>();
+    axisItem->setProperty(ViewportAxisItem::P_MIN, 1.0);
+    axisItem->setProperty(ViewportAxisItem::P_MAX, 2.0);
 
-//    // setting up QCustomPlot and item controller.
-//    ViewportAxisPlotController controller(custom_plot->xAxis);
-//    controller.setItem(axisItem);
+    // setting up QCustomPlot and item controller.
+    ViewportAxisPlotController controller(custom_plot->xAxis);
+    controller.setItem(axisItem);
 
-//    MockWidgetForItem widget(axisItem);
-//    EXPECT_CALL(widget, onDataChange(_, _)).Times(0);
-//    EXPECT_CALL(widget, onPropertyChange(axisItem, ViewportAxisItem::P_MAX)).Times(1);
-//    EXPECT_CALL(widget, onChildPropertyChange(_, _)).Times(0);
-//    EXPECT_CALL(widget, onItemInserted(_, _)).Times(0);
-//    EXPECT_CALL(widget, onAboutToRemoveItem(_, _)).Times(0);
+    MockWidgetForItem widget(axisItem);
+    EXPECT_CALL(widget, onDataChange(_, _)).Times(0);
+    EXPECT_CALL(widget, onPropertyChange(axisItem, ViewportAxisItem::P_MAX)).Times(1);
+    EXPECT_CALL(widget, onChildPropertyChange(_, _)).Times(0);
+    EXPECT_CALL(widget, onItemInserted(_, _)).Times(0);
+    EXPECT_CALL(widget, onAboutToRemoveItem(_, _)).Times(0);
 
-//    // making a change
-//    const double expected_max = 20.0;
-//    axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
+    // making a change
+    const double expected_max = 20.0;
+    axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
 
-//    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
-//    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
-//}
+    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+}
 
 //! Set ViewportAxisItem logz, subscribe controller and check that QCPAxis has it.
 

--- a/tests/testview/viewportaxisplotcontroller.test.cpp
+++ b/tests/testview/viewportaxisplotcontroller.test.cpp
@@ -9,6 +9,7 @@
 
 #include "google_test.h"
 #include "qcustomplot.h"
+#include "customplot_test_utils.h"
 #include <QSignalSpy>
 #include <mvvm/model/sessionmodel.h>
 #include <mvvm/plotting/viewportaxisplotcontroller.h>
@@ -28,6 +29,12 @@ public:
     {
         return std::make_unique<QSignalSpy>(
             axis, static_cast<void (QCPAxis::*)(const QCPRange&)>(&QCPAxis::rangeChanged));
+    }
+
+    std::unique_ptr<QSignalSpy> createSpy2(QCPAxis* axis)
+    {
+        return std::make_unique<QSignalSpy>(
+            axis, static_cast<void (QCPAxis::*)(const QCPRange&, const QCPRange&)>(&QCPAxis::rangeChanged));
     }
 };
 
@@ -165,6 +172,58 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItem)
     EXPECT_EQ(custom_plot->xAxis->range().lower, expected_min);
     EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
 }
+
+//! Controller subscribed to ViewportAxisItem.
+//! Change ViewportAxisItem and check that QCPAxis got new values.
+//! Check correctness of signals issued by QCPAxisItem.
+
+TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemSignaling)
+{
+    auto custom_plot = std::make_unique<QCustomPlot>();
+
+    // creating the model with single ViewportAxisItem
+    SessionModel model;
+    auto axisItem = model.insertItem<ViewportAxisItem>();
+    axisItem->setProperty(ViewportAxisItem::P_MIN, 1.0);
+    axisItem->setProperty(ViewportAxisItem::P_MAX, 2.0);
+
+    // setting up QCustomPlot and item controller.
+    ViewportAxisPlotController controller(custom_plot->xAxis);
+    controller.setItem(axisItem);
+
+    // initial condition
+    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot->xAxis->range().upper, 2.0);
+
+    auto rangeChanged = createSpy(custom_plot->xAxis);
+    auto rangeChanged2 = createSpy2(custom_plot->xAxis);
+
+    // making a change
+    const double expected_max = 20.0;
+    axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
+
+    // Checking QCPAxis
+    EXPECT_EQ(rangeChanged->count(), 1);
+    EXPECT_EQ(rangeChanged2->count(), 1);
+    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
+    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+
+    QList<QVariant> arguments = rangeChanged->takeFirst();
+    EXPECT_EQ(arguments.size(), 1);
+    auto reportedRange = arguments.at(0).value<QCPRange>();
+    EXPECT_EQ(reportedRange.lower, 1.0);
+    EXPECT_EQ(reportedRange.upper, 20.0);
+
+    arguments = rangeChanged2->takeFirst();
+    EXPECT_EQ(arguments.size(), 2);
+    auto newRange = arguments.at(0).value<QCPRange>();
+    auto oldRange = arguments.at(1).value<QCPRange>();
+    EXPECT_EQ(newRange.lower, 1.0);
+    EXPECT_EQ(newRange.upper, 20.0);
+    EXPECT_EQ(oldRange.lower, 1.0);
+    EXPECT_EQ(oldRange.upper, 2.0);
+}
+
 
 //! Set ViewportAxisItem logz, subscribe controller and check that QCPAxis has it.
 

--- a/tests/testviewmodel/CMakeLists.txt
+++ b/tests/testviewmodel/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(test testviewmodel)
 
-include(GoogleTest)
-
 file(GLOB source_files "*.cpp")
 file(GLOB include_files "*.h")
 


### PR DESCRIPTION
- ViewportItem::setViewportToContent now allow to define margins around graphs
- setViewportToContent now is a macro for undo/redo
- Fix bug on application crash 
- New functional tests for undo/redo scenario