### PR TITLE
Insert item refactoring

### DIFF
--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -56,6 +56,7 @@ void CopyItemCommand::execute_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
     auto item = parent->insertItem(p_impl->backup_strategy->restoreItem(), p_impl->tagrow);
+    // FIXME revise behaviour in the case of invalid operation. Catch or not here?
     setResult(item);
     setObsolete(!item); // command is osbolete if insertion failed
 }

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -55,15 +55,9 @@ void CopyItemCommand::undo_command()
 void CopyItemCommand::execute_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
-    auto item = p_impl->backup_strategy->restoreItem();
-    if (parent->insertItem(item.get(), p_impl->tagrow)) {
-        auto result = item.release();
-        setResult(result);
-    }
-    else {
-        setResult(nullptr);
-        setObsolete(true);
-    }
+    auto item = parent->insertItem(p_impl->backup_strategy->restoreItem(), p_impl->tagrow);
+    setResult(item);
+    setObsolete(!item); // command is osbolete if insertion failed
 }
 
 namespace {

--- a/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/copyitemcommand.cpp
@@ -48,7 +48,7 @@ CopyItemCommand::~CopyItemCommand() = default;
 void CopyItemCommand::undo_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
-    delete parent->takeItem(p_impl->tagrow);
+    parent->takeItem(p_impl->tagrow);
     setResult(nullptr);
 }
 

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -51,6 +51,20 @@ void InsertNewItemCommand::undo_command()
 
 void InsertNewItemCommand::execute_command()
 {
+    //    auto parent = itemFromPath(p_impl->item_path);
+    //    if (auto child = parent->insertItem(p_impl->factory_func(), p_impl->tagrow); child) {
+    //        // here we restore original identifier to get exactly same item on consequitive
+    //        undo/redo if (!p_impl->initial_identifier.empty())
+    //            child->setData(QVariant::fromValue(p_impl->initial_identifier),
+    //                           ItemDataRole::IDENTIFIER,
+    //                           /*direct*/ true);
+    //        setDescription(generate_description(child->modelType(), p_impl->tagrow));
+    //        setResult(child);
+    //    }
+    //    else {
+    //        setObsolete(true);
+    //    }
+
     auto parent = itemFromPath(p_impl->item_path);
     auto child = p_impl->factory_func().release();
     // here we restore original identifier to get exactly same item on consequitive undo/redo

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -46,7 +46,6 @@ void InsertNewItemCommand::undo_command()
     // saving identifier for later redo
     if (p_impl->initial_identifier.empty())
         p_impl->initial_identifier = item->identifier();
-    delete item;
     setResult(nullptr);
 }
 

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -73,7 +73,7 @@ void InsertNewItemCommand::execute_command()
                        /*direct*/ true);
 
     setDescription(generate_description(child->modelType(), p_impl->tagrow));
-    if (parent->insertItem(child, p_impl->tagrow)) {
+    if (parent->insertItem(std::unique_ptr<SessionItem>(child), p_impl->tagrow)) {
         setResult(child);
     }
     else {

--- a/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/insertnewitemcommand.cpp
@@ -51,20 +51,6 @@ void InsertNewItemCommand::undo_command()
 
 void InsertNewItemCommand::execute_command()
 {
-    //    auto parent = itemFromPath(p_impl->item_path);
-    //    if (auto child = parent->insertItem(p_impl->factory_func(), p_impl->tagrow); child) {
-    //        // here we restore original identifier to get exactly same item on consequitive
-    //        undo/redo if (!p_impl->initial_identifier.empty())
-    //            child->setData(QVariant::fromValue(p_impl->initial_identifier),
-    //                           ItemDataRole::IDENTIFIER,
-    //                           /*direct*/ true);
-    //        setDescription(generate_description(child->modelType(), p_impl->tagrow));
-    //        setResult(child);
-    //    }
-    //    else {
-    //        setObsolete(true);
-    //    }
-
     auto parent = itemFromPath(p_impl->item_path);
     auto child = p_impl->factory_func().release();
     // here we restore original identifier to get exactly same item on consequitive undo/redo
@@ -73,7 +59,7 @@ void InsertNewItemCommand::execute_command()
                        /*direct*/ true);
 
     setDescription(generate_description(child->modelType(), p_impl->tagrow));
-    if (parent->insertItem(std::unique_ptr<SessionItem>(child), p_impl->tagrow)) {
+    if (parent->insertItem(child, p_impl->tagrow)) {
         setResult(child);
     }
     else {

--- a/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
@@ -87,8 +87,7 @@ void MoveItemCommand::execute_command()
     if (!taken)
         throw std::runtime_error("MoveItemCommand::execute() -> Can't take an item.");
 
-    bool succeeded = target_parent->insertItem(std::move(taken), p_impl->target_tagrow);
-    if (!succeeded)
+    if (!target_parent->insertItem(std::move(taken), p_impl->target_tagrow))
         throw std::runtime_error("MoveItemCommand::execute() -> Can't insert item.");
 
     // adjusting new addresses

--- a/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/moveitemcommand.cpp
@@ -68,7 +68,7 @@ void MoveItemCommand::undo_command()
 
     // then make manipulations
     auto taken = current_parent->takeItem(p_impl->target_tagrow);
-    target_parent->insertItem(taken, p_impl->original_tagrow);
+    target_parent->insertItem(std::move(taken), p_impl->original_tagrow);
 
     // adjusting new addresses
     p_impl->target_parent_path = pathFromItem(current_parent);
@@ -87,7 +87,7 @@ void MoveItemCommand::execute_command()
     if (!taken)
         throw std::runtime_error("MoveItemCommand::execute() -> Can't take an item.");
 
-    bool succeeded = target_parent->insertItem(taken, p_impl->target_tagrow);
+    bool succeeded = target_parent->insertItem(std::move(taken), p_impl->target_tagrow);
     if (!succeeded)
         throw std::runtime_error("MoveItemCommand::execute() -> Can't insert item.");
 

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
@@ -43,8 +43,7 @@ RemoveItemCommand::~RemoveItemCommand() = default;
 void RemoveItemCommand::undo_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
-    auto reco_item = p_impl->backup_strategy->restoreItem();
-    parent->insertItem(reco_item.release(), p_impl->tagrow);
+    parent->insertItem(p_impl->backup_strategy->restoreItem(), p_impl->tagrow);
 }
 
 void RemoveItemCommand::execute_command()

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
@@ -50,8 +50,7 @@ void RemoveItemCommand::execute_command()
 {
     auto parent = itemFromPath(p_impl->item_path);
     if (auto child = parent->takeItem(p_impl->tagrow); child) {
-        p_impl->backup_strategy->saveItem(child);
-        delete child;
+        p_impl->backup_strategy->saveItem(child.get());
         setResult(true);
     }
     else {

--- a/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
+++ b/source/libmvvm_model/mvvm/commands/removeitemcommand.cpp
@@ -52,8 +52,7 @@ void RemoveItemCommand::execute_command()
     if (auto child = parent->takeItem(p_impl->tagrow); child) {
         p_impl->backup_strategy->saveItem(child.get());
         setResult(true);
-    }
-    else {
+    } else {
         setResult(false);
         setObsolete(true);
     }

--- a/source/libmvvm_model/mvvm/model/compounditem.h
+++ b/source/libmvvm_model/mvvm/model/compounditem.h
@@ -24,9 +24,10 @@ class MVVM_MODEL_EXPORT CompoundItem : public SessionItem {
 public:
     CompoundItem(const std::string& modelType = Constants::CompoundItemType);
 
-    //! Adds property item of given type.
+    //! Adds property item of given type and register it under the given 'name'.
     template <typename T = PropertyItem> T* addProperty(const std::string& name);
 
+    //! Adds PropertyItem and sets its value to 'value'.
     template <typename V> PropertyItem* addProperty(const std::string& name, const V& value);
 
     //! Register char property. Special case to turn it into std::string.
@@ -45,21 +46,19 @@ template <typename T> T* CompoundItem::addProperty(const std::string& name)
 
 inline PropertyItem* CompoundItem::addProperty(const std::string& name, const char* value)
 {
+    // Consider merging with the method ::addProperty(const std::string& name, const V& value).
+    // Currently it is not possible because of QVariant dependency. It converts 'const char*'
+    // to QString, and we want std::string.
     return addProperty(name, std::string(value));
 }
 
 template <typename V>
 PropertyItem* CompoundItem::addProperty(const std::string& name, const V& value)
 {
-    auto property = new PropertyItem;
-    registerTag(TagInfo::propertyTag(name, property->modelType()));
-    property->setDisplayName(name);
+    auto property = addProperty<PropertyItem>(name);
     property->setData(value);
-
     if constexpr (std::is_floating_point_v<V>)
         property->setData(RealLimits::limitless(), ItemDataRole::LIMITS);
-
-    insertItem(property, {name, 0});
     return property;
 }
 

--- a/source/libmvvm_model/mvvm/model/compounditem.h
+++ b/source/libmvvm_model/mvvm/model/compounditem.h
@@ -37,11 +37,10 @@ public:
 
 template <typename T> T* CompoundItem::addProperty(const std::string& name)
 {
-    T* property = new T;
+    auto property = std::make_unique<T>();
     registerTag(TagInfo::propertyTag(name, property->modelType()));
     property->setDisplayName(name);
-    insertItem(property, {name, 0});
-    return property;
+    return static_cast<T*>(insertItem(std::move(property), {name, 0}));
 }
 
 inline PropertyItem* CompoundItem::addProperty(const std::string& name, const char* value)

--- a/source/libmvvm_model/mvvm/model/compounditem.h
+++ b/source/libmvvm_model/mvvm/model/compounditem.h
@@ -37,10 +37,10 @@ public:
 
 template <typename T> T* CompoundItem::addProperty(const std::string& name)
 {
-    auto property = std::make_unique<T>();
-    registerTag(TagInfo::propertyTag(name, property->modelType()));
-    property->setDisplayName(name);
-    return static_cast<T*>(insertItem(std::move(property), {name, 0}));
+    registerTag(TagInfo::propertyTag(name, T().modelType()));
+    auto result = insertItem<T>({name, 0});
+    result->setDisplayName(name);
+    return result;
 }
 
 inline PropertyItem* CompoundItem::addProperty(const std::string& name, const char* value)

--- a/source/libmvvm_model/mvvm/model/groupitem.cpp
+++ b/source/libmvvm_model/mvvm/model/groupitem.cpp
@@ -18,7 +18,7 @@ using namespace ModelView;
 namespace {
 
 //! Returns vector of model types for given vector of items.
-std::vector<std::string> modelTypes(const std::vector<SessionItem*> items)
+std::vector<std::string> modelTypes(const std::vector<SessionItem*>& items)
 {
     std::vector<std::string> result;
     std::transform(items.begin(), items.end(), std::back_inserter(result),
@@ -29,9 +29,7 @@ std::vector<std::string> modelTypes(const std::vector<SessionItem*> items)
 
 GroupItem::~GroupItem() = default;
 
-GroupItem::GroupItem(model_type modelType)
-    : SessionItem(std::move(modelType))
-    , m_index_to_select(0)
+GroupItem::GroupItem(model_type modelType) : SessionItem(std::move(modelType)), m_index_to_select(0)
 {
     registerTag(TagInfo::universalTag(T_GROUP_ITEMS), /*set_as_default*/ true);
     setData(ComboProperty());
@@ -46,7 +44,7 @@ int GroupItem::currentIndex() const
 
 const SessionItem* GroupItem::currentItem() const
 {
-    return isValidIndex() ? getItem("", currentIndex()) : nullptr;
+    return currentIndex() != -1 ? getItem("", currentIndex()) : nullptr;
 }
 
 SessionItem* GroupItem::currentItem()
@@ -67,7 +65,6 @@ void GroupItem::setCurrentType(const std::string& model_type)
     if (index == -1)
         throw std::runtime_error("GroupItem::setCurrentType() -> Model type '" + model_type
                                  + "' doesn't belong to the group");
-
     setCurrentIndex(index);
 }
 
@@ -76,11 +73,6 @@ void GroupItem::setCurrentIndex(int index)
     auto combo = data<ComboProperty>();
     combo.setCurrentIndex(index);
     setData(combo, ItemDataRole::DATA);
-}
-
-bool GroupItem::isValidIndex() const
-{
-    return currentIndex() != -1;
 }
 
 //! Updates internal data representing selection of items, and current selection.

--- a/source/libmvvm_model/mvvm/model/groupitem.h
+++ b/source/libmvvm_model/mvvm/model/groupitem.h
@@ -51,7 +51,7 @@ template <typename T> void GroupItem::addToGroup(const std::string& text, bool m
     auto item = std::make_unique<T>();
     std::string item_text = text.empty() ? item->modelType() : text;
     m_item_text.push_back(item_text);
-    insertItem(item.release(), TagRow::append(T_GROUP_ITEMS));
+    insertItem(std::move(item), TagRow::append(T_GROUP_ITEMS));
     if (make_selected)
         m_index_to_select = m_item_text.size() - 1;
 

--- a/source/libmvvm_model/mvvm/model/groupitem.h
+++ b/source/libmvvm_model/mvvm/model/groupitem.h
@@ -35,7 +35,6 @@ public:
 protected:
     GroupItem(model_type modelType);
     void setCurrentIndex(int index);
-    bool isValidIndex() const;
     template <typename T> void addToGroup(const std::string& text = {}, bool make_selected = false);
     void updateCombo();
 
@@ -48,13 +47,10 @@ protected:
 //! @param make_selected defines whether the item should be selected by default.
 template <typename T> void GroupItem::addToGroup(const std::string& text, bool make_selected)
 {
-    auto item = std::make_unique<T>();
-    std::string item_text = text.empty() ? item->modelType() : text;
-    m_item_text.push_back(item_text);
-    insertItem(std::move(item), TagRow::append(T_GROUP_ITEMS));
+    m_item_text.push_back(text.empty() ? T().modelType() : text);
+    insertItem<T>(TagRow::append(T_GROUP_ITEMS));
     if (make_selected)
         m_index_to_select = m_item_text.size() - 1;
-
     updateCombo();
 }
 

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -241,11 +241,12 @@ bool SessionItem::insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& 
 }
 
 //! Removes item from given row from given tag, returns it to the caller.
+//! Ownership is granted to the caller.
 
-SessionItem* SessionItem::takeItem(const TagRow& tagrow)
+std::unique_ptr<SessionItem> SessionItem::takeItem(const TagRow& tagrow)
 {
     if (!p_impl->m_tags->canTakeItem(tagrow))
-        return nullptr;
+        return {};
 
     if (p_impl->m_model)
         p_impl->m_model->mapper()->callOnItemAboutToBeRemoved(this, tagrow);
@@ -257,7 +258,7 @@ SessionItem* SessionItem::takeItem(const TagRow& tagrow)
     if (p_impl->m_model)
         p_impl->m_model->mapper()->callOnItemRemoved(this, tagrow);
 
-    return result;
+    return std::unique_ptr<SessionItem>(result);
 }
 
 //! Returns true if this item has `editable` flag set.

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -220,32 +220,32 @@ bool SessionItem::insertItem(SessionItem* item, const TagRow& tagrow)
 //! Insert item into given tag under the given row. Will take ownership of inserted item.
 //! Returns back a pointer to the same item for convenience.
 
-SessionItem* SessionItem::insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow)
+SessionItem* SessionItem::insertItem(std::unique_ptr<SessionItem> item, const TagRow& tagrow)
 {
-    auto item = p_item.release();
+    auto p_item = item.release();
 
-    if (!item)
+    if (!p_item)
         throw std::runtime_error("SessionItem::insertItem() -> Invalid item.");
 
-    if (item->parent())
+    if (p_item->parent())
         throw std::runtime_error("SessionItem::insertItem() -> Existing parent.");
 
-    if (item->model())
+    if (p_item->model())
         throw std::runtime_error("SessionItem::insertItem() -> Existing model.");
 
-    auto result = p_impl->m_tags->insertItem(item, tagrow);
+    auto result = p_impl->m_tags->insertItem(p_item, tagrow);
     if (result) {
-        item->setParent(this);
-        item->setModel(model());
+        p_item->setParent(this);
+        p_item->setModel(model());
 
         if (p_impl->m_model) {
             // FIXME think of actual_tagrow removal if input tag,row will be always valid
-            auto actual_tagrow = tagRowOfItem(item);
+            auto actual_tagrow = tagRowOfItem(p_item);
             p_impl->m_model->mapper()->callOnItemInserted(this, actual_tagrow);
         }
     }
 
-    return result ? item : nullptr;
+    return result ? p_item : nullptr;
 }
 
 //! Removes item from given row from given tag, returns it to the caller.

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -212,7 +212,10 @@ bool SessionItem::insertItem(SessionItem* item, const TagRow& tagrow)
     return insertItem(std::unique_ptr<SessionItem>(item), tagrow);
 }
 
-bool SessionItem::insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow)
+//! Insert item into given tag under the given row. Will take ownership of inserted item.
+//! Returns back a pointer to the same item for convenience.
+
+SessionItem* SessionItem::insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow)
 {
     auto item = p_item.release();
 
@@ -237,7 +240,7 @@ bool SessionItem::insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& 
         }
     }
 
-    return result;
+    return result ? item : nullptr;
 }
 
 //! Removes item from given row from given tag, returns it to the caller.

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -209,7 +209,12 @@ SessionItemTags* SessionItem::itemTags()
 
 bool SessionItem::insertItem(SessionItem* item, const TagRow& tagrow)
 {
-    // think of passing unique_ptr directly
+    return insertItem(std::unique_ptr<SessionItem>(item), tagrow);
+}
+
+bool SessionItem::insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow)
+{
+    auto item = p_item.release();
 
     if (!item)
         throw std::runtime_error("SessionItem::insertItem() -> Invalid item.");

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -209,7 +209,10 @@ SessionItemTags* SessionItem::itemTags()
 
 bool SessionItem::insertItem(SessionItem* item, const TagRow& tagrow)
 {
+//    if (!p_impl->m_tags->canInsertItem(item, tagrow))
+//        return false;
     return insertItem(std::unique_ptr<SessionItem>(item), tagrow);
+//    return true;
 }
 
 //! Insert item into given tag under the given row. Will take ownership of inserted item.

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -234,6 +234,9 @@ SessionItem* SessionItem::insertItem(std::unique_ptr<SessionItem> item, const Ta
         throw std::runtime_error("SessionItem::insertItem() -> Existing model.");
 
     auto result = p_impl->m_tags->insertItem(p_item, tagrow);
+    if (!result)
+        throw std::runtime_error("SessionItem::insertItem() -> Can't insert item.");
+
     if (result) {
         p_item->setParent(this);
         p_item->setModel(model());

--- a/source/libmvvm_model/mvvm/model/sessionitem.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitem.cpp
@@ -205,14 +205,16 @@ SessionItemTags* SessionItem::itemTags()
     return const_cast<SessionItemTags*>(static_cast<const SessionItem*>(this)->itemTags());
 }
 
-//! Insert item into given tag under the given row.
+//! Inserts the item into the given tag under the given row.
+//! Returns 'true' in the case of success, take ownership over the item.
+//! If an item can't be inserted for a given TagRow (i.e. when the container is full, or not
+//! intended for items of a given type) will return false and will not take ownership.
 
 bool SessionItem::insertItem(SessionItem* item, const TagRow& tagrow)
 {
-//    if (!p_impl->m_tags->canInsertItem(item, tagrow))
-//        return false;
-    return insertItem(std::unique_ptr<SessionItem>(item), tagrow);
-//    return true;
+    if (!p_impl->m_tags->canInsertItem(item, tagrow))
+        return false;
+    return insertItem(std::unique_ptr<SessionItem>(item), tagrow) != nullptr;
 }
 
 //! Insert item into given tag under the given row. Will take ownership of inserted item.

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -92,7 +92,7 @@ public:
 
     bool insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
 
-    SessionItem* takeItem(const TagRow& tagrow);
+    std::unique_ptr<SessionItem> takeItem(const TagRow& tagrow);
 
     // more convenience methods
 

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -90,6 +90,8 @@ public:
 
     bool insertItem(SessionItem* item, const TagRow& tagrow);
 
+    bool insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
+
     SessionItem* takeItem(const TagRow& tagrow);
 
     // more convenience methods

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -90,7 +90,7 @@ public:
 
     bool insertItem(SessionItem* item, const TagRow& tagrow);
 
-    bool insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
+    SessionItem *insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
 
     std::unique_ptr<SessionItem> takeItem(const TagRow& tagrow);
 

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -90,7 +90,7 @@ public:
 
     bool insertItem(SessionItem* item, const TagRow& tagrow);
 
-    SessionItem* insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
+    SessionItem* insertItem(std::unique_ptr<SessionItem> item, const TagRow& tagrow);
     template <typename T = SessionItem> T* insertItem(const TagRow& tagrow);
 
     std::unique_ptr<SessionItem> takeItem(const TagRow& tagrow);

--- a/source/libmvvm_model/mvvm/model/sessionitem.h
+++ b/source/libmvvm_model/mvvm/model/sessionitem.h
@@ -90,7 +90,8 @@ public:
 
     bool insertItem(SessionItem* item, const TagRow& tagrow);
 
-    SessionItem *insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
+    SessionItem* insertItem(std::unique_ptr<SessionItem> p_item, const TagRow& tagrow);
+    template <typename T = SessionItem> T* insertItem(const TagRow& tagrow);
 
     std::unique_ptr<SessionItem> takeItem(const TagRow& tagrow);
 
@@ -173,6 +174,14 @@ template <typename T> std::vector<T*> SessionItem::items(const std::string& tag)
         if (auto casted = dynamic_cast<T*>(item); casted)
             result.push_back(casted);
     return result;
+}
+
+//! Creates a new item and insert it into given tag under the given row.
+//! Returns pointer to inserted item to the user.
+
+template <typename T> inline T* SessionItem::insertItem(const TagRow& tagrow)
+{
+    return static_cast<T*>(insertItem(std::make_unique<T>(), tagrow));
 }
 
 //! Returns data stored in property item.

--- a/source/libmvvm_model/mvvm/model/sessionitemtags.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitemtags.cpp
@@ -63,7 +63,10 @@ int SessionItemTags::itemCount(const std::string& tag_name) const
 
 bool SessionItemTags::canInsertItem(const SessionItem* item, const TagRow &tagrow) const
 {
-    return container(tagrow.tag)->canInsertItem(item, tagrow.row);
+    auto tag_container = container(tagrow.tag);
+    // negative row means appending to the vector
+    auto row = tagrow.row < 0 ? tag_container->itemCount() : tagrow.row;
+    return container(tagrow.tag)->canInsertItem(item, row);
 }
 
 //! Inserts item in container with given tag name and at given row.
@@ -72,6 +75,7 @@ bool SessionItemTags::canInsertItem(const SessionItem* item, const TagRow &tagro
 bool SessionItemTags::insertItem(SessionItem* item, const TagRow& tagrow)
 {
     auto tag_container = container(tagrow.tag);
+    // negative row means appending to the vector
     auto row = tagrow.row < 0 ? tag_container->itemCount() : tagrow.row;
     return container(tagrow.tag)->insertItem(item, row);
 }

--- a/source/libmvvm_model/mvvm/model/sessionitemtags.cpp
+++ b/source/libmvvm_model/mvvm/model/sessionitemtags.cpp
@@ -59,6 +59,13 @@ int SessionItemTags::itemCount(const std::string& tag_name) const
     return container(tag_name)->itemCount();
 }
 
+//! Returns true if item can be inserted.
+
+bool SessionItemTags::canInsertItem(const SessionItem* item, const TagRow &tagrow) const
+{
+    return container(tagrow.tag)->canInsertItem(item, tagrow.row);
+}
+
 //! Inserts item in container with given tag name and at given row.
 //! Returns true in the case of success. If tag name is empty, default tag will be used.
 
@@ -69,18 +76,18 @@ bool SessionItemTags::insertItem(SessionItem* item, const TagRow& tagrow)
     return container(tagrow.tag)->insertItem(item, row);
 }
 
-//! Removes item at given row and for given tag, returns it to the user.
-
-SessionItem* SessionItemTags::takeItem(const TagRow& tagrow)
-{
-    return container(tagrow.tag)->takeItem(tagrow.row);
-}
-
 //! Returns true if item can be taken.
 
 bool SessionItemTags::canTakeItem(const TagRow& tagrow) const
 {
     return container(tagrow.tag)->canTakeItem(tagrow.row);
+}
+
+//! Removes item at given row and for given tag, returns it to the user.
+
+SessionItem* SessionItemTags::takeItem(const TagRow& tagrow)
+{
+    return container(tagrow.tag)->takeItem(tagrow.row);
 }
 
 //! Returns item at given row of given tag.

--- a/source/libmvvm_model/mvvm/model/sessionitemtags.h
+++ b/source/libmvvm_model/mvvm/model/sessionitemtags.h
@@ -47,11 +47,13 @@ public:
 
     // adding and removal
 
+    bool canInsertItem(const SessionItem *item, const TagRow& tagrow) const;
+
     bool insertItem(SessionItem* item, const TagRow& tagrow);
 
-    SessionItem* takeItem(const TagRow& tagrow);
-
     bool canTakeItem(const TagRow& tagrow) const;
+
+    SessionItem* takeItem(const TagRow& tagrow);
 
     // item access
     SessionItem* getItem(const TagRow& tagrow) const;

--- a/source/libmvvm_model/mvvm/model/tagrow.h
+++ b/source/libmvvm_model/mvvm/model/tagrow.h
@@ -16,6 +16,7 @@
 namespace ModelView {
 
 //! Aggregate to hold (tag, row) information for SessionModel.
+//! row=-1 is a special value for appending to the end of the in the SessionIteTags context.
 
 class MVVM_MODEL_EXPORT TagRow {
 public:

--- a/source/libmvvm_model/mvvm/serialization/jsonmodelconverter.cpp
+++ b/source/libmvvm_model/mvvm/serialization/jsonmodelconverter.cpp
@@ -80,8 +80,7 @@ void JsonModelConverter::from_json(const QJsonObject& json, SessionModel& model)
 
     auto rebuild_root = [&json, &itemConverter](auto parent) {
         for (const auto ref : json[JsonItemFormatAssistant::itemsKey].toArray()) {
-            auto item = itemConverter->from_json(ref.toObject());
-            parent->insertItem(item.release(), TagRow::append());
+            parent->insertItem(itemConverter->from_json(ref.toObject()), TagRow::append());
         }
     };
     model.clear(rebuild_root);

--- a/source/libmvvm_model/mvvm/standarditems/data1ditem.h
+++ b/source/libmvvm_model/mvvm/standarditems/data1ditem.h
@@ -52,15 +52,8 @@ template <typename T, typename... Args> T* Data1DItem::setAxis(Args&&... args)
     if (getItem(T_AXIS, 0))
         throw std::runtime_error("Axis was already set. Currently we do not support axis change");
 
-    T* result{nullptr};
-    if (model()) {
-        // acting through the model to enable undo/redo
-        result = model()->insertItem<T>(this);
-    }
-    else {
-        result = new T;
-        insertItem(result, {T_AXIS, 0});
-    }
+    // acting through the model, if model exists, to enable undo/redo
+    auto result = model() ? model()->insertItem<T>(this) : insertItem<T>({T_AXIS, 0});
     result->setParameters(std::forward<Args>(args)...);
     setValues(std::vector<double>(result->size(), 0.0));
     return result;

--- a/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
@@ -76,7 +76,7 @@ void Data2DItem::insert_axis(std::unique_ptr<BinnedAxisItem> axis, const std::st
 {
     // removing current axis
     if (getItem(tag, 0))
-        delete takeItem({tag, 0});
+        takeItem({tag, 0});
 
     insertItem(std::move(axis), {tag, 0});
 }

--- a/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
+++ b/source/libmvvm_model/mvvm/standarditems/data2ditem.cpp
@@ -78,5 +78,5 @@ void Data2DItem::insert_axis(std::unique_ptr<BinnedAxisItem> axis, const std::st
     if (getItem(tag, 0))
         delete takeItem({tag, 0});
 
-    insertItem(axis.release(), {tag, 0});
+    insertItem(std::move(axis), {tag, 0});
 }

--- a/tests/testmodel/compounditem.test.cpp
+++ b/tests/testmodel/compounditem.test.cpp
@@ -180,9 +180,7 @@ TEST_F(CompoundItemTest, itemAccess)
     parent.registerTag(TagInfo::universalTag(tag));
 
     // inserting two children
-    auto property = new PropertyItem;
-    parent.insertItem(property, {tag, 0});
-
+    auto property = parent.insertItem<PropertyItem>({tag, 0});
     EXPECT_TRUE(parent.item<PropertyItem>(tag) == property);
     EXPECT_THROW(parent.item<CompoundItem>(tag), std::runtime_error);
 }
@@ -196,10 +194,8 @@ TEST_F(CompoundItemTest, itemVectorAccess)
     parent.registerTag(TagInfo::universalTag(tag));
 
     // inserting two children
-    auto property1 = new PropertyItem;
-    auto property2 = new PropertyItem;
-    parent.insertItem(property1, TagRow::append(tag));
-    parent.insertItem(property2, TagRow::append(tag));
+    auto property1 = parent.insertItem<PropertyItem>(TagRow::append(tag));
+    auto property2 = parent.insertItem<PropertyItem>(TagRow::append(tag));
 
     auto items = parent.items<PropertyItem>(tag);
     std::vector<PropertyItem*> expected = {property1, property2};
@@ -218,10 +214,8 @@ TEST_F(CompoundItemTest, displayNameIndexAddition)
     parent.registerTag(TagInfo::universalTag(tag));
 
     // inserting two children
-    auto child0 = new CompoundItem;
-    parent.insertItem(child0, TagRow::append(tag));
-    auto child1 = new CompoundItem;
-    parent.insertItem(child1, TagRow::append(tag));
+    auto child0 = parent.insertItem<CompoundItem>(TagRow::append(tag));
+    auto child1 = parent.insertItem<CompoundItem>(TagRow::append(tag));
 
     // Default display names of items of the same type should have indices
     EXPECT_EQ(child0->displayName(), Constants::CompoundItemType + "0");

--- a/tests/testmodel/containeritem.test.cpp
+++ b/tests/testmodel/containeritem.test.cpp
@@ -29,11 +29,7 @@ TEST_F(ContainerItemTest, initialState)
 TEST_F(ContainerItemTest, isEmpty)
 {
     ContainerItem item;
-
-    // inserting two children
-    auto property = new PropertyItem;
-    item.insertItem(property, {"", 0});
-
+    item.insertItem<PropertyItem>({"", 0});
     EXPECT_EQ(item.size(), 1);
     EXPECT_FALSE(item.empty());
 }

--- a/tests/testmodel/copyitemcommand.test.cpp
+++ b/tests/testmodel/copyitemcommand.test.cpp
@@ -70,11 +70,13 @@ TEST_F(CopyItemCommandTest, invalidCopyAttempt)
 
     // making copy of child
     auto command = std::make_unique<CopyItemCommand>(child0, parent, TagRow{"thickness", 0});
-    command->execute();
+    EXPECT_THROW(command->execute(), std::runtime_error);
 
     // checking that parent has now three children
-    EXPECT_TRUE(command->isObsolete());
-    EXPECT_EQ(std::get<SessionItem*>(command->result()), nullptr);
+    // FIXME revise command behavior in the case of invalid operation
+    // Exception or catch?
+    // EXPECT_TRUE(command->isObsolete());
+//    EXPECT_EQ(std::get<SessionItem*>(command->result()), nullptr);
 
     // undoing of obsolete command is not possible
     EXPECT_THROW(command->undo(), std::runtime_error);

--- a/tests/testmodel/itemutils.test.cpp
+++ b/tests/testmodel/itemutils.test.cpp
@@ -43,10 +43,8 @@ TEST_F(ItemUtilsTest, iterateItem)
     EXPECT_EQ(visited_items, expected);
 
     // adding children
-    auto child1 = new SessionItem;
-    auto child2 = new SessionItem;
-    parent->insertItem(child1, TagRow::append());
-    parent->insertItem(child2, TagRow::append());
+    auto child1 = parent->insertItem<SessionItem>(TagRow::append());
+    auto child2 = parent->insertItem<SessionItem>(TagRow::append());
 
     visited_items.clear();
     Utils::iterate(parent.get(), fun);
@@ -71,10 +69,8 @@ TEST_F(ItemUtilsTest, iterateIfItem)
     std::unique_ptr<SessionItem> parent(new SessionItem);
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
-    auto child1 = new SessionItem;
-    auto child2 = new SessionItem;
-    parent->insertItem(child1, TagRow::append());
-    parent->insertItem(child2, TagRow::append());
+    parent->insertItem<SessionItem>(TagRow::append());
+    parent->insertItem<SessionItem>(TagRow::append());
 
     std::vector<const SessionItem*> expected = {parent.get()};
     Utils::iterate_if(parent.get(), fun);

--- a/tests/testmodel/jsonitembackupstrategy.test.cpp
+++ b/tests/testmodel/jsonitembackupstrategy.test.cpp
@@ -80,9 +80,9 @@ TEST_F(JsonItemBackupStrategyTest, customItem)
     auto parent = std::make_unique<SessionItem>(model_type);
     parent->setDisplayName("parent_name");
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    auto child = new SessionItem(model_type);
+
+    auto child = parent->insertItem(std::make_unique<SessionItem>(model_type), TagRow::append());
     child->setDisplayName("child_name");
-    parent->insertItem(child, TagRow::append());
 
     // creating copy
     strategy->saveItem(parent.get());

--- a/tests/testmodel/jsonitemconverter.test.cpp
+++ b/tests/testmodel/jsonitemconverter.test.cpp
@@ -128,9 +128,8 @@ TEST_F(JsonItemConverterTest, parentAndChildToJsonAndBack)
     auto parent = std::make_unique<SessionItem>(model_type);
     parent->setDisplayName("parent_name");
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    auto child = new SessionItem(model_type);
+    auto child = parent->insertItem(std::make_unique<SessionItem>(model_type), TagRow::append());
     child->setDisplayName("child_name");
-    parent->insertItem(child, TagRow::append());
 
     // converting to json
     auto object = converter->to_json(parent.get());
@@ -168,9 +167,8 @@ TEST_F(JsonItemConverterTest, parentAndChildToFileAndBack)
     auto parent = std::make_unique<SessionItem>(model_type);
     parent->setDisplayName("parent_name");
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    auto child = new SessionItem(model_type);
+    auto child = parent->insertItem(std::make_unique<SessionItem>(model_type), TagRow::append());
     child->setDisplayName("child_name");
-    parent->insertItem(child, TagRow::append());
 
     // converting to json
     auto object = converter->to_json(parent.get());

--- a/tests/testmodel/jsonitemcopystrategy.test.cpp
+++ b/tests/testmodel/jsonitemcopystrategy.test.cpp
@@ -78,9 +78,8 @@ TEST_F(JsonItemCopyStrategyTest, customItem)
     auto parent = std::make_unique<SessionItem>(model_type);
     parent->setDisplayName("parent_name");
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
-    auto child = new SessionItem(model_type);
+    auto child = parent->insertItem(std::make_unique<SessionItem>(model_type), TagRow::append());
     child->setDisplayName("child_name");
-    parent->insertItem(child, TagRow::append());
 
     // creating copy
     auto parent_copy = strategy->createCopy(parent.get());

--- a/tests/testmodel/modelmapper.test.cpp
+++ b/tests/testmodel/modelmapper.test.cpp
@@ -217,6 +217,6 @@ TEST(ModelMapperTest, onClearRebuild)
     EXPECT_CALL(*widget, onModelAboutToBeReset(_)).Times(1);
     EXPECT_CALL(*widget, onModelReset(model.get())).Times(1);
 
-    auto rebuild = [](auto item) { item->insertItem(new SessionItem, TagRow::append()); };
+    auto rebuild = [](auto item) { item->insertItem(TagRow::append()); };
     model->clear(rebuild);
 }

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -352,8 +352,6 @@ TEST_F(SessionItemTest, takeItem)
     EXPECT_EQ(taken->parent(), nullptr);
     std::vector<SessionItem*> expected = {child2, child3};
     EXPECT_EQ(parent->children(), expected);
-
-    delete taken;
 }
 
 //! Insert and take tagged items.
@@ -389,10 +387,10 @@ TEST_F(SessionItemTest, singleTagAndItems)
     EXPECT_EQ(parent->getItems(tag1), expected);
 
     // removing first item
-    delete parent->takeItem({tag1, 0});
+    parent->takeItem({tag1, 0});
     EXPECT_EQ(parent->getItems(tag1), std::vector<SessionItem*>() = {child2});
     // removing second item
-    delete parent->takeItem({tag1, 0});
+    parent->takeItem({tag1, 0});
     EXPECT_EQ(parent->getItems(tag1), std::vector<SessionItem*>() = {});
 
     // removing from already empty container
@@ -450,7 +448,7 @@ TEST_F(SessionItemTest, twoTagsAndItems)
     EXPECT_EQ(parent->getItems(tag2), expected);
 
     // removing item from the middle of tag2
-    delete parent->takeItem({tag2, 1});
+    parent->takeItem({tag2, 1});
     expected = {child_t1_a, child_t1_b};
     EXPECT_EQ(parent->getItems(tag1), expected);
     expected = {child_t2_a, child_t2_c};
@@ -480,7 +478,7 @@ TEST_F(SessionItemTest, tagWithLimits)
     EXPECT_FALSE(parent->insertItem(extra, {tag1, -1}));
 
     // removing first element
-    delete parent->takeItem({tag1, 0});
+    parent->takeItem({tag1, 0});
     expected.erase(expected.begin());
     EXPECT_EQ(parent->getItems(tag1), expected);
 

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -466,72 +466,73 @@ TEST_F(SessionItemTest, twoTagsAndItems)
 }
 
 //! Inserting and removing items when tag has limits.
+//! FIXME restore
 
-TEST_F(SessionItemTest, tagWithLimits)
-{
-    const std::string tag1 = "tag1";
-    const int maxItems = 3;
-    auto parent = std::make_unique<SessionItem>();
-    parent->registerTag(TagInfo(tag1, 0, maxItems, std::vector<std::string>() = {}));
+// TEST_F(SessionItemTest, tagWithLimits)
+//{
+//    const std::string tag1 = "tag1";
+//    const int maxItems = 3;
+//    auto parent = std::make_unique<SessionItem>();
+//    parent->registerTag(TagInfo(tag1, 0, maxItems, std::vector<std::string>() = {}));
 
-    // placing maximu allowed number of items
-    std::vector<SessionItem*> expected;
-    for (int i = 0; i < maxItems; ++i) {
-        auto child = new SessionItem;
-        expected.push_back(child);
-        EXPECT_TRUE(parent->insertItem(child, {tag1, -1}));
-    }
-    EXPECT_EQ(parent->getItems(tag1), expected);
+//    // placing maximu allowed number of items
+//    std::vector<SessionItem*> expected;
+//    for (int i = 0; i < maxItems; ++i) {
+//        auto child = new SessionItem;
+//        expected.push_back(child);
+//        EXPECT_TRUE(parent->insertItem(child, {tag1, -1}));
+//    }
+//    EXPECT_EQ(parent->getItems(tag1), expected);
 
-    // no room for extra item
-    auto extra = new SessionItem;
-    EXPECT_FALSE(parent->insertItem(extra, {tag1, -1}));
+//    // no room for extra item
+//    auto extra = new SessionItem;
+//    EXPECT_FALSE(parent->insertItem(extra, {tag1, -1}));
 
-    // removing first element
-    parent->takeItem({tag1, 0});
-    expected.erase(expected.begin());
-    EXPECT_EQ(parent->getItems(tag1), expected);
+//    // removing first element
+//    parent->takeItem({tag1, 0});
+//    expected.erase(expected.begin());
+//    EXPECT_EQ(parent->getItems(tag1), expected);
 
-    // adding extra item
-    parent->insertItem(extra, {tag1, -1});
-    expected.push_back(extra);
-    EXPECT_EQ(parent->getItems(tag1), expected);
-}
+//    // adding extra item
+//    parent->insertItem(extra, {tag1, -1});
+//    expected.push_back(extra);
+//    EXPECT_EQ(parent->getItems(tag1), expected);
+//}
 
 //! Inserting and removing items when tag has limits.
+// FIXME restore
+//TEST_F(SessionItemTest, tagModelTypes)
+//{
+//    const std::string tag1 = "tag1";
+//    const std::string tag2 = "tag2";
+//    const std::string modelType1 = "ModelType1";
+//    const std::string modelType2 = "ModelType2";
+//    const std::string modelType3 = "ModelType3";
+//    const std::string modelType4 = "ModelType4";
 
-TEST_F(SessionItemTest, tagModelTypes)
-{
-    const std::string tag1 = "tag1";
-    const std::string tag2 = "tag2";
-    const std::string modelType1 = "ModelType1";
-    const std::string modelType2 = "ModelType2";
-    const std::string modelType3 = "ModelType3";
-    const std::string modelType4 = "ModelType4";
+//    auto parent = std::make_unique<SessionItem>();
+//    parent->registerTag(
+//        TagInfo(tag1, 0, -1, std::vector<std::string>() = {modelType1, modelType2}));
+//    parent->registerTag(TagInfo(tag2, 0, -1, std::vector<std::string>() = {modelType3}));
 
-    auto parent = std::make_unique<SessionItem>();
-    parent->registerTag(
-        TagInfo(tag1, 0, -1, std::vector<std::string>() = {modelType1, modelType2}));
-    parent->registerTag(TagInfo(tag2, 0, -1, std::vector<std::string>() = {modelType3}));
+//    auto item1 = new SessionItem(modelType1);
+//    auto item2 = new SessionItem(modelType2);
+//    auto item3 = new SessionItem(modelType3);
 
-    auto item1 = new SessionItem(modelType1);
-    auto item2 = new SessionItem(modelType2);
-    auto item3 = new SessionItem(modelType3);
+//    // attempt to add item not intended for tag
+//    EXPECT_FALSE(parent->insertItem(item1, {tag2, -1}));
+//    EXPECT_FALSE(parent->insertItem(item3, {tag1, -1}));
 
-    // attempt to add item not intended for tag
-    EXPECT_FALSE(parent->insertItem(item1, {tag2, -1}));
-    EXPECT_FALSE(parent->insertItem(item3, {tag1, -1}));
+//    // normal insert to appropriate tag
+//    parent->insertItem(item3, {tag2, -1});
+//    parent->insertItem(item1, {tag1, -1});
+//    parent->insertItem(item2, {tag1, -1});
 
-    // normal insert to appropriate tag
-    parent->insertItem(item3, {tag2, -1});
-    parent->insertItem(item1, {tag1, -1});
-    parent->insertItem(item2, {tag1, -1});
-
-    std::vector<SessionItem*> expected = {item1, item2};
-    EXPECT_EQ(parent->getItems(tag1), expected);
-    expected = {item3};
-    EXPECT_EQ(parent->getItems(tag2), expected);
-}
+//    std::vector<SessionItem*> expected = {item1, item2};
+//    EXPECT_EQ(parent->getItems(tag1), expected);
+//    expected = {item3};
+//    EXPECT_EQ(parent->getItems(tag2), expected);
+//}
 
 //! Testing method ::tag.
 
@@ -546,16 +547,11 @@ TEST_F(SessionItemTest, tag)
     parent->registerTag(TagInfo::universalTag(tag2));
 
     // inserting two children
-    auto child_t1_a = new SessionItem;
-    auto child_t1_b = new SessionItem;
-    auto child_t2_a = new SessionItem;
-    auto child_t2_b = new SessionItem;
-    auto child_t2_c = new SessionItem;
-    parent->insertItem(child_t2_a, {tag2, -1});
-    parent->insertItem(child_t2_c, {tag2, -1});
-    parent->insertItem(child_t1_a, {tag1, -1});
-    parent->insertItem(child_t1_b, {tag1, -1});
-    parent->insertItem(child_t2_b, {tag2, 1}); // between child_t2_a and child_t2_c
+    auto child_t2_a = parent->insertItem({tag2, -1});
+    auto child_t2_c = parent->insertItem({tag2, -1});
+    auto child_t1_a = parent->insertItem({tag1, -1});
+    auto child_t1_b = parent->insertItem({tag1, -1});
+    auto child_t2_b = parent->insertItem({tag2, 1}); // between child_t2_a and child_t2_c
 
     EXPECT_EQ(child_t1_a->tagRow().tag, "tag1");
     EXPECT_EQ(child_t1_b->tagRow().tag, "tag1");
@@ -580,16 +576,11 @@ TEST_F(SessionItemTest, tagRow)
     parent->registerTag(TagInfo::universalTag(tag2));
 
     // inserting two children
-    auto child_t1_a = new SessionItem;
-    auto child_t1_b = new SessionItem;
-    auto child_t2_a = new SessionItem;
-    auto child_t2_b = new SessionItem;
-    auto child_t2_c = new SessionItem;
-    parent->insertItem(child_t2_a, {tag2, -1}); // 0
-    parent->insertItem(child_t2_c, {tag2, -1}); // 2
-    parent->insertItem(child_t1_a, {tag1, -1}); // 0
-    parent->insertItem(child_t1_b, {tag1, -1}); // 1
-    parent->insertItem(child_t2_b, {tag2, 1});  // 1 between child_t2_a and child_t2_c
+    auto child_t2_a = parent->insertItem({tag2, -1}); // 0
+    auto child_t2_c = parent->insertItem({tag2, -1}); // 2
+    auto child_t1_a = parent->insertItem({tag1, -1}); // 0
+    auto child_t1_b = parent->insertItem({tag1, -1}); // 1
+    auto child_t2_b = parent->insertItem({tag2, 1});  // 1 between child_t2_a and child_t2_c
 
     EXPECT_EQ(child_t1_a->tagRow().row, 0);
     EXPECT_EQ(child_t1_b->tagRow().row, 1);
@@ -617,16 +608,11 @@ TEST_F(SessionItemTest, tagRowOfItem)
     parent->registerTag(TagInfo::universalTag(tag2));
 
     // inserting two children
-    auto child_t1_a = new SessionItem;
-    auto child_t1_b = new SessionItem;
-    auto child_t2_a = new SessionItem;
-    auto child_t2_b = new SessionItem;
-    auto child_t2_c = new SessionItem;
-    parent->insertItem(child_t2_a, {tag2, -1}); // 0
-    parent->insertItem(child_t2_c, {tag2, -1}); // 2
-    parent->insertItem(child_t1_a, {tag1, -1}); // 0
-    parent->insertItem(child_t1_b, {tag1, -1}); // 1
-    parent->insertItem(child_t2_b, {tag2, 1});  // 1 between child_t2_a and child_t2_c
+    auto child_t2_a = parent->insertItem({tag2, -1}); // 0
+    auto child_t2_c = parent->insertItem({tag2, -1}); // 2
+    auto child_t1_a = parent->insertItem({tag1, -1}); // 0
+    auto child_t1_b = parent->insertItem({tag1, -1}); // 1
+    auto child_t2_b = parent->insertItem({tag2, 1});  // 1 between child_t2_a and child_t2_c
 
     EXPECT_EQ(parent->tagRowOfItem(child_t1_a).row, 0);
     EXPECT_EQ(parent->tagRowOfItem(child_t1_b).row, 1);
@@ -718,12 +704,9 @@ TEST_F(SessionItemTest, itemsInTag)
     parent->registerTag(TagInfo::universalTag(tag2));
 
     // inserting two children
-    auto child_t1_a = new SessionItem;
-    auto child_t2_a = new SessionItem;
-    auto child_t2_b = new SessionItem;
-    parent->insertItem(child_t1_a, {tag1, -1});
-    parent->insertItem(child_t2_a, {tag2, -1});
-    parent->insertItem(child_t2_b, {tag2, -1});
+    parent->insertItem({tag1, -1});
+    parent->insertItem({tag2, -1});
+    parent->insertItem({tag2, -1});
 
     EXPECT_EQ(parent->itemCount(tag1), 1);
     EXPECT_EQ(parent->itemCount(tag2), 2);

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -343,9 +343,9 @@ TEST_F(SessionItemTest, insertChildren)
                  std::runtime_error);
 
     // attempt to insert item using out of scope index
-    // FIXME revise behaviour
     auto child5 = std::make_unique<SessionItem>();
-    EXPECT_FALSE(parent->insertItem(std::move(child5), {"", parent->childrenCount() + 1}));
+    EXPECT_THROW(parent->insertItem(std::move(child5), {"", parent->childrenCount() + 1}),
+                 std::runtime_error);
 }
 
 //! Removing (taking) item from parent.
@@ -467,7 +467,7 @@ TEST_F(SessionItemTest, twoTagsAndItems)
 
 //! Inserting and removing items when tag has limits.
 
- TEST_F(SessionItemTest, tagWithLimits)
+TEST_F(SessionItemTest, tagWithLimits)
 {
     const std::string tag1 = "tag1";
     const int maxItems = 3;

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -12,6 +12,7 @@
 #include "google_test.h"
 #include "mvvm/model/itempool.h"
 #include "mvvm/model/itemutils.h"
+#include "mvvm/model/propertyitem.h"
 #include "mvvm/model/sessionitemdata.h"
 #include "mvvm/model/sessionitemtags.h"
 #include "mvvm/model/taginfo.h"
@@ -273,6 +274,31 @@ TEST_F(SessionItemTest, insertItem)
     EXPECT_EQ(parent->children()[0], inserted);
     EXPECT_EQ(parent->getItem("", 0), inserted);
     EXPECT_EQ(inserted->parent(), parent.get());
+}
+
+//! Simple child insert.
+
+TEST_F(SessionItemTest, insertItemTemplated)
+{
+    auto parent = std::make_unique<SessionItem>();
+    parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
+
+    // inserting child
+    auto inserted = parent->insertItem({"", 0});
+    EXPECT_EQ(parent->childrenCount(), 1);
+    EXPECT_EQ(Utils::IndexOfChild(parent.get(), inserted), 0);
+    EXPECT_EQ(parent->children()[0], inserted);
+    EXPECT_EQ(parent->getItem("", 0), inserted);
+    EXPECT_EQ(inserted->parent(), parent.get());
+
+    // inserting property item
+    auto property = parent->insertItem<PropertyItem>({"", 1});
+    EXPECT_EQ(parent->childrenCount(), 2);
+    EXPECT_EQ(Utils::IndexOfChild(parent.get(), property), 1);
+    EXPECT_EQ(parent->children()[1], property);
+    EXPECT_EQ(parent->getItem("", 1), property);
+    EXPECT_EQ(property->parent(), parent.get());
+
 }
 
 //! Simple children insert.

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -466,73 +466,71 @@ TEST_F(SessionItemTest, twoTagsAndItems)
 }
 
 //! Inserting and removing items when tag has limits.
-//! FIXME restore
 
-// TEST_F(SessionItemTest, tagWithLimits)
-//{
-//    const std::string tag1 = "tag1";
-//    const int maxItems = 3;
-//    auto parent = std::make_unique<SessionItem>();
-//    parent->registerTag(TagInfo(tag1, 0, maxItems, std::vector<std::string>() = {}));
+ TEST_F(SessionItemTest, tagWithLimits)
+{
+    const std::string tag1 = "tag1";
+    const int maxItems = 3;
+    auto parent = std::make_unique<SessionItem>();
+    parent->registerTag(TagInfo(tag1, 0, maxItems, std::vector<std::string>() = {}));
 
-//    // placing maximu allowed number of items
-//    std::vector<SessionItem*> expected;
-//    for (int i = 0; i < maxItems; ++i) {
-//        auto child = new SessionItem;
-//        expected.push_back(child);
-//        EXPECT_TRUE(parent->insertItem(child, {tag1, -1}));
-//    }
-//    EXPECT_EQ(parent->getItems(tag1), expected);
+    // placing maximu allowed number of items
+    std::vector<SessionItem*> expected;
+    for (int i = 0; i < maxItems; ++i) {
+        auto child = new SessionItem;
+        expected.push_back(child);
+        EXPECT_TRUE(parent->insertItem(child, {tag1, -1}));
+    }
+    EXPECT_EQ(parent->getItems(tag1), expected);
 
-//    // no room for extra item
-//    auto extra = new SessionItem;
-//    EXPECT_FALSE(parent->insertItem(extra, {tag1, -1}));
+    // no room for extra item
+    auto extra = new SessionItem;
+    EXPECT_FALSE(parent->insertItem(extra, {tag1, -1}));
 
-//    // removing first element
-//    parent->takeItem({tag1, 0});
-//    expected.erase(expected.begin());
-//    EXPECT_EQ(parent->getItems(tag1), expected);
+    // removing first element
+    parent->takeItem({tag1, 0});
+    expected.erase(expected.begin());
+    EXPECT_EQ(parent->getItems(tag1), expected);
 
-//    // adding extra item
-//    parent->insertItem(extra, {tag1, -1});
-//    expected.push_back(extra);
-//    EXPECT_EQ(parent->getItems(tag1), expected);
-//}
+    // adding extra item
+    parent->insertItem(extra, {tag1, -1});
+    expected.push_back(extra);
+    EXPECT_EQ(parent->getItems(tag1), expected);
+}
 
 //! Inserting and removing items when tag has limits.
-// FIXME restore
-//TEST_F(SessionItemTest, tagModelTypes)
-//{
-//    const std::string tag1 = "tag1";
-//    const std::string tag2 = "tag2";
-//    const std::string modelType1 = "ModelType1";
-//    const std::string modelType2 = "ModelType2";
-//    const std::string modelType3 = "ModelType3";
-//    const std::string modelType4 = "ModelType4";
+TEST_F(SessionItemTest, tagModelTypes)
+{
+    const std::string tag1 = "tag1";
+    const std::string tag2 = "tag2";
+    const std::string modelType1 = "ModelType1";
+    const std::string modelType2 = "ModelType2";
+    const std::string modelType3 = "ModelType3";
+    const std::string modelType4 = "ModelType4";
 
-//    auto parent = std::make_unique<SessionItem>();
-//    parent->registerTag(
-//        TagInfo(tag1, 0, -1, std::vector<std::string>() = {modelType1, modelType2}));
-//    parent->registerTag(TagInfo(tag2, 0, -1, std::vector<std::string>() = {modelType3}));
+    auto parent = std::make_unique<SessionItem>();
+    parent->registerTag(
+        TagInfo(tag1, 0, -1, std::vector<std::string>() = {modelType1, modelType2}));
+    parent->registerTag(TagInfo(tag2, 0, -1, std::vector<std::string>() = {modelType3}));
 
-//    auto item1 = new SessionItem(modelType1);
-//    auto item2 = new SessionItem(modelType2);
-//    auto item3 = new SessionItem(modelType3);
+    auto item1 = new SessionItem(modelType1);
+    auto item2 = new SessionItem(modelType2);
+    auto item3 = new SessionItem(modelType3);
 
-//    // attempt to add item not intended for tag
-//    EXPECT_FALSE(parent->insertItem(item1, {tag2, -1}));
-//    EXPECT_FALSE(parent->insertItem(item3, {tag1, -1}));
+    // attempt to add item not intended for tag
+    EXPECT_FALSE(parent->insertItem(item1, {tag2, -1}));
+    EXPECT_FALSE(parent->insertItem(item3, {tag1, -1}));
 
-//    // normal insert to appropriate tag
-//    parent->insertItem(item3, {tag2, -1});
-//    parent->insertItem(item1, {tag1, -1});
-//    parent->insertItem(item2, {tag1, -1});
+    // normal insert to appropriate tag
+    parent->insertItem(item3, {tag2, -1});
+    parent->insertItem(item1, {tag1, -1});
+    parent->insertItem(item2, {tag1, -1});
 
-//    std::vector<SessionItem*> expected = {item1, item2};
-//    EXPECT_EQ(parent->getItems(tag1), expected);
-//    expected = {item3};
-//    EXPECT_EQ(parent->getItems(tag2), expected);
-//}
+    std::vector<SessionItem*> expected = {item1, item2};
+    EXPECT_EQ(parent->getItems(tag1), expected);
+    expected = {item3};
+    EXPECT_EQ(parent->getItems(tag2), expected);
+}
 
 //! Testing method ::tag.
 

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -254,7 +254,8 @@ TEST_F(SessionItemTest, insertItem)
     auto parent = std::make_unique<SessionItem>();
     parent->registerTag(TagInfo::universalTag("defaultTag"), /*set_as_default*/ true);
 
-    std::unique_ptr<SessionItem> child(new SessionItem);
+    auto child = std::make_unique<SessionItem>();
+    auto p_child = child.get();
 
     // empty parent
     EXPECT_EQ(parent->childrenCount(), 0);
@@ -265,13 +266,13 @@ TEST_F(SessionItemTest, insertItem)
     EXPECT_EQ(parent->getItem("", 10), nullptr);
 
     // inserting child
-    auto p_child = child.release();
-    parent->insertItem(p_child, {"", 0});
+    auto inserted = parent->insertItem(std::move(child), {"", 0});
+    EXPECT_EQ(inserted, p_child);
     EXPECT_EQ(parent->childrenCount(), 1);
-    EXPECT_EQ(Utils::IndexOfChild(parent.get(), p_child), 0);
-    EXPECT_EQ(parent->children()[0], p_child);
-    EXPECT_EQ(parent->getItem("", 0), p_child);
-    EXPECT_EQ(p_child->parent(), parent.get());
+    EXPECT_EQ(Utils::IndexOfChild(parent.get(), inserted), 0);
+    EXPECT_EQ(parent->children()[0], inserted);
+    EXPECT_EQ(parent->getItem("", 0), inserted);
+    EXPECT_EQ(inserted->parent(), parent.get());
 }
 
 //! Simple children insert.

--- a/tests/testmodel/sessionitemcontainer.test.cpp
+++ b/tests/testmodel/sessionitemcontainer.test.cpp
@@ -277,6 +277,37 @@ TEST_F(SessionItemContainerTest, canInsertItemForPropertyTag)
     EXPECT_FALSE(tag.canInsertItem(child2.get(), 0));
 }
 
+//! Checking ::canInsertItem.
+
+TEST_F(SessionItemContainerTest, canInsertItemForUniversalTag)
+{
+    const std::string tag1 = "tag1";
+    const int maxItems = 2;
+    auto parent = std::make_unique<SessionItem>();
+    SessionItemContainer tag(TagInfo(tag1, 0, maxItems, std::vector<std::string>() = {}));
+
+    // inserting child
+    auto child1 = std::make_unique<SessionItem>();
+    EXPECT_FALSE(tag.canInsertItem(child1.get(), -1)); // implementation requires exact index
+    EXPECT_TRUE(tag.canInsertItem(child1.get(), 0));
+    EXPECT_TRUE(tag.canInsertItem(child1.get(), tag.itemCount()));
+    EXPECT_TRUE(tag.insertItem(child1.release(), tag.itemCount()));
+
+    // inserting second child
+    auto child2 = std::make_unique<SessionItem>();
+    EXPECT_FALSE(tag.canInsertItem(child2.get(), -1));
+    EXPECT_TRUE(tag.canInsertItem(child2.get(), 0));
+    EXPECT_TRUE(tag.canInsertItem(child2.get(), tag.itemCount()));
+    EXPECT_TRUE(tag.insertItem(child2.release(), tag.itemCount()));
+
+    // inserting third child is not possible
+    auto child3 = std::make_unique<SessionItem>();
+    EXPECT_FALSE(tag.canInsertItem(child3.get(), -1));
+    EXPECT_FALSE(tag.canInsertItem(child3.get(), 0));
+    EXPECT_FALSE(tag.canInsertItem(child3.get(), tag.itemCount()));
+}
+
+
 //! Checking ::takeItem when tag is related to property tag.
 
 TEST_F(SessionItemContainerTest, takeItemPropertyType)

--- a/tests/testmodel/sessionitemcontainer.test.cpp
+++ b/tests/testmodel/sessionitemcontainer.test.cpp
@@ -44,8 +44,8 @@ TEST_F(SessionItemContainerTest, insertItem)
     EXPECT_EQ(tag.itemCount(), 0);
 
     // insertion at the end
-    SessionItem* child1 = new SessionItem;
-    SessionItem* child2 = new SessionItem;
+    auto child1 = new SessionItem;
+    auto child2 = new SessionItem;
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_TRUE(tag.insertItem(child2, tag.itemCount()));
     EXPECT_EQ(tag.itemCount(), 2);
@@ -54,25 +54,25 @@ TEST_F(SessionItemContainerTest, insertItem)
     EXPECT_EQ(tag.items(), expected);
 
     // insertion at the beginning
-    SessionItem* child3 = new SessionItem;
+    auto child3 = new SessionItem;
     EXPECT_TRUE(tag.insertItem(child3, 0));
     expected = {child3, child1, child2};
     EXPECT_EQ(tag.items(), expected);
 
     // insertion in between
-    SessionItem* child4 = new SessionItem;
+    auto child4 = new SessionItem;
     EXPECT_TRUE(tag.insertItem(child4, 1));
     expected = {child3, child4, child1, child2};
     EXPECT_EQ(tag.items(), expected);
 
     // using index equal to number of items
-    SessionItem* child5 = new SessionItem;
+    auto child5 = new SessionItem;
     EXPECT_TRUE(tag.insertItem(child5, tag.itemCount()));
     expected = {child3, child4, child1, child2, child5};
     EXPECT_EQ(tag.items(), expected);
 
     // insertion with wrong index
-    SessionItem* child6 = new SessionItem;
+    auto child6 = new SessionItem;
     EXPECT_FALSE(tag.insertItem(child6, 42));
     EXPECT_EQ(tag.items(), expected);
     delete child6;
@@ -88,8 +88,8 @@ TEST_F(SessionItemContainerTest, insertItemModelType)
     SessionItemContainer tag(TagInfo::universalTag(tag_name, model_types));
 
     // insertion of wrong model type is not allowed
-    SessionItem* child1 = new SessionItem("model_a");
-    SessionItem* child2 = new SessionItem("model_b");
+    auto child1 = new SessionItem("model_a");
+    auto child2 = new SessionItem("model_b");
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_FALSE(tag.insertItem(child2, tag.itemCount()));
     delete child2;
@@ -108,14 +108,14 @@ TEST_F(SessionItemContainerTest, insertItemPropertyType)
     SessionItemContainer tag(TagInfo::propertyTag(name, property_type));
 
     // insertion of second property item is not allowed (because of reached maximum)
-    SessionItem* child1 = new SessionItem(property_type);
-    SessionItem* child2 = new SessionItem(property_type);
+    auto child1 = new SessionItem(property_type);
+    auto child2 = new SessionItem(property_type);
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_FALSE(tag.insertItem(child2, tag.itemCount()));
     delete child2;
 
     // insertion of wrong model type is not allowed
-    SessionItem* child3 = new SessionItem("another_model");
+    auto child3 = new SessionItem("another_model");
     EXPECT_FALSE(tag.insertItem(child3, tag.itemCount()));
     delete child3;
     std::vector<SessionItem*> expected = {child1};
@@ -132,8 +132,8 @@ TEST_F(SessionItemContainerTest, indexOfItem)
     SessionItemContainer tag(TagInfo::universalTag(tag_name));
 
     // index of two items
-    SessionItem* child1 = new SessionItem(model_type);
-    SessionItem* child2 = new SessionItem(model_type);
+    auto child1 = new SessionItem(model_type);
+    auto child2 = new SessionItem(model_type);
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_EQ(tag.indexOfItem(child1), 0);
     EXPECT_TRUE(tag.insertItem(child2, tag.itemCount()));
@@ -156,8 +156,8 @@ TEST_F(SessionItemContainerTest, itemAt)
     SessionItemContainer tag(TagInfo::universalTag(tag_name));
 
     // items at given indices
-    SessionItem* child1 = new SessionItem(model_type);
-    SessionItem* child2 = new SessionItem(model_type);
+    auto child1 = new SessionItem(model_type);
+    auto child2 = new SessionItem(model_type);
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_TRUE(tag.insertItem(child2, tag.itemCount()));
     EXPECT_EQ(tag.itemAt(0), child1);
@@ -182,9 +182,9 @@ TEST_F(SessionItemContainerTest, takeItem)
     EXPECT_EQ(tag.takeItem(0), nullptr);
 
     // inserting items
-    SessionItem* child1 = new SessionItem(model_type);
-    SessionItem* child2 = new SessionItem(model_type);
-    SessionItem* child3 = new SessionItem(model_type);
+    auto child1 = new SessionItem(model_type);
+    auto child2 = new SessionItem(model_type);
+    auto child3 = new SessionItem(model_type);
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_TRUE(tag.insertItem(child2, tag.itemCount()));
     EXPECT_TRUE(tag.insertItem(child3, tag.itemCount()));
@@ -216,7 +216,7 @@ TEST_F(SessionItemContainerTest, canTakeItem)
     EXPECT_FALSE(tag.canTakeItem(0));
 
     // inserting items
-    SessionItem* child1 = new SessionItem(model_type);
+    auto child1 = new SessionItem(model_type);
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
     EXPECT_TRUE(tag.canTakeItem(0));
 
@@ -287,7 +287,7 @@ TEST_F(SessionItemContainerTest, takeItemPropertyType)
     SessionItemContainer tag(TagInfo::propertyTag(name, property_type));
 
     // insertion of second property item is not allowed (because of reached maximum)
-    SessionItem* child1 = new SessionItem(property_type);
+    auto child1 = new SessionItem(property_type);
     EXPECT_TRUE(tag.insertItem(child1, tag.itemCount()));
 
     // attempt to take property item

--- a/tests/testmodel/sessionitemtags.test.cpp
+++ b/tests/testmodel/sessionitemtags.test.cpp
@@ -68,6 +68,33 @@ TEST_F(SessionItemTagsTest, canInsertItem)
     EXPECT_FALSE(tag.canInsertItem(item.get(), {"tag2", 0}));
 }
 
+//! Testing ::canInsertItem.
+
+TEST_F(SessionItemTagsTest, canInsertItemForUniversalTag)
+{
+    SessionItemTags tag;
+    const std::string tagname = "tag1";
+    const int maxItems = 2;
+    tag.registerTag(TagInfo(tagname, 0, maxItems, std::vector<std::string>() = {}));
+
+    auto child1 = std::make_unique<SessionItem>();
+    EXPECT_TRUE(tag.canInsertItem(child1.get(), {tagname, 0}));
+    EXPECT_TRUE(tag.canInsertItem(child1.get(), {tagname, -1}));
+    EXPECT_TRUE(tag.canInsertItem(child1.get(), {tagname, tag.itemCount(tagname)}));
+    EXPECT_TRUE(tag.insertItem(child1.release(), {tagname, -1}));
+
+    // inserting second child
+    auto child2 = std::make_unique<SessionItem>();
+    EXPECT_TRUE(tag.canInsertItem(child2.get(), {tagname, 0}));
+    EXPECT_TRUE(tag.canInsertItem(child2.get(), {tagname, -1}));
+    EXPECT_TRUE(tag.canInsertItem(child2.get(), {tagname, tag.itemCount(tagname)}));
+    EXPECT_TRUE(tag.insertItem(child2.release(), {tagname, -1}));
+
+    // inserting third child is not possible
+    auto child3 = std::make_unique<SessionItem>();
+    EXPECT_FALSE(tag.canInsertItem(child3.get(), {tagname, -1}));
+}
+
 //! Insert item.
 
 TEST_F(SessionItemTagsTest, insertItem)

--- a/tests/testmodel/sessionitemtags.test.cpp
+++ b/tests/testmodel/sessionitemtags.test.cpp
@@ -55,6 +55,19 @@ TEST_F(SessionItemTagsTest, registerTag)
     EXPECT_THROW(tag.registerTag(TagInfo::universalTag("abc")), std::runtime_error);
 }
 
+//! Testing ::canInsertItem.
+
+TEST_F(SessionItemTagsTest, canInsertItem)
+{
+    SessionItemTags tag;
+    tag.registerTag(TagInfo::universalTag("tag1"));
+    tag.registerTag(TagInfo::propertyTag("tag2", "Property"));
+
+    auto item = std::make_unique<SessionItem>();
+    EXPECT_TRUE(tag.canInsertItem(item.get(), {"tag1", 0}));
+    EXPECT_FALSE(tag.canInsertItem(item.get(), {"tag2", 0}));
+}
+
 //! Insert item.
 
 TEST_F(SessionItemTagsTest, insertItem)

--- a/tests/testmodel/sessionmodel.test.cpp
+++ b/tests/testmodel/sessionmodel.test.cpp
@@ -266,8 +266,8 @@ TEST_F(SessionModelTest, clearRebuildModel)
     model.insertItem<SessionItem>();
     EXPECT_EQ(model.rootItem()->childrenCount(), 2);
 
-    auto new_item = new SessionItem;
-    auto rebuild = [new_item](auto parent) { parent->insertItem(new_item, TagRow::append()); };
+    SessionItem* new_item {nullptr};
+    auto rebuild = [&new_item](auto parent) { new_item = parent->insertItem(TagRow::append()); };
 
     model.clear(rebuild);
     EXPECT_EQ(model.rootItem()->childrenCount(), 1);

--- a/tests/testmodel/sessionmodel.test.cpp
+++ b/tests/testmodel/sessionmodel.test.cpp
@@ -356,9 +356,8 @@ TEST_F(SessionModelTest, forbiddenCopy)
     auto property = model.insertItem<PropertyItem>(parent0, "property");
 
     // copying property to same property tag is not allowed
-    auto copy = model.copyItem(property, parent0, {"property", -1});
+    EXPECT_THROW(model.copyItem(property, parent0, {"property", -1}), std::runtime_error);
     EXPECT_EQ(parent0->childrenCount(), 1);
-    EXPECT_EQ(copy, nullptr);
 }
 
 //! Test item find using identifier.

--- a/tests/testmodel/sessionmodel.test.cpp
+++ b/tests/testmodel/sessionmodel.test.cpp
@@ -69,13 +69,11 @@ TEST_F(SessionModelTest, insertItem)
 
     // taking child back
     auto taken = item->takeItem({"", 0});
-    EXPECT_EQ(taken, child);
+    EXPECT_EQ(taken.get(), child);
     EXPECT_EQ(child->model(), nullptr);
 
     // childitem not registered anymore
     EXPECT_EQ(pool->item_for_key(child_key), nullptr);
-
-    delete taken;
 }
 
 TEST_F(SessionModelTest, insertNewItem)
@@ -111,13 +109,11 @@ TEST_F(SessionModelTest, insertNewItem)
 
     // taking child back
     auto taken = item->takeItem({"", 0});
-    EXPECT_EQ(taken, child);
+    EXPECT_EQ(taken.get(), child);
     EXPECT_EQ(child->model(), nullptr);
 
     // childitem not registered anymore
     EXPECT_EQ(pool->item_for_key(child_key), nullptr);
-
-    delete taken;
 }
 
 TEST_F(SessionModelTest, insertNewItemWithTag)
@@ -211,7 +207,6 @@ TEST_F(SessionModelTest, takeRowFromRootItem)
     auto taken = model.rootItem()->takeItem({"", 0});
     EXPECT_EQ(pool->item_for_key(parent_key), nullptr);
     EXPECT_EQ(pool->item_for_key(child_key), nullptr);
-    delete taken;
 }
 
 TEST_F(SessionModelTest, moveItem)

--- a/tests/testviewmodel/standardchildrenstrategies.test.cpp
+++ b/tests/testviewmodel/standardchildrenstrategies.test.cpp
@@ -29,7 +29,7 @@ public:
         {
             addProperty("length", 8.0);
             registerTag(TagInfo::universalTag("children"), /*set_as_default*/ true);
-            insertItem(new SessionItem, TagRow::append());
+            insertItem<SessionItem>(TagRow::append());
             addProperty("height", 12.0);
         }
     };


### PR DESCRIPTION
Switch `SessionItem::insertItem` and `takeItem` to `unique_ptr` to stress ownership change.