### PR TITLE
Cmake fails to build using Qt6

### DIFF
--- a/.github/workflows/linux-build-coverage.yml
+++ b/.github/workflows/linux-build-coverage.yml
@@ -18,8 +18,7 @@ jobs:
     - name: setup dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake ccache \
-          cmake lcov qt5-default qttools5-dev libqt5svg5-dev qtdeclarative5-dev libx11-xcb1
+        sudo apt-get install -y build-essential cmake cmake-extras ccache qt6-base-dev qt6-tools-dev-tools libqt6svg6 qt6-declarative-dev libx11-xcb1 libxkbcommon-dev lcov
         
     - name: ccache timestamp
       id: ccache_cache_timestamp
@@ -46,8 +45,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE && pwd && ls
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DMVVM_SETUP_CODECOVERAGE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ../
+        cmake -DCMAKE_BUILD_TYPE=Debug -DMVVM_SETUP_CODECOVERAGE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ../
         make coverage -j4        
         
     - name: Uploading to codecov

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -18,8 +18,7 @@ jobs:
     - name: setup dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake ccache \
-          cmake qt5-default qttools5-dev libqt5svg5-dev qtdeclarative5-dev libx11-xcb1 libgtest-dev
+        sudo apt-get install -y build-essential cmake cmake-extras ccache qt6-base-dev qt6-tools-dev-tools libqt6svg6 qt6-declarative-dev libx11-xcb1 libxkbcommon-dev
         
     - name: ccache timestamp
       id: ccache_cache_timestamp
@@ -46,8 +45,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE && pwd && ls
         mkdir build && cd build
-        cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ../
+        cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ../
         make package_source
         make -j4        
         

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -17,8 +17,8 @@ jobs:
 
     - name: dependencies
       run: |
-        brew install cmake qt5 ccache
-        echo "Qt5 is installed to"
+        brew install cmake qt6 ccache
+        echo "Qt6 is installed to"
         echo $QTDIR
         
     - name: ccache timestamp

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -19,18 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: '5.15.2'
-        host: 'windows'
-        target: 'desktop'
-        arch: 'win64_msvc2019_64'
-        dir: '${{ github.workspace }}/qt5/'
-        mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
-        install-deps: 'true'
-        cached: 'false'
-
     - name: Download ccache and Ninja
       id: ccache
       shell: cmake -P {0}
@@ -57,7 +45,21 @@ jobs:
         key: qtmvvm-win-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
         restore-keys: |
           qtmvvm-win-ccache-
-          
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.10.3'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_msvc2022_64'
+        dir: '${{github.workspace}}/'
+        install-deps: 'false'
+        setup-python: 'false'
+        use-official: 'false'
+        cache: 'true'
+        cache-key-prefix: 'install-qt-action'
+
     - name: build
       shell: cmd
       env:
@@ -67,14 +69,14 @@ jobs:
         CCACHE_COMPRESSLEVEL: "6"
         CCACHE_MAXSIZE: "1000M"
       run: |
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
-        set QTDIR=${{github.workspace}}\qt5\Qt\5.15.2\msvc2019_64
+        call "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+        set QTDIR=${{github.workspace}}\Qt\6.10.3\msvc2022_64
         set PATH=${{github.workspace}};%QTDIR%\bin;%PATH%
         cd ${{github.workspace}}
         dir
         mkdir build
         cd build
-        cmake -G "Visual Studio 16 2019" -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
+        cmake -G "Visual Studio 17 2022" -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
         ccache -z
         ccache -p
         cmake --build . --config Release -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(qt-mvvm VERSION 0.2.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 option(MVVM_BUMP_VERSION "Propagate version number" OFF)
-option(MVVM_USE_QT6 "Compile with Qt6" OFF)
+option(MVVM_USE_QT6 "Compile with Qt6" ON)
 option(MVVM_DISCOVER_TESTS "Auto discover tests and add to ctest, otherwise will run at compile time" ON)
 option(MVVM_ENABLE_FILESYSTEM "Enable <filesystem> (requires modern compiler), otherwise rely on Qt" ON)
 option(MVVM_BUILD_EXAMPLES "Build user examples" ON)

--- a/cmake/scripts/MVVMConfig.cmake.in
+++ b/cmake/scripts/MVVMConfig.cmake.in
@@ -4,7 +4,7 @@
 get_filename_component(MVVM_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 include(CMakeFindDependencyMacro)
-find_dependency(Qt5 5.12 COMPONENTS Widgets REQUIRED)
+find_dependency(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 find_dependency(Threads)
 
 if(TARGET MVVM::Model OR TARGET MVVM::ViewModel OR TARGET MVVM::View)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qt-mvvm
 Maintainer: Gennady Pospelov <gennady.pospelov@gmail.com>
 Section: libs
 Priority: optional
-Build-Depends: debhelper-compat (= 11), debhelper (>= 11), libstdc++6, cmake, qtbase5-dev, qttools5-dev, pkgconf
+Build-Depends: debhelper-compat (= 11), debhelper (>= 11), libstdc++6, cmake, qtbase6-dev, qttools6-dev, pkgconf
 Rules-Requires-Root: no
 Standards-Version: 4.1.4
 Vcs-Browser: https://github.com/gpospelov/qt-mvvm
@@ -30,5 +30,5 @@ Architecture: any
 Section: libdevel
 Depends: ${shlibs:Depends},
          ${misc:Depends}
-Description: Development files for libmvvm-qt5
+Description: Development files for libmvvm-qt6
  Model-View-ViewModel framework for Qt based applications written in C++

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 export DH_VERBOSE=1
-export QT_SELECT=qt5
+export QT_SELECT=qt6
 
 %:
 	dh $@ 


### PR DESCRIPTION
https://github.com/gpospelov/qt-mvvm/issues/348

Due to a few references to Qt5 components in some of the project's CMake configuration files, e.g.
`find_dependency(Qt5 5.12 COMPONENTS Widgets REQUIRED)`
the build process fails when using Qt6.

```
  Could not find a package configuration file provided by "Qt5" (requested
  version 5.12) with any of the following names:

    Qt5.cps
    qt5.cps
    Qt5Config.cmake
    qt5-config.cmake
```
(Closes #348)