### PR TITLE
CI build fails due to googletest mismatch

### DIFF
--- a/cmake/modules/CodeTools.cmake
+++ b/cmake/modules/CodeTools.cmake
@@ -49,10 +49,8 @@ endfunction()
 # Fetches google test version 1.12.1
 function(fetch_googletest)
   include(FetchContent)
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850)
+  FetchContent_Declare(googletest GIT_REPOSITORY https://github.com/google/googletest.git GIT_TAG v1.17.0)
+
 FetchContent_MakeAvailable(googletest)
   message(VERBOSE "GTest binaries are present at ${googletest_BINARY_DIR}")
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,15 +1,6 @@
 enable_testing()
 
-find_package(GTest 1.10 QUIET CONFIG)
-if (NOT GTest_FOUND)
-  message(WARNING "GTest with version >= \"1.10\" was not found, fetching from internet" )
-  fetch_googletest()
-endif()
-find_package_message(
-  GTest_DETAILS
-  "Found GTest: ${GTest_DIR} (version \"${GTest_VERSION}\")"
-  "[${GTest_FOUND}][${GTest_DIR}][v${GTest_VERSION}]")
-
+fetch_googletest()
 include(GoogleTest)
 
 if(WIN32)


### PR DESCRIPTION
In case the googletest binaries are found (i.e. are pre-installed) on the build environment the build may fail due to mismatching setup.
(Closes #349)