### PR TITLE
CI build fails due to GitHub deprecated action versions

### DIFF
--- a/.github/workflows/linux-build-coverage.yml
+++ b/.github/workflows/linux-build-coverage.yml
@@ -6,14 +6,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 3
 
     steps:
-    - uses: actions/checkout@v2
-      with: 
-        submodules: true    
+    - uses: actions/checkout@v6.0.2
 
     - name: setup dependencies
       run: |
@@ -29,7 +27,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
         
     - name: ccache files
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v5.0.5
       with:
         path: .ccache
         key: qtmvvm-coverage-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 3
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
 
     - name: setup dependencies
       run: |
@@ -29,7 +29,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
         
     - name: ccache files
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v5.0.5
       with:
         path: .ccache
         key: qtmvvm-ubuntu-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -52,7 +52,7 @@ jobs:
         make -j4        
         
     - name: Upload tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v7.0.1
       if: success()
       with:
          name: qt-mvvm
@@ -67,7 +67,7 @@ jobs:
         ctest -j4
 
     - name: upload test logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v7.0.1
       if: failure()
       with:
          name: LastTest.log

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -13,12 +13,12 @@ jobs:
       max-parallel: 3
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
 
     - name: dependencies
       run: |
-        brew install cmake qt5 ccache
-        echo "Qt5 is installed to"
+        brew install cmake qt6 ccache
+        echo "Qt6 is installed to"
         echo $QTDIR
         
     - name: ccache timestamp
@@ -29,7 +29,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
         
     - name: ccache files
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v5.0.5
       with:
         path: .ccache
         key: qtmvvm-macos-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -67,7 +67,7 @@ jobs:
         ctest -j4
 
     - name: ctest output
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v7.0.1
       if: failure()
       with:
          name: LastTest.log

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 3
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6.0.2
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
@@ -51,7 +51,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
         
     - name: ccache files 
-      uses: actions/cache@v1.1.0
+      uses: actions/cache@v5.0.5
       with:
         path: .ccache
         key: qtmvvm-win-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}


### PR DESCRIPTION
The versions of various (GitHub) actions used on the CI workflows have been deprecated are are no longer available.
(Closes #352)