### PR TITLE
Windows CI build fails with 'MT_StaticRelease' doesn't match value 'MD_DynamicRelease'

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -76,7 +76,7 @@ jobs:
         dir
         mkdir build
         cd build
-        cmake -G "Visual Studio 17 2022" -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
+        cmake -G "Visual Studio 17 2022" -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
         ccache -z
         ccache -p
         cmake --build . --config Release -j4


### PR DESCRIPTION
Changed the target Microsoft Visual C++ (MSVC) runtime library to MultiThreaded (i.e. use a multi-threaded statically-linked runtime library).
(Closes #353)