### PR TITLE
Remove the installation of Ninja from the Windows (GitHub) CI workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -2,7 +2,6 @@ name: Windows
 
 env:
   CCACHE_VERSION: 3.7.7
-  NINJA_VERSION: 1.10.0
 
 on:
   push:
@@ -31,7 +30,7 @@ jobs:
         install-deps: 'true'
         cached: 'false'
 
-    - name: Download ccache and Ninja
+    - name: Download ccache
       id: ccache
       shell: cmake -P {0}
       run: |
@@ -39,10 +38,6 @@ jobs:
         file(DOWNLOAD "${ccache_url}" ./ccache.tar.xz SHOW_PROGRESS)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ccache.tar.xz)
         
-        set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v$ENV{NINJA_VERSION}/ninja-win.zip")
-        file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
-
     - name: ccache timestamp
       id: ccache_cache_timestamp
       shell: cmake -P {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ option(MVVM_BUILD_EXAMPLES "Build user examples" ON)
 option(MVVM_SETUP_CLANGFORMAT "Setups target to beautify the code with 'make clangformat'" OFF)
 option(MVVM_SETUP_CODECOVERAGE "Setups target to generate coverage information with 'make coverage'" OFF)
 
+find_program(NINJA_PROGRAM ninja)
+if(NINJA_PROGRAM)
+    message(STATUS "Found ninja: ${NINJA_PROGRAM}.")
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
 include(configuration)
 


### PR DESCRIPTION
Removed the download and install of Ninja from the windows-build workflow.
The (latest) version of Ninja is already installed in the respective (GitHub) Windows runner: https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
(Closes #355)