### PR TITLE
Update the required ccache version to 4.13.6 (the current release) on the (GitHub) Windows CI build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,7 +1,7 @@
 name: Windows
 
 env:
-  CCACHE_VERSION: 3.7.7
+  CCACHE_VERSION: 4.13.6
   NINJA_VERSION: 1.10.0
 
 on:
@@ -23,9 +23,9 @@ jobs:
       id: ccache
       shell: cmake -P {0}
       run: |
-        set(ccache_url "https://github.com/cristianadam/ccache/releases/download/v$ENV{CCACHE_VERSION}/${{ runner.os }}.tar.xz")
-        file(DOWNLOAD "${ccache_url}" ./ccache.tar.xz SHOW_PROGRESS)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ccache.tar.xz)
+        set(ccache_url "https://github.com/ccache/ccache/releases/download/v$ENV{CCACHE_VERSION}/ccache-$ENV{CCACHE_VERSION}-windows-x86_64.zip")
+        file(DOWNLOAD "${ccache_url}" ./ccache.zip SHOW_PROGRESS)
+        execute_process(COMMAND 7z e ccache.zip -bb3 -r ccache.exe)
         
         set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v$ENV{NINJA_VERSION}/ninja-win.zip")
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,19 @@ option(MVVM_BUILD_EXAMPLES "Build user examples" ON)
 option(MVVM_SETUP_CLANGFORMAT "Setups target to beautify the code with 'make clangformat'" OFF)
 option(MVVM_SETUP_CODECOVERAGE "Setups target to generate coverage information with 'make coverage'" OFF)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    message(STATUS "Found ccache: ${CCACHE_PROGRAM}.")
+endif()
+
+if(CMAKE_C_COMPILER_LAUNCHER)
+    message(STATUS "CMAKE_C_COMPILER_LAUNCHER set: ${CMAKE_C_COMPILER_LAUNCHER}.")
+endif()
+
+if(CMAKE_CXX_COMPILER_LAUNCHER)
+    message(STATUS "CMAKE_CXX_COMPILER_LAUNCHER set: ${CMAKE_CXX_COMPILER_LAUNCHER}.")
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
 include(configuration)
 


### PR DESCRIPTION
Updated the required ccache version to 4.13.6 (the current release) and changed the source repo to the official (https://github.com/ccache/ccache).
(Closes #357)