### PR TITLE
Warning C4756: overflow in constant arithmetic

### DIFF
--- a/tests/testintegration/toyitemsserialization.test.cpp
+++ b/tests/testintegration/toyitemsserialization.test.cpp
@@ -60,9 +60,9 @@ TEST_F(ToyItemsSerializationTest, modifiedShapeGroupItemInModel)
     // checking properties of
     EXPECT_EQ(groupCopy->currentIndex(), group->currentIndex());
     EXPECT_EQ(groupCopy->currentItem()->modelType(), group->currentItem()->modelType());
-    EXPECT_EQ(groupCopy->children().at(0)->property<double>(CylinderItem::P_RADIUS), 42.0);
-    EXPECT_EQ(groupCopy->children().at(1)->property<double>(SphereItem::P_RADIUS), 43.0);
-    EXPECT_EQ(groupCopy->children().at(2)->property<double>(AnysoPyramidItem::P_LENGTH), 44.0);
+    EXPECT_DOUBLE_EQ(groupCopy->children().at(0)->property<double>(CylinderItem::P_RADIUS), 42.0);
+    EXPECT_DOUBLE_EQ(groupCopy->children().at(1)->property<double>(SphereItem::P_RADIUS), 43.0);
+    EXPECT_DOUBLE_EQ(groupCopy->children().at(2)->property<double>(AnysoPyramidItem::P_LENGTH), 44.0);
 }
 
 //! Insert all supported items in a model and check that after serialization

--- a/tests/testintegration/toyitemsshapegroup.test.cpp
+++ b/tests/testintegration/toyitemsshapegroup.test.cpp
@@ -72,7 +72,7 @@ TEST_F(ToyItemsShapeGroupTest, currentItemNoConst)
 {
     ToyItems::ShapeGroupItem item;
     item.currentItem()->setProperty(ToyItems::SphereItem::P_RADIUS, 42.0);
-    EXPECT_EQ(item.currentItem()->property<double>(ToyItems::SphereItem::P_RADIUS), 42.0);
+    EXPECT_DOUBLE_EQ(item.currentItem()->property<double>(ToyItems::SphereItem::P_RADIUS), 42.0);
 }
 
 TEST_F(ToyItemsShapeGroupTest, inModelContext)

--- a/tests/testintegration/undoscenario.test.cpp
+++ b/tests/testintegration/undoscenario.test.cpp
@@ -36,8 +36,8 @@ TEST_F(UndoScenarioTest, undoViewportSetRange)
     controller.setItem(axisItem);
 
     // initial axis state
-    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot.xAxis->range().upper, 2.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().upper, 2.0);
 
     // enabling undo/redo, and  its initial state
     model.setUndoRedoEnabled(true);
@@ -53,8 +53,8 @@ TEST_F(UndoScenarioTest, undoViewportSetRange)
     EXPECT_TRUE(stack->canUndo());
     EXPECT_EQ(stack->index(), 1);
     EXPECT_EQ(stack->count(), 1);
-    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot.xAxis->range().upper, 20.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().upper, 20.0);
 
     // undoing
     stack->undo();
@@ -62,8 +62,8 @@ TEST_F(UndoScenarioTest, undoViewportSetRange)
     EXPECT_FALSE(stack->canUndo());
     EXPECT_EQ(stack->index(), 0);
     EXPECT_EQ(stack->count(), 1);
-    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot.xAxis->range().upper, 2.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().upper, 2.0);
 
     // redoing
     stack->redo();
@@ -71,6 +71,6 @@ TEST_F(UndoScenarioTest, undoViewportSetRange)
     EXPECT_TRUE(stack->canUndo());
     EXPECT_EQ(stack->index(), 1);
     EXPECT_EQ(stack->count(), 1);
-    EXPECT_EQ(custom_plot.xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot.xAxis->range().upper, 20.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot.xAxis->range().upper, 20.0);
 }

--- a/tests/testmodel/axisitems.test.cpp
+++ b/tests/testmodel/axisitems.test.cpp
@@ -23,8 +23,8 @@ class AxisItemsTest : public ::testing::Test {
 TEST_F(AxisItemsTest, viewportAxisInitialState)
 {
     ViewportAxisItem axis;
-    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MIN), 0.0);
-    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MAX), 1.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(ViewportAxisItem::P_MIN), 0.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(ViewportAxisItem::P_MAX), 1.0);
     EXPECT_FALSE(axis.property<bool>(ViewportAxisItem::P_IS_LOG));
 }
 
@@ -36,12 +36,12 @@ TEST_F(AxisItemsTest, viewportAxisSetRange)
 
     // default range
     auto [lower, upper] = axis.range();
-    EXPECT_EQ(lower, 0.0);
-    EXPECT_EQ(upper, 1.0);
+    EXPECT_DOUBLE_EQ(lower, 0.0);
+    EXPECT_DOUBLE_EQ(upper, 1.0);
 
     axis.set_range(1.0, 2.0);
-    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MIN), 1.0);
-    EXPECT_EQ(axis.property<double>(ViewportAxisItem::P_MAX), 2.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(ViewportAxisItem::P_MIN), 1.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(ViewportAxisItem::P_MAX), 2.0);
 }
 
 //! Factory method for FixedBinAxisItem.
@@ -49,14 +49,14 @@ TEST_F(AxisItemsTest, viewportAxisSetRange)
 TEST_F(AxisItemsTest, fixedBinAxisInitialState)
 {
     FixedBinAxisItem axis;
-    EXPECT_EQ(axis.property<double>(FixedBinAxisItem::P_MIN), 0.0);
-    EXPECT_EQ(axis.property<double>(FixedBinAxisItem::P_MAX), 1.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(FixedBinAxisItem::P_MIN), 0.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(FixedBinAxisItem::P_MAX), 1.0);
     EXPECT_EQ(axis.property<int>(FixedBinAxisItem::P_NBINS), 1);
     EXPECT_EQ(axis.binCenters(), std::vector<double>{0.5});
     EXPECT_EQ(axis.size(), 1);
     auto [lower, upper] = axis.range();
-    EXPECT_EQ(lower, 0.0);
-    EXPECT_EQ(upper, 1.0);
+    EXPECT_DOUBLE_EQ(lower, 0.0);
+    EXPECT_DOUBLE_EQ(upper, 1.0);
 }
 
 //! Factory method for FixedBinAxisItem.
@@ -67,8 +67,8 @@ TEST_F(AxisItemsTest, fixedBinAxisSetParameters)
     axis.setParameters(3, 1.0, 4.0);
 
     EXPECT_EQ(axis.property<int>(FixedBinAxisItem::P_NBINS), 3);
-    EXPECT_EQ(axis.property<double>(FixedBinAxisItem::P_MIN), 1.0);
-    EXPECT_EQ(axis.property<double>(FixedBinAxisItem::P_MAX), 4.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(FixedBinAxisItem::P_MIN), 1.0);
+    EXPECT_DOUBLE_EQ(axis.property<double>(FixedBinAxisItem::P_MAX), 4.0);
 
     std::vector<double> expected{1.5, 2.5, 3.5};
     EXPECT_EQ(axis.binCenters(), expected);
@@ -82,8 +82,8 @@ TEST_F(AxisItemsTest, fixedBinAxisFactory)
     auto axis = FixedBinAxisItem::create(3, 1.0, 4.0);
 
     EXPECT_EQ(axis->property<int>(FixedBinAxisItem::P_NBINS), 3);
-    EXPECT_EQ(axis->property<double>(FixedBinAxisItem::P_MIN), 1.0);
-    EXPECT_EQ(axis->property<double>(FixedBinAxisItem::P_MAX), 4.0);
+    EXPECT_DOUBLE_EQ(axis->property<double>(FixedBinAxisItem::P_MIN), 1.0);
+    EXPECT_DOUBLE_EQ(axis->property<double>(FixedBinAxisItem::P_MAX), 4.0);
 
     std::vector<double> expected{1.5, 2.5, 3.5};
     EXPECT_EQ(axis->binCenters(), expected);

--- a/tests/testmodel/compounditem.test.cpp
+++ b/tests/testmodel/compounditem.test.cpp
@@ -70,7 +70,7 @@ TEST_F(CompoundItemTest, addDoubleProperty)
     EXPECT_EQ(propertyItem->modelType(), Constants::PropertyType);
     EXPECT_TRUE(Utils::IsDoubleVariant(propertyItem->data<QVariant>()));
     EXPECT_EQ(propertyItem->displayName(), property_name);
-    EXPECT_EQ(propertyItem->data<double>(), expected);
+    EXPECT_DOUBLE_EQ(propertyItem->data<double>(), expected);
 
     EXPECT_TRUE(propertyItem->data<QVariant>(ItemDataRole::LIMITS).isValid());
 
@@ -88,8 +88,8 @@ TEST_F(CompoundItemTest, setDoubleProperty)
     const double expected = 42.0;
     item.setProperty(property_name, expected);
 
-    EXPECT_EQ(item.property<double>(property_name), expected);
-    EXPECT_EQ(propertyItem->data<double>(), expected);
+    EXPECT_DOUBLE_EQ(item.property<double>(property_name), expected);
+    EXPECT_DOUBLE_EQ(propertyItem->data<double>(), expected);
 }
 
 TEST_F(CompoundItemTest, addCharProperty)

--- a/tests/testmodel/copyitemcommand.test.cpp
+++ b/tests/testmodel/copyitemcommand.test.cpp
@@ -45,7 +45,7 @@ TEST_F(CopyItemCommandTest, copyChild)
     EXPECT_EQ(parent->childrenCount(), 3);
     std::vector<SessionItem*> expected = {child0, copy, child1};
     EXPECT_EQ(parent->getItems("tag1"), expected);
-    EXPECT_EQ(copy->data<double>(), 43.0);
+    EXPECT_DOUBLE_EQ(copy->data<double>(), 43.0);
 
     // undoing command
     command->undo();

--- a/tests/testmodel/groupitem.test.cpp
+++ b/tests/testmodel/groupitem.test.cpp
@@ -127,7 +127,7 @@ TEST_F(GroupItemTest, currentItemNoConst)
 {
     TestGroupItem item;
     item.currentItem()->setProperty("Radius", 42.0);
-    EXPECT_EQ(item.currentItem()->property<double>("Radius"), 42.0);
+    EXPECT_DOUBLE_EQ(item.currentItem()->property<double>("Radius"), 42.0);
 }
 
 TEST_F(GroupItemTest, inModelContext)

--- a/tests/testmodel/itemmapper.test.cpp
+++ b/tests/testmodel/itemmapper.test.cpp
@@ -166,8 +166,8 @@ TEST(ItemMapperTest, onPropertyChange)
 
     // perform action
     item->setProperty("height", 43.0);
-    EXPECT_EQ(item->property<double>("height"), 43.0);
-    EXPECT_EQ(property->data<double>(), 43.0);
+    EXPECT_DOUBLE_EQ(item->property<double>("height"), 43.0);
+    EXPECT_DOUBLE_EQ(property->data<double>(), 43.0);
 }
 
 //! Changing item property.
@@ -193,8 +193,8 @@ TEST(ItemMapperTest, onChildPropertyChange)
 
     // perform action
     compound2->setProperty("height", 43.0);
-    EXPECT_EQ(compound2->property<double>("height"), 43.0);
-    EXPECT_EQ(property->data<double>(), 43.0);
+    EXPECT_DOUBLE_EQ(compound2->property<double>("height"), 43.0);
+    EXPECT_DOUBLE_EQ(property->data<double>(), 43.0);
 }
 
 //! Inserting item to item.

--- a/tests/testmodel/jsonitembackupstrategy.test.cpp
+++ b/tests/testmodel/jsonitembackupstrategy.test.cpp
@@ -64,7 +64,7 @@ TEST_F(JsonItemBackupStrategyTest, compoundItem)
 
     EXPECT_EQ(item.modelType(), restored->modelType());
     EXPECT_EQ(item.identifier(), restored->identifier());
-    EXPECT_EQ(restored->getItem("thickness")->data<double>(), property->data<double>());
+    EXPECT_DOUBLE_EQ(restored->getItem("thickness")->data<double>(), property->data<double>());
     EXPECT_EQ(restored->getItem("thickness")->identifier(), property->identifier());
 }
 

--- a/tests/testmodel/jsonitemcopystrategy.test.cpp
+++ b/tests/testmodel/jsonitemcopystrategy.test.cpp
@@ -61,7 +61,7 @@ TEST_F(JsonItemCopyStrategyTest, compoundItem)
     auto copy = strategy->createCopy(&item);
 
     EXPECT_EQ(item.modelType(), copy->modelType());
-    EXPECT_EQ(copy->getItem("thickness")->data<double>(), property->data<double>());
+    EXPECT_DOUBLE_EQ(copy->getItem("thickness")->data<double>(), property->data<double>());
     EXPECT_FALSE(copy->getItem("thickness")->identifier() == property->identifier());
     EXPECT_FALSE(item.identifier() == copy->identifier());
 }

--- a/tests/testmodel/modelutils.test.cpp
+++ b/tests/testmodel/modelutils.test.cpp
@@ -80,7 +80,7 @@ TEST_F(ModelUtilsTest, CreateCopy)
 
     auto modelCopy = Utils::CreateCopy<ToyItems::SampleModel>(model);
     auto layerCopy = modelCopy->topItem<ToyItems::LayerItem>();
-    EXPECT_EQ(layerCopy->property<double>(ToyItems::LayerItem::P_THICKNESS), 42.0);
+    EXPECT_DOUBLE_EQ(layerCopy->property<double>(ToyItems::LayerItem::P_THICKNESS), 42.0);
 
     // Copied model has unique identifiers
     EXPECT_FALSE(model.rootItem()->identifier() == modelCopy->rootItem()->identifier());
@@ -95,7 +95,7 @@ TEST_F(ModelUtilsTest, CreateClone)
 
     auto modelCopy = Utils::CreateClone<ToyItems::SampleModel>(model);
     auto layerCopy = modelCopy->topItem<ToyItems::LayerItem>();
-    EXPECT_EQ(layerCopy->property<double>(ToyItems::LayerItem::P_THICKNESS), 42.0);
+    EXPECT_DOUBLE_EQ(layerCopy->property<double>(ToyItems::LayerItem::P_THICKNESS), 42.0);
 
     // Copied model has unique identifiers
     EXPECT_TRUE(layerCopy->identifier() == layer->identifier());

--- a/tests/testmodel/reallimits.test.cpp
+++ b/tests/testmodel/reallimits.test.cpp
@@ -109,8 +109,8 @@ TEST_F(RealLimitsTest, positive)
     EXPECT_FALSE(limits.hasUpperLimit());
     EXPECT_FALSE(limits.hasLowerAndUpperLimits());
 
-    EXPECT_EQ(limits.lowerLimit(), std::numeric_limits<double>::min());
-    EXPECT_EQ(limits.upperLimit(), std::numeric_limits<double>::max());
+    EXPECT_DOUBLE_EQ(limits.lowerLimit(), std::numeric_limits<double>::min());
+    EXPECT_DOUBLE_EQ(limits.upperLimit(), std::numeric_limits<double>::max());
 
     EXPECT_FALSE(limits.isInRange(-11.0));
     EXPECT_FALSE(limits.isInRange(0.0));
@@ -132,8 +132,8 @@ TEST_F(RealLimitsTest, nonnegative)
     EXPECT_FALSE(limits.hasUpperLimit());
     EXPECT_FALSE(limits.hasLowerAndUpperLimits());
 
-    EXPECT_EQ(limits.lowerLimit(), 0.0);
-    EXPECT_EQ(limits.upperLimit(), std::numeric_limits<double>::max());
+    EXPECT_DOUBLE_EQ(limits.lowerLimit(), 0.0);
+    EXPECT_DOUBLE_EQ(limits.upperLimit(), std::numeric_limits<double>::max());
 
     EXPECT_FALSE(limits.isInRange(-11.0));
     EXPECT_TRUE(limits.isInRange(0.0));
@@ -155,8 +155,8 @@ TEST_F(RealLimitsTest, limitless)
     EXPECT_FALSE(limits.hasUpperLimit());
     EXPECT_FALSE(limits.hasLowerAndUpperLimits());
 
-    EXPECT_EQ(limits.lowerLimit(), std::numeric_limits<double>::lowest());
-    EXPECT_EQ(limits.upperLimit(), std::numeric_limits<double>::max());
+    EXPECT_DOUBLE_EQ(limits.lowerLimit(), std::numeric_limits<double>::lowest());
+    EXPECT_DOUBLE_EQ(limits.upperLimit(), std::numeric_limits<double>::max());
 
     EXPECT_TRUE(limits.isInRange(-std::numeric_limits<double>::infinity()));
     EXPECT_TRUE(limits.isInRange(0.0));

--- a/tests/testmodel/removeitemcommand.test.cpp
+++ b/tests/testmodel/removeitemcommand.test.cpp
@@ -73,7 +73,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandChild)
     EXPECT_EQ(restored->identifier(), child1_identifier);
 
     // checking the data of restored item
-    EXPECT_EQ(restored->data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(restored->data<double>(), 42.0);
 }
 
 TEST_F(RemoveItemCommandTest, removeAtCommandParentWithChild)
@@ -108,7 +108,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandParentWithChild)
     EXPECT_EQ(restored_child->identifier(), child1_identifier);
 
     // checking the data of restored item
-    EXPECT_EQ(restored_child->data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(restored_child->data<double>(), 42.0);
 }
 
 //! RemoveAtCommand in multitag context
@@ -154,7 +154,7 @@ TEST_F(RemoveItemCommandTest, removeAtCommandMultitag)
     EXPECT_EQ(restored_child2->identifier(), child2_identifier);
 
     // checking the data of restored item
-    EXPECT_EQ(restored_child2->data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(restored_child2->data<double>(), 42.0);
 }
 
 //! Attempt to remove property item.

--- a/tests/testmodel/sessionitem.test.cpp
+++ b/tests/testmodel/sessionitem.test.cpp
@@ -121,7 +121,7 @@ TEST_F(SessionItemTest, setDoubleData)
     SessionItem item;
     const double expected = 42.0;
     EXPECT_TRUE(item.setData(expected));
-    EXPECT_EQ(item.data<double>(), expected);
+    EXPECT_DOUBLE_EQ(item.data<double>(), expected);
 }
 
 TEST_F(SessionItemTest, setIntData)
@@ -165,7 +165,7 @@ TEST_F(SessionItemTest, displayName)
     // checking setter
     item.setDisplayName("width");
     EXPECT_EQ(item.displayName(), "width");
-    EXPECT_EQ(item.data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(item.data<double>(), 42.0);
 }
 
 //! Attempt to set the different Variant to already existing role.

--- a/tests/testmodel/sessionmodel.test.cpp
+++ b/tests/testmodel/sessionmodel.test.cpp
@@ -297,7 +297,7 @@ TEST_F(SessionModelTest, copyModelItemRootContext)
     ASSERT_TRUE(copy != item);
     EXPECT_FALSE(copy->identifier().empty());
     EXPECT_TRUE(copy->identifier() != item->identifier());
-    EXPECT_EQ(copy->data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(copy->data<double>(), 42.0);
     EXPECT_EQ(model.rootItem()->children().size(), 2);
     EXPECT_TRUE(item != copy);
     std::vector<SessionItem*> expected = {item, copy};
@@ -324,7 +324,7 @@ TEST_F(SessionModelTest, copyParentWithProperty)
     ASSERT_TRUE(copy_child != nullptr);
     EXPECT_FALSE(copy->identifier().empty());
     EXPECT_TRUE(copy->identifier() != parent0->identifier());
-    EXPECT_EQ(copy_child->data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(copy_child->data<double>(), 42.0);
 }
 
 //! Tests item copy for property item.
@@ -343,7 +343,7 @@ TEST_F(SessionModelTest, copyFreeItem)
 
     // copying to parent
     auto copy = model.copyItem(item.get(), parent0);
-    EXPECT_EQ(copy->data<double>(), 42.0);
+    EXPECT_DOUBLE_EQ(copy->data<double>(), 42.0);
 }
 
 //! Attempt to copy property item into the same tag.

--- a/tests/testmodel/undostack.test.cpp
+++ b/tests/testmodel/undostack.test.cpp
@@ -752,7 +752,7 @@ TEST_F(UndoStackTest, copyLayerFromMultilayer)
     // copying layer
     auto layer_copy = dynamic_cast<ToyItems::LayerItem*>(model.copyItem(layer0, multilayer1));
     EXPECT_EQ(multilayer1->itemCount(ToyItems::MultiLayerItem::T_LAYERS), 1);
-    EXPECT_EQ(layer_copy->property<double>(ToyItems::LayerItem::P_THICKNESS), expected_thickness);
+    EXPECT_DOUBLE_EQ(layer_copy->property<double>(ToyItems::LayerItem::P_THICKNESS), expected_thickness);
     EXPECT_TRUE(layer0->identifier() != layer_copy->identifier());
 
     auto id = layer_copy->identifier();

--- a/tests/testmodel/vectoritem.test.cpp
+++ b/tests/testmodel/vectoritem.test.cpp
@@ -32,9 +32,9 @@ TEST_F(VectorItemTest, initialState)
 
     EXPECT_FALSE(item.isEditable());
 
-    EXPECT_EQ(item.property<double>(VectorItem::P_X), 0.0);
-    EXPECT_EQ(item.property<double>(VectorItem::P_Y), 0.0);
-    EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_X), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
     // default label
     EXPECT_EQ(item.data<std::string>(), "(0, 0, 0)");
@@ -47,9 +47,9 @@ TEST_F(VectorItemTest, initialStateFromModel)
     SessionModel model;
     auto item = model.insertItem<VectorItem>();
 
-    EXPECT_EQ(item->property<double>(VectorItem::P_X), 0.0);
-    EXPECT_EQ(item->property<double>(VectorItem::P_Y), 0.0);
-    EXPECT_EQ(item->property<double>(VectorItem::P_Z), 0.0);
+    EXPECT_DOUBLE_EQ(item->property<double>(VectorItem::P_X), 0.0);
+    EXPECT_DOUBLE_EQ(item->property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_DOUBLE_EQ(item->property<double>(VectorItem::P_Z), 0.0);
 
     // default label
     EXPECT_EQ(item->data<std::string>(), "(0, 0, 0)");

--- a/tests/testview/viewportaxisplotcontroller.test.cpp
+++ b/tests/testview/viewportaxisplotcontroller.test.cpp
@@ -50,13 +50,13 @@ TEST_F(ViewportAxisPlotControllerTest, initialState)
     // checking initial defaults
     const double customplot_default_lower(0.0);
     const double customplot_default_upper(5.0);
-    EXPECT_EQ(axis->range().lower, customplot_default_lower);
-    EXPECT_EQ(axis->range().upper, customplot_default_upper);
+    EXPECT_DOUBLE_EQ(axis->range().lower, customplot_default_lower);
+    EXPECT_DOUBLE_EQ(axis->range().upper, customplot_default_upper);
 
     // controller shouldn''t change axis range
     ViewportAxisPlotController controller(axis);
-    EXPECT_EQ(axis->range().lower, customplot_default_lower);
-    EXPECT_EQ(axis->range().upper, customplot_default_upper);
+    EXPECT_DOUBLE_EQ(axis->range().lower, customplot_default_lower);
+    EXPECT_DOUBLE_EQ(axis->range().upper, customplot_default_upper);
 
     // checking axis signaling
     auto xChanged = createSpy(custom_plot->xAxis);
@@ -96,8 +96,8 @@ TEST_F(ViewportAxisPlotControllerTest, setViewportAxisItem)
     // Subscribtion to ViewportAxisItem should change QCPAxis range for X.
     controller.setItem(axisItem);
 
-    EXPECT_EQ(custom_plot->xAxis->range().lower, expected_min);
-    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().lower, expected_min);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().upper, expected_max);
     EXPECT_EQ(xChanged->count(), 1);
     EXPECT_EQ(yChanged->count(), 0);
 
@@ -137,8 +137,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeQCPAxis)
     EXPECT_EQ(yChanged->count(), 0);
 
     // Check changed properties in ViewportAxisItem
-    EXPECT_EQ(axisItem->property<double>(ViewportAxisItem::P_MIN), expected_min);
-    EXPECT_EQ(axisItem->property<double>(ViewportAxisItem::P_MAX), expected_max);
+    EXPECT_DOUBLE_EQ(axisItem->property<double>(ViewportAxisItem::P_MIN), expected_min);
+    EXPECT_DOUBLE_EQ(axisItem->property<double>(ViewportAxisItem::P_MAX), expected_max);
 }
 
 //! Controller subscribed to ViewportAxisItem.
@@ -169,8 +169,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItem)
     // Checking QCPAxis
     EXPECT_EQ(xChanged->count(), 2);
     EXPECT_EQ(yChanged->count(), 0);
-    EXPECT_EQ(custom_plot->xAxis->range().lower, expected_min);
-    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().lower, expected_min);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().upper, expected_max);
 }
 
 //! Controller subscribed to ViewportAxisItem.
@@ -192,8 +192,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemSignaling)
     controller.setItem(axisItem);
 
     // initial condition
-    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot->xAxis->range().upper, 2.0);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().upper, 2.0);
 
     auto rangeChanged = createSpy(custom_plot->xAxis);
     auto rangeChanged2 = createSpy2(custom_plot->xAxis);
@@ -205,8 +205,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemSignaling)
     // Checking QCPAxis
     EXPECT_EQ(rangeChanged->count(), 1);
     EXPECT_EQ(rangeChanged2->count(), 1);
-    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().upper, expected_max);
 
     QList<QVariant> arguments = rangeChanged->takeFirst();
     EXPECT_EQ(arguments.size(), 1);
@@ -253,8 +253,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemMapping)
     const double expected_max = 20.0;
     axisItem->setProperty(ViewportAxisItem::P_MAX, expected_max);
 
-    EXPECT_EQ(custom_plot->xAxis->range().lower, 1.0);
-    EXPECT_EQ(custom_plot->xAxis->range().upper, expected_max);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().lower, 1.0);
+    EXPECT_DOUBLE_EQ(custom_plot->xAxis->range().upper, expected_max);
 }
 
 //! Set ViewportAxisItem logz, subscribe controller and check that QCPAxis has it.
@@ -332,8 +332,8 @@ TEST_F(ViewportAxisPlotControllerTest, changeViewportAxisItemYCase)
     // Checking QCPAxis
     EXPECT_EQ(xChanged->count(), 0);
     EXPECT_EQ(yChanged->count(), 2);
-    EXPECT_EQ(custom_plot->yAxis->range().lower, expected_min);
-    EXPECT_EQ(custom_plot->yAxis->range().upper, expected_max);
+    EXPECT_DOUBLE_EQ(custom_plot->yAxis->range().lower, expected_min);
+    EXPECT_DOUBLE_EQ(custom_plot->yAxis->range().upper, expected_max);
 }
 
 //! Model with two AxisItem's. Controller first is subscribed to one item, then to another.
@@ -359,10 +359,8 @@ TEST_F(ViewportAxisPlotControllerTest, oneControllerTwoAxisItems)
     auto yChanged = createSpy(custom_plot->yAxis);
 
     // initial axis status
-    EXPECT_EQ(axis_item0->property<double>(ViewportAxisItem::P_MIN),
-              custom_plot->xAxis->range().lower);
-    EXPECT_EQ(axis_item0->property<double>(ViewportAxisItem::P_MAX),
-              custom_plot->xAxis->range().upper);
+    EXPECT_DOUBLE_EQ(axis_item0->property<double>(ViewportAxisItem::P_MIN), custom_plot->xAxis->range().lower);
+    EXPECT_DOUBLE_EQ(axis_item0->property<double>(ViewportAxisItem::P_MAX), custom_plot->xAxis->range().upper);
 
     // switching to second axis
     controller->setItem(axis_item1);
@@ -370,10 +368,8 @@ TEST_F(ViewportAxisPlotControllerTest, oneControllerTwoAxisItems)
     EXPECT_EQ(xChanged->count(), 1);
     EXPECT_EQ(yChanged->count(), 0);
 
-    EXPECT_EQ(axis_item1->property<double>(ViewportAxisItem::P_MIN),
-              custom_plot->xAxis->range().lower);
-    EXPECT_EQ(axis_item1->property<double>(ViewportAxisItem::P_MAX),
-              custom_plot->xAxis->range().upper);
+    EXPECT_DOUBLE_EQ(axis_item1->property<double>(ViewportAxisItem::P_MIN), custom_plot->xAxis->range().lower);
+    EXPECT_DOUBLE_EQ(axis_item1->property<double>(ViewportAxisItem::P_MAX), custom_plot->xAxis->range().upper);
 
     // changing QCPAxis
     const double expected_min = 100.0;
@@ -381,12 +377,12 @@ TEST_F(ViewportAxisPlotControllerTest, oneControllerTwoAxisItems)
     custom_plot->xAxis->setRange(expected_min, expected_max);
 
     // previous axis should still have original values
-    EXPECT_EQ(axis_item0->property<double>(ViewportAxisItem::P_MIN), 1.0);
-    EXPECT_EQ(axis_item0->property<double>(ViewportAxisItem::P_MAX), 2.0);
+    EXPECT_DOUBLE_EQ(axis_item0->property<double>(ViewportAxisItem::P_MIN), 1.0);
+    EXPECT_DOUBLE_EQ(axis_item0->property<double>(ViewportAxisItem::P_MAX), 2.0);
 
     // second axis should get values from QCPAxis
-    EXPECT_EQ(axis_item1->property<double>(ViewportAxisItem::P_MIN), expected_min);
-    EXPECT_EQ(axis_item1->property<double>(ViewportAxisItem::P_MAX), expected_max);
+    EXPECT_DOUBLE_EQ(axis_item1->property<double>(ViewportAxisItem::P_MIN), expected_min);
+    EXPECT_DOUBLE_EQ(axis_item1->property<double>(ViewportAxisItem::P_MAX), expected_max);
 
     // removing axes from the model
     model.removeItem(model.rootItem(), {"", 0});

--- a/tests/testviewmodel/defaulteditorfactory.test.cpp
+++ b/tests/testviewmodel/defaulteditorfactory.test.cpp
@@ -77,8 +77,8 @@ TEST_F(DefaultEditorFactoryTest, integerProperty)
     auto spin_box = editor->findChild<QSpinBox*>();
 
     ASSERT_TRUE(spin_box != nullptr);
-    EXPECT_EQ(spin_box->minimum(), -65536);
-    EXPECT_EQ(spin_box->maximum(), 65536);
+    EXPECT_DOUBLE_EQ(spin_box->minimum(), -65536);
+    EXPECT_DOUBLE_EQ(spin_box->maximum(), 65536);
 }
 
 //! Tests editor creation on integer property with limits.
@@ -90,8 +90,8 @@ TEST_F(DefaultEditorFactoryTest, integerPropertyWithLimits)
 
     auto spin_box = editor->findChild<QSpinBox*>();
     ASSERT_TRUE(spin_box != nullptr);
-    EXPECT_EQ(spin_box->minimum(), -1);
-    EXPECT_EQ(spin_box->maximum(), 1);
+    EXPECT_DOUBLE_EQ(spin_box->minimum(), -1);
+    EXPECT_DOUBLE_EQ(spin_box->maximum(), 1);
 }
 
 //! Tests editor creation on double property.
@@ -103,8 +103,8 @@ TEST_F(DefaultEditorFactoryTest, doubleProperty)
 
     auto spin_box = editor->findChild<ScientificSpinBox*>();
     ASSERT_TRUE(spin_box != nullptr);
-    EXPECT_FLOAT_EQ(spin_box->minimum(), -std::numeric_limits<double>::max());
-    EXPECT_FLOAT_EQ(spin_box->maximum(), std::numeric_limits<double>::max());
+    EXPECT_DOUBLE_EQ(spin_box->minimum(), -std::numeric_limits<double>::max());
+    EXPECT_DOUBLE_EQ(spin_box->maximum(), std::numeric_limits<double>::max());
 }
 
 //! Tests editor creation on double property with limits.
@@ -116,8 +116,8 @@ TEST_F(DefaultEditorFactoryTest, doublePropertyWithLimits)
 
     auto spin_box = editor->findChild<ScientificSpinBox*>();
     ASSERT_TRUE(spin_box != nullptr);
-    EXPECT_FLOAT_EQ(spin_box->minimum(), 41);
-    EXPECT_FLOAT_EQ(spin_box->maximum(), 43);
+    EXPECT_DOUBLE_EQ(spin_box->minimum(), 41);
+    EXPECT_DOUBLE_EQ(spin_box->maximum(), 43);
 }
 
 //! Tests editor creation on color property.

--- a/tests/testviewmodel/propertiesrowstrategy.test.cpp
+++ b/tests/testviewmodel/propertiesrowstrategy.test.cpp
@@ -59,9 +59,9 @@ TEST_F(PropertiesRowStrategyTest, vectorItemCustomLabels)
 {
     VectorItem item;
 
-    EXPECT_EQ(item.property<double>(VectorItem::P_X), 0.0);
-    EXPECT_EQ(item.property<double>(VectorItem::P_Y), 0.0);
-    EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_X), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
     PropertiesRowStrategy strategy({"a", "b", "c"});
     auto items = strategy.constructRow(&item);
@@ -88,9 +88,9 @@ TEST_F(PropertiesRowStrategyTest, vectorItemAutoLabels)
 {
     VectorItem item;
 
-    EXPECT_EQ(item.property<double>(VectorItem::P_X), 0.0);
-    EXPECT_EQ(item.property<double>(VectorItem::P_Y), 0.0);
-    EXPECT_EQ(item.property<double>(VectorItem::P_Z), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_X), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_Y), 0.0);
+    EXPECT_DOUBLE_EQ(item.property<double>(VectorItem::P_Z), 0.0);
 
     QStringList expected = QStringList() << "X"
                                          << "Y"

--- a/tests/testviewmodel/viewmodeldelegate.test.cpp
+++ b/tests/testviewmodel/viewmodeldelegate.test.cpp
@@ -81,5 +81,5 @@ TEST_F(ViewModelDelegateTest, widgetMapper)
 
     editor->setData(43.0);
     editor->dataChanged(editor->data());
-    EXPECT_EQ(x_item->data<double>(), 43.0);
+    EXPECT_DOUBLE_EQ(x_item->data<double>(), 43.0);
 }


### PR DESCRIPTION
Changed the related tests to use EXPECT_DOUBLE_EQ() instead of EXPECT_FLOAT_EQ() (or EXPECT_EQ()).
(Closes #361)