### PR TITLE
Command line warning D9025 : overriding '/W3' with '/W2'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,49 @@ option(MVVM_SETUP_CODECOVERAGE "Setups target to generate coverage information w
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/modules)
 include(configuration)
 
+message(STATUS "Building for: ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}")
+
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    message(STATUS "MSVC: C VERSION=${CMAKE_C_COMPILER_VERSION} ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
+    message(STATUS "MSVC: C COMPILER=${CMAKE_C_COMPILER}")
+    message(STATUS "MSVC: CMAKE_C_FLAGS=${CMAKE_C_FLAGS}")
+    message(STATUS "MSVC: CMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}")
+    message(STATUS "MSVC: CMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}")
+    message(STATUS "MSVC: CMAKE_C_FLAGS_MINSIZEREL=${CMAKE_C_FLAGS_MINSIZEREL}")
+    message(STATUS "MSVC: CMAKE_C_FLAGS_RELWITHDEBINFO=${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    message(STATUS "MSVC: CXX VERSION=${CMAKE_CXX_COMPILER_VERSION} ARCHITECTURE=${CMAKE_CXX_COMPILER_ARCHITECTURE_ID}")
+    message(STATUS "MSVC: CXX COMPILER=${CMAKE_CXX_COMPILER}")
+    message(STATUS "MSVC: CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
+    message(STATUS "MSVC: CMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
+    message(STATUS "MSVC: CMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}")
+    message(STATUS "MSVC: CMAKE_CXX_FLAGS_MINSIZEREL=${CMAKE_CXX_FLAGS_MINSIZEREL}")
+    message(STATUS "MSVC: CMAKE_CXX_FLAGS_RELWITHDEBINFO=${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+endif()
+
+# https://github.com/cpp-best-practices/cmake_template/blob/main/cmake/CompilerWarnings.cmake
+
+if((CMAKE_C_COMPILER_ID STREQUAL "MSVC") OR (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"))
+
+    # Set /MP (Build with multiple processes):
+    # https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes
+    add_compile_options(/MP)
+
+    # Warning level:
+    add_compile_options(/W4)
+    # Note: /W3 is automatically added to the default set of compiler flags on CMake versions previous to 3.15.
+    string(REGEX REPLACE "/W[1-3]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REGEX REPLACE "/W[1-3]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+else()
+
+    # Warning level:
+    add_compile_options(-Wall -Wextra -Wpedantic)
+
+endif()
+
 add_subdirectory(source)
 add_subdirectory(thirdparty)
 if(BUILD_TESTING)

--- a/cmake/modules/configuration.cmake
+++ b/cmake/modules/configuration.cmake
@@ -72,16 +72,3 @@ configure_file(${MVVM_PROJECT_DIR}/cmake/scripts/testconfig.h.in  ${MVVM_AUTOGEN
 if (MVVM_BUMP_VERSION)
     configure_file(${MVVM_PROJECT_DIR}/cmake/scripts/mvvm_version.h.in  ${MVVM_PROJECT_DIR}/source/libmvvm_model/mvvm/core/version.h @ONLY)
 endif()
-
-# -----------------------------------------------------------------------------
-# Compile options
-# -----------------------------------------------------------------------------
-
-add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
-
-# warning level
-if (MSVC)
-    add_compile_options(/W2)
-else()
-    add_compile_options(-Wall -Wextra -pedantic)
-endif()


### PR DESCRIPTION
The Windows build log is flooded with these warnings.
Reducing these will greatly help identifying the (actual) issues with the build.

Added some info output to the CMakeLists.txt for aiding in troubleshooting.
Moved the compiler options to the main CMakeLists file (for transparency).
Increased the (overridden) warning level for the MSVC compilers to W4 thus avoiding the "W3 overridden with W2" warning flood.

(Closes #365)